### PR TITLE
add emptry schedules rows to top of list. Fixes UICIRC-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use `<EntryManager>` to manage loan policies. Fixes UICIRC-32.
 * Include fixed due date schedule list in loan-policy form. Fixes UICIRC-27.
 * Show empty schedules in new Fixed Due Date Schedule form. Fixes UICIRC-30.
+* Add empty schedule rows to top of list. Fixes UICIRC-29.
 
 ## [1.1.1](https://github.com/folio-org/ui-circulation/tree/v1.1.1) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.1.0...v1.1.1)

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -11,7 +11,7 @@ const renderSchedules = ({ fields, meta: { error, submitFailed } }) => (
   <div>
     <Row>
       <Col xs={11}><h2 style={{ marginTop: '0' }}>Schedules</h2></Col>
-      <Col xs={1}><Button type="button" onClick={() => fields.push({})}>+ New</Button></Col>
+      <Col xs={1}><Button type="button" onClick={() => fields.unshift({})}>+ New</Button></Col>
     </Row>
     {submitFailed && error && <Row><Col xs={12} className="error">{error}</Col></Row>}
     {fields.map((schedule, index, f) => (


### PR DESCRIPTION
This commit changes "push" to "unshift" and closes a ticket as a result,
but really @JohnC-80  should get the credit for fixing the Datepicker
element so that it behaves nicely under both circumstances. So,
technically this fixes UICIRC-29 but really the work was on STCOM-119.