### PR TITLE
validate fixedDueDateSchedule field

### DIFF
--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -21,6 +21,12 @@ const defaultPolicy = {
 };
 
 class LoanPolicySettings extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.validate = this.validate.bind(this);
+  }
+
   static propTypes = {
     resources: PropTypes.shape({
       entries: PropTypes.object,
@@ -54,7 +60,7 @@ class LoanPolicySettings extends React.Component {
     }
     if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
       && !values.loansPolicy.fixedDueDateSchedule) {
-      errors.loansPolicy = {fixedDueDateSchedule: 'Please select a schedule'}
+      errors.loansPolicy = { fixedDueDateSchedule: 'Please select a schedule' };
     }
     return errors;
   }

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -47,6 +47,18 @@ class LoanPolicySettings extends React.Component {
     },
   });
 
+  validate(values) {
+    const errors = {};
+    if (!values.name) {
+      errors.name = 'Please fill this in to continue';
+    }
+    if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
+      && !values.loansPolicy.fixedDueDateSchedule) {
+      errors.loansPolicy = {fixedDueDateSchedule: 'Please select a schedule'}
+    }
+    return errors;
+  }
+
   render() {
     return (
       <EntryManager
@@ -64,6 +76,7 @@ class LoanPolicySettings extends React.Component {
           post: 'ui-circulation.settings.loan-policies',
           delete: 'ui-circulation.settings.loan-policies',
         }}
+        validate={this.validate}
       />
     );
   }

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -20,8 +20,19 @@ const defaultPolicy = {
   },
 };
 
-class LoanPolicySettings extends React.Component {
+function validate(values) {
+  const errors = {};
+  if (!values.name) {
+    errors.name = 'Please fill this in to continue';
+  }
+  if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
+    && !values.loansPolicy.fixedDueDateSchedule) {
+    errors.loansPolicy = { fixedDueDateSchedule: 'Please select a schedule' };
+  }
+  return errors;
+}
 
+class LoanPolicySettings extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
       entries: PropTypes.object,
@@ -69,18 +80,6 @@ class LoanPolicySettings extends React.Component {
       />
     );
   }
-}
-
-function validate(values) {
-  const errors = {};
-  if (!values.name) {
-    errors.name = 'Please fill this in to continue';
-  }
-  if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
-    && !values.loansPolicy.fixedDueDateSchedule) {
-    errors.loansPolicy = { fixedDueDateSchedule: 'Please select a schedule' };
-  }
-  return errors;
 }
 
 export default LoanPolicySettings;

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -22,11 +22,6 @@ const defaultPolicy = {
 
 class LoanPolicySettings extends React.Component {
 
-  constructor(props) {
-    super(props);
-    this.validate = this.validate.bind(this);
-  }
-
   static propTypes = {
     resources: PropTypes.shape({
       entries: PropTypes.object,
@@ -53,18 +48,6 @@ class LoanPolicySettings extends React.Component {
     },
   });
 
-  validate(values) {
-    const errors = {};
-    if (!values.name) {
-      errors.name = 'Please fill this in to continue';
-    }
-    if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
-      && !values.loansPolicy.fixedDueDateSchedule) {
-      errors.loansPolicy = { fixedDueDateSchedule: 'Please select a schedule' };
-    }
-    return errors;
-  }
-
   render() {
     return (
       <EntryManager
@@ -82,10 +65,22 @@ class LoanPolicySettings extends React.Component {
           post: 'ui-circulation.settings.loan-policies',
           delete: 'ui-circulation.settings.loan-policies',
         }}
-        validate={this.validate}
+        validate={validate}
       />
     );
   }
+}
+
+function validate(values) {
+  const errors = {};
+  if (!values.name) {
+    errors.name = 'Please fill this in to continue';
+  }
+  if (values.loansPolicy.profileId === '1' // 1 is for 'fixed'
+    && !values.loansPolicy.fixedDueDateSchedule) {
+    errors.loansPolicy = { fixedDueDateSchedule: 'Please select a schedule' };
+  }
+  return errors;
 }
 
 export default LoanPolicySettings;


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-43

Currently, when the user creates a new loan policy, there is no validation for the Fixed profile.

With this PR, if the profile is 'Fixed', the form will require fixedDueDateSchedule to be set, too.