### PR TITLE
Share resources between Settings pages

### DIFF
--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -10,7 +10,7 @@ class FixedDueDateScheduleManager extends React.Component {
   static propTypes = {
     resources: PropTypes.object.isRequired,
     mutator: PropTypes.shape({
-      entries: PropTypes.shape({
+      fixedDueDateSchedules: PropTypes.shape({
         POST: PropTypes.func,
         DELETE: PropTypes.func,
         GET: PropTypes.func,
@@ -22,7 +22,7 @@ class FixedDueDateScheduleManager extends React.Component {
   };
 
   static manifest = Object.freeze({
-    entries: {
+    fixedDueDateSchedules: {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
@@ -58,7 +58,7 @@ class FixedDueDateScheduleManager extends React.Component {
     }
 
     // when searching for a name-match, skip the current record
-    const records = (this.props.resources.entries || {}).records || [];
+    const records = (this.props.resources.fixedDueDateSchedules || {}).records || [];
     if (values.name && _.find(records, entry => entry.name === values.name && entry.id !== values.id)) {
       errors.name = 'Please enter a unique name.';
     }
@@ -110,8 +110,8 @@ class FixedDueDateScheduleManager extends React.Component {
       <EntryManager
         {...this.props}
         parentMutator={this.props.mutator}
-        entryList={_.sortBy((this.props.resources.entries || {}).records || [], ['name'])}
-        dataKey="fixedDueDateSchedules"
+        entryList={_.sortBy((this.props.resources.fixedDueDateSchedules || {}).records || [], ['name'])}
+        dataKey='fixedDueDateSchedules'
         detailComponent={FixedDueDateScheduleDetail}
         formComponent={FixedDueDateScheduleForm}
         paneTitle="Fixed due date schedules"

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -31,7 +31,7 @@ class FixedDueDateScheduleManager extends React.Component {
       type: 'okapi',
       records: 'loanPolicies',
       path: 'loan-policy-storage/loan-policies',
-      dataKey: 'loan-policies'
+      dataKey: 'loan-policies',
     },
   });
 
@@ -112,7 +112,7 @@ class FixedDueDateScheduleManager extends React.Component {
         {...this.props}
         parentMutator={this.props.mutator}
         entryList={_.sortBy((this.props.resources.fixedDueDateSchedules || {}).records || [], ['name'])}
-        resourceKey='fixedDueDateSchedules'
+        resourceKey="fixedDueDateSchedules"
         detailComponent={FixedDueDateScheduleDetail}
         formComponent={FixedDueDateScheduleForm}
         paneTitle="Fixed due date schedules"

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -31,6 +31,7 @@ class FixedDueDateScheduleManager extends React.Component {
       type: 'okapi',
       records: 'loanPolicies',
       path: 'loan-policy-storage/loan-policies',
+      dataKey: 'loan-policies'
     },
   });
 
@@ -111,7 +112,7 @@ class FixedDueDateScheduleManager extends React.Component {
         {...this.props}
         parentMutator={this.props.mutator}
         entryList={_.sortBy((this.props.resources.fixedDueDateSchedules || {}).records || [], ['name'])}
-        dataKey='fixedDueDateSchedules'
+        resourceKey='fixedDueDateSchedules'
         detailComponent={FixedDueDateScheduleDetail}
         formComponent={FixedDueDateScheduleForm}
         paneTitle="Fixed due date schedules"

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -35,11 +35,11 @@ function validate(values) {
 class LoanPolicySettings extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
-      entries: PropTypes.object,
+      loanPolicies: PropTypes.object,
       fixedDueDateSchedules: PropTypes.object,
     }).isRequired,
     mutator: PropTypes.shape({
-      entries: PropTypes.shape({
+      loanPolicies: PropTypes.shape({
         POST: PropTypes.func,
         DELETE: PropTypes.func,
       }),
@@ -47,7 +47,7 @@ class LoanPolicySettings extends React.Component {
   };
 
   static manifest = Object.freeze({
-    entries: {
+    loanPolicies: {
       type: 'okapi',
       records: 'loanPolicies',
       path: 'loan-policy-storage/loan-policies',
@@ -64,7 +64,7 @@ class LoanPolicySettings extends React.Component {
       <EntryManager
         {...this.props}
         parentMutator={this.props.mutator}
-        entryList={_.sortBy((this.props.resources.entries || {}).records || [], ['name'])}
+        entryList={_.sortBy((this.props.resources.loanPolicies || {}).records || [], ['name'])}
         dataKey="loanPolicies"
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -56,6 +56,7 @@ class LoanPolicySettings extends React.Component {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
+      dataKey: 'fixed-due-date-schedules'
     },
   });
 
@@ -65,7 +66,7 @@ class LoanPolicySettings extends React.Component {
         {...this.props}
         parentMutator={this.props.mutator}
         entryList={_.sortBy((this.props.resources.loanPolicies || {}).records || [], ['name'])}
-        dataKey="loanPolicies"
+        resourceKey="loanPolicies"
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}
         paneTitle="Loan Policies"

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -56,7 +56,7 @@ class LoanPolicySettings extends React.Component {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
-      dataKey: 'fixed-due-date-schedules'
+      dataKey: 'fixed-due-date-schedules',
     },
   });
 

--- a/settings/LoanRules.js
+++ b/settings/LoanRules.js
@@ -155,7 +155,7 @@ class LoanRules extends React.Component {
   }
 
   render() {
-    if (!this.props.resources.loanPolicies) {
+    if (!this.props.resources.loanTypes) {
       return (<div />);
     }
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-42
This PR fixes the bug that resources were not shared between Settings pages. Now the manifest specifies the dataKey used by the other Settings page, and the resource is a unique name (not `entries`)

Dependencies:
- https://github.com/folio-org/stripes-smart-components/pull/99: parameterize resourceKey for EntryManager
- https://github.com/folio-org/stripes-connect/pull/37 support dataKey in manifest