### PR TITLE
provide sortby clause to ControlledVocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 1.4.0 (IN PROGRESS)
+
+* Provide `sortby` prop to `<ControlledVocab>`. Refs STSMACOM-139.
+
 ## 1.3.0 (https://github.com/folio-org/ui-circulation/tree/v1.3.0) (2018-10-04)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.2.0...v1.3.0)
 

--- a/settings/RequestCancellationReasons.js
+++ b/settings/RequestCancellationReasons.js
@@ -38,6 +38,7 @@ class RequestCancellationReasons extends React.Component {
         }}
         nameKey="name"
         id="request-cancellation-reasons"
+        sortby="name"
       />
     );
   }


### PR DESCRIPTION
`<ControlledVocab>` now requires the sortby prop.

Refs [STSMACOM-139](https://issues.folio.org/browse/STSMACOM-139)