### PR TITLE
default to a single fixed due date schedule

### DIFF
--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -124,7 +124,7 @@ class FixedDueDateScheduleManager extends React.Component {
         validate={this.validate}
         deleteDisabled={this.deleteDisabled}
         deleteDisabledMessage="Schedule cannot be deleted when used by one or more loan policies."
-        defaultEntry={{ schedules: [{}, {}] }}
+        defaultEntry={{ schedules: [{}] }}
       />
     );
   }


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-45

Currently if you create a new fixed due date schedule, it will have two schedules. 

With this PR, only one schedule is shown, and a user can add more if desired.