### PR TITLE
removing unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "prop-types": "^15.5.10",
     "query-string": "^4.3.2",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
     "react-codemirror2": "^1.0.0",
     "react-flexbox-grid": "^1.1.3",
     "react-router-dom": "^4.0.0",


### PR DESCRIPTION
This package is no longer in use, and old versions of it can cause the console warning, `Warning: Accessing PropTypes via the main React package is deprecated...`