### PR TITLE
stripes-components dep consistent with stripes-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Loan policy intervals should display on read only view. Fixes UICIRC-65.
 * Add last updated record metadata to loan policy form. Fixes UICIRC-63.
 * Add view/edit hold staff strip. Fixes UICIRC-52.
+* Update to stripes-components 3 for Pane/Paneset compatibility.
 
 ## [1.1.1](https://github.com/folio-org/ui-circulation/tree/v1.1.1) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.1.0...v1.1.1)

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "eslint": "^4.8.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.1.5",
+    "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-core": "^2.8.0",
     "@folio/stripes-form": "^0.8.0",
     "@folio/stripes-smart-components": "^1.4.19",


### PR DESCRIPTION
The stripes-components dependency was out of sync with stripes-core,
which was causing funky overlaps of the settings pane where the third
column would be superimposed on the second. This probably means we have
our Pane and Paneset components in the wrong repository, or maybe that
we are managing that dependency incorrectly. In any case, the version of
stripes-components we get from stripes-core needs to be the same as the
one we depend on here. And now it is.