### PR TITLE
STCOM-284 Update stripes-components paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint": "^4.8.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.0",
+    "@folio/stripes-components": "^2.0.20",
     "@folio/stripes-core": "^2.8.0",
     "@folio/stripes-form": "^0.8.0",
     "@folio/stripes-smart-components": "^1.1.0",

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -16,7 +16,7 @@ import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import stripesForm from '@folio/stripes-form';
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 import ViewMetadata from './ViewMetadata';
 import css from './FixedDueDateSchedule.css';
 


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-284

Components previously found in `@folio/stripes-components/lib/structures` are now at `@folio/stripes-components/lib`.