### PR TITLE
tidy-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Support permission for loan-policy maintenance. Fixes UICIRC-21.
 * Replace `data` with `resources` Fixes UICIRC-25.
 * Focus on name field for a newly-created loan policy. Fixes UICIRC-19.
-* Get <EntrySelector> from stripes-components v1.9.0 (and delete the local copy). Fixes UICIRC-26.
+* Get `<EntrySelector>` from stripes-components v1.9.0 (and delete the local copy). Fixes UICIRC-26.
 
 ## [1.1.1](https://github.com/folio-org/ui-circulation/tree/v1.1.1) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.1.0...v1.1.1)


### PR DESCRIPTION
Escape angle brackets in Markdown

Otherwise "<Foo>" names are rendered invisible.