### PR TITLE
 Rely on new-style permission name to guard loan-policy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 1.2.0 (IN PROGRESS)
 
-* Setup Loan Rules crud v1. For UICIRC-5
-* Add Real Loan Rule Params. Fixes UICIRC-17
+* Setup Loan Rules crud v1. For UICIRC-5.
+* Add Real Loan Rule Params. Fixes UICIRC-17.
+* Support permission for loan-policy maintenance. Fixes UICIRC-21.
 
 ## [1.1.1](https://github.com/folio-org/ui-circulation/tree/v1.1.1) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.1.0...v1.1.1)

--- a/settings/index.js
+++ b/settings/index.js
@@ -9,7 +9,7 @@ const pages = [
     route: 'loan-policies',
     label: 'Loan policies',
     component: LoanPolicySettings,
-    perm: 'settings.loan-policies.all',
+    perm: 'ui-circulation.settings.loan-policies',
   },
   {
     route: 'loan-rules',

--- a/settings/index.js
+++ b/settings/index.js
@@ -15,7 +15,7 @@ const pages = [
     route: 'loan-rules',
     label: 'Loan rules',
     component: LoanRules,
-    perm: 'settings.loan-rules.all',
+    perm: 'ui-circulation.settings.loan-rules',
   },
 ];
 


### PR DESCRIPTION
Should fix UICIRC-21.