### PR TITLE
add dataKey prop to properly sync data with store

### DIFF
--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -111,6 +111,7 @@ class FixedDueDateScheduleManager extends React.Component {
         {...this.props}
         parentMutator={this.props.mutator}
         entryList={_.sortBy((this.props.resources.entries || {}).records || [], ['name'])}
+        dataKey="fixedDueDateSchedules"
         detailComponent={FixedDueDateScheduleDetail}
         formComponent={FixedDueDateScheduleForm}
         paneTitle="Fixed due date schedules"

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -65,6 +65,7 @@ class LoanPolicySettings extends React.Component {
         {...this.props}
         parentMutator={this.props.mutator}
         entryList={_.sortBy((this.props.resources.entries || {}).records || [], ['name'])}
+        dataKey="loanPolicies"
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}
         paneTitle="Loan Policies"


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-42

Currently, if you create a Fixed Due Date Schedule, then create a new Fixed Loan Policy, you will not see that schedule available. This PR fixed that bug.

Thanks to @MikeTaylor and @zburke for the tip.