### PR TITLE
pass id prop to ConfirmationModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-core": "^2.8.0",
     "@folio/stripes-form": "^0.8.0",
-    "@folio/stripes-smart-components": "^1.4.19",
+    "@folio/stripes-smart-components": "^1.4.23",
     "html-to-react": "^1.3.3",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -262,6 +262,7 @@ class FixedDueDateScheduleForm extends React.Component {
                 </section>
               </Accordion>
               <ConfirmationModal
+                id="deletefixedduedateschedule-confirmation"
                 open={confirmDelete}
                 heading={formatMsg({ id: 'ui-circulation.settings.fDDSform.deleteHeader' })}
                 message={confirmationMessage}


### PR DESCRIPTION
Generation of HTML element-IDs in `<ConfirmationModal>` changed in
https://github.com/folio-org/stripes-components/commit/ce3ba8c996463a389ae3c3aeb36069d9a785ed69
and that broke a bunch of tests that relied on the old style of element
IDs. Happily, we can restore this behavior by passing in an ID prop that
matches the old format.

Refs [STCOM-317](https://issues.folio.org/browse/STCOM-317)