### PR TITLE
always show checkout-scanning checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Add last updated record metadata to loan policy form. Fixes UICIRC-63.
 * Add view/edit hold staff strip. Fixes UICIRC-52.
 * Update to stripes-components 3 for Pane/Paneset compatibility.
+* Checkout scanning checkboxes sometimes would not display. They should ALWAYS display. Refs UICIRC-75.
 
 ## [1.1.1](https://github.com/folio-org/ui-circulation/tree/v1.1.1) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.1.0...v1.1.1)

--- a/settings/CheckoutSettings.js
+++ b/settings/CheckoutSettings.js
@@ -39,15 +39,16 @@ class CheckoutSettings extends React.Component {
 
     return { idents, audioAlertsEnabled, checkoutTimeout, checkoutTimeoutDuration };
   }
+
   validate(values, allthevalues) {
     const stripes = this.props.stripes;
     const errors = {};
-    const idents = values.idents;
-    if (!idents) return errors;
-    const isValid = idents.reduce((valid, v) => (valid || v), false);
+
+    const isValid = values.idents && values.idents.reduce((valid, v) => (valid || v), false);
     if (!isValid) {
       errors.idents = { _error: stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.validate.selectContinue' }) };
     }
+
     if (!values.checkoutTimeout) {
       values.checkoutTimeoutDuration = allthevalues.initialValues.checkoutTimeoutDuration;
     }

--- a/settings/CheckoutSettingsForm.js
+++ b/settings/CheckoutSettingsForm.js
@@ -48,20 +48,21 @@ class CheckoutSettingsForm extends React.Component {
       </Button>
     );
   }
+
   handleCheckoutTimeout() {
     this.setState({
       checked: !this.state.checked
     });
   }
+
   getCurrentValues() {
     const { stripes: { store } } = this.props;
     const state = store.getState();
     return getFormValues('checkoutForm')(state) || {};
   }
+
   // eslint-disable-next-line class-methods-use-this
   renderList({ fields, meta }) {
-    if (!fields.length) return (<div />);
-
     const items = patronIdentifierTypes.map((iden, index) => (
       <Row key={`row-${index}`}>
         <Col xs={12}>
@@ -70,7 +71,6 @@ class CheckoutSettingsForm extends React.Component {
             id={`${iden.queryKey}-checkbox`}
             data-checked={fields.get(index)}
             label={iden.label}
-            key={`item-${index}`}
             name={`idents[${index}]`}
           />
         </Col>


### PR DESCRIPTION
Sometimes, the checkboxes for checkout-scanning would not show. I don't
know why, exactly, but it's clear that was not the desired behavior, and
it's clear that when they didn't show, then we couldn't check those
boxes as we wanted to in integration tests, and then those tests would
fail. May the fail no longer.

Refs [UICIRC-75](https://issues.folio.org/browse/UICIRC-75)