### PR TITLE
[UICIRC-91] Use documented react-intl patterns instead of stripes.intl

### DIFF
--- a/settings/CheckoutSettings.js
+++ b/settings/CheckoutSettings.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import { intlShape, injectIntl } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
@@ -11,6 +12,7 @@ class CheckoutSettings extends React.Component {
   static propTypes = {
     label: PropTypes.string,
     stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -41,12 +43,12 @@ class CheckoutSettings extends React.Component {
   }
 
   validate(values, allthevalues) {
-    const stripes = this.props.stripes;
+    const { formatMessage } = this.props.intl;
     const errors = {};
 
     const isValid = values.idents && values.idents.reduce((valid, v) => (valid || v), false);
     if (!isValid) {
-      errors.idents = { _error: stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.validate.selectContinue' }) };
+      errors.idents = { _error: formatMessage({ id: 'ui-circulation.settings.checkout.validate.selectContinue' }) };
     }
 
     if (!values.checkoutTimeout) {
@@ -54,7 +56,7 @@ class CheckoutSettings extends React.Component {
     }
     const checkoutTimeoutDuration = (_.isInteger(+values.checkoutTimeoutDuration) && (+values.checkoutTimeoutDuration > 0));
     if (!checkoutTimeoutDuration) {
-      errors.checkoutTimeoutDuration = { _error: stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.validate.timeoutDuration' }) };
+      errors.checkoutTimeoutDuration = { _error: formatMessage({ id: 'ui-circulation.settings.checkout.validate.timeoutDuration' }) };
     }
     return errors;
   }
@@ -74,4 +76,4 @@ class CheckoutSettings extends React.Component {
   }
 }
 
-export default CheckoutSettings;
+export default injectIntl(CheckoutSettings);

--- a/settings/CheckoutSettingsForm.js
+++ b/settings/CheckoutSettingsForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { Button, Checkbox, Col, Pane, Row, Select, TextField } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
@@ -52,7 +52,7 @@ class CheckoutSettingsForm extends React.Component {
   }
 
   getCurrentValues() {
-    const { stripes: { store } } = this.props;
+    const { store } = this.props.stripes;
     const state = store.getState();
     return getFormValues('checkoutForm')(state) || {};
   }
@@ -85,7 +85,12 @@ class CheckoutSettingsForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, label, stripes } = this.props;
+    const {
+      handleSubmit,
+      label,
+      intl: { formatMessage },
+    } = this.props;
+
     const checkoutValues = this.getCurrentValues();
     const hidden = this.state.checked ? '' : 'hidden';
     return (
@@ -96,7 +101,7 @@ class CheckoutSettingsForm extends React.Component {
           <Row>
             <Col xs={12}>
               <Field
-                label={stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.timeout' })}
+                label={formatMessage({ id: 'ui-circulation.settings.checkout.timeout' })}
                 id="checkoutTimeout"
                 name="checkoutTimeout"
                 component={Checkbox}
@@ -117,7 +122,7 @@ class CheckoutSettingsForm extends React.Component {
                   />
                 </Col>
                 <Col xs={7}>
-                  <div>{stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.minutes' })}</div>
+                  <div>{formatMessage({ id: 'ui-circulation.settings.checkout.minutes' })}</div>
                 </Col>
               </div>
             </Row>
@@ -126,16 +131,16 @@ class CheckoutSettingsForm extends React.Component {
           <Row>
             <Col xs={12}>
               <Field
-                label={stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.audioAlerts' })}
+                label={formatMessage({ id: 'ui-circulation.settings.checkout.audioAlerts' })}
                 name="audioAlertsEnabled"
                 component={Select}
                 dataOptions={[
                   {
-                    label: stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.no' }),
+                    label: formatMessage({ id: 'ui-circulation.settings.checkout.no' }),
                     value: false,
                   },
                   {
-                    label: stripes.intl.formatMessage({ id: 'ui-circulation.settings.checkout.yes' }),
+                    label: formatMessage({ id: 'ui-circulation.settings.checkout.yes' }),
                     value: true,
                   },
                 ]}
@@ -155,10 +160,11 @@ CheckoutSettingsForm.propTypes = {
   submitting: PropTypes.bool,
   label: PropTypes.string,
   stripes: stripesShape.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default stripesForm({
   form: 'checkoutForm',
   navigationCheck: true,
   enableReinitialize: true,
-})(CheckoutSettingsForm);
+})(injectIntl(CheckoutSettingsForm));

--- a/settings/CheckoutSettingsForm.js
+++ b/settings/CheckoutSettingsForm.js
@@ -122,7 +122,7 @@ class CheckoutSettingsForm extends React.Component {
                   />
                 </Col>
                 <Col xs={7}>
-                  <div>{formatMessage({ id: 'ui-circulation.settings.checkout.minutes' })}</div>
+                  <FormattedMessage id="ui-circulation.settings.checkout.minutes" />
                 </Col>
               </div>
             </Row>

--- a/settings/FixedDueDateScheduleDetail.js
+++ b/settings/FixedDueDateScheduleDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { stripesShape } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -10,6 +10,7 @@ import css from './FixedDueDateSchedule.css';
 class FixedDueDateScheduleDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
+    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
   }
 
@@ -17,7 +18,6 @@ class FixedDueDateScheduleDetail extends React.Component {
     super(props);
     this.handleSectionToggle = this.handleSectionToggle.bind(this);
     this.handleExpandAll = this.handleExpandAll.bind(this);
-    this.formatDate = props.stripes.formatDate;
     this.cViewMetaData = props.stripes.connect(ViewMetaData);
     this.state = {
       sections: {
@@ -44,8 +44,11 @@ class FixedDueDateScheduleDetail extends React.Component {
   }
 
   render() {
-    const fixedDueDateSchedule = this.props.initialValues;
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const {
+      intl: { formatDate, formatMessage },
+      initialValues: fixedDueDateSchedule,
+    } = this.props;
+
     const { sections } = this.state;
     const renderSchedules = fixedDueDateSchedule.schedules.map((schedule, index) => (
       <div key={index} className={css.scheduleItem}>
@@ -69,9 +72,9 @@ class FixedDueDateScheduleDetail extends React.Component {
             </Col>
           </Row>
           <Row key={index + 2}>
-            <Col xs={4}>{this.formatDate(schedule.from)}</Col>
-            <Col xs={4}>{this.formatDate(schedule.to)}</Col>
-            <Col xs={4}>{this.formatDate(schedule.due)}</Col>
+            <Col xs={4}>{formatDate(schedule.from)}</Col>
+            <Col xs={4}>{formatDate(schedule.to)}</Col>
+            <Col xs={4}>{formatDate(schedule.due)}</Col>
           </Row>
         </div>
       </div>
@@ -97,15 +100,15 @@ class FixedDueDateScheduleDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMsg({ id: 'ui-circulation.settings.fDDSform.name' })}
-                  value={_.get(fixedDueDateSchedule, ['name'], formatMsg({ id: 'ui-circulation.settings.fDDSform.untitled' }))}
+                  label={formatMessage({ id: 'ui-circulation.settings.fDDSform.name' })}
+                  value={_.get(fixedDueDateSchedule, ['name'], formatMessage({ id: 'ui-circulation.settings.fDDSform.untitled' }))}
                 />
               </Col>
             </Row>
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMsg({ id: 'ui-circulation.settings.fDDSform.description' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.fDDSform.description' })}
                   value={_.get(fixedDueDateSchedule, ['description'], '')}
                 />
               </Col>
@@ -127,4 +130,4 @@ class FixedDueDateScheduleDetail extends React.Component {
   }
 }
 
-export default FixedDueDateScheduleDetail;
+export default injectIntl(FixedDueDateScheduleDetail);

--- a/settings/FixedDueDateScheduleDetail.js
+++ b/settings/FixedDueDateScheduleDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage, FormattedDate, intlShape, injectIntl } from 'react-intl';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { stripesShape } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -45,7 +45,7 @@ class FixedDueDateScheduleDetail extends React.Component {
 
   render() {
     const {
-      intl: { formatDate, formatMessage },
+      intl: { formatMessage },
       initialValues: fixedDueDateSchedule,
     } = this.props;
 
@@ -72,9 +72,15 @@ class FixedDueDateScheduleDetail extends React.Component {
             </Col>
           </Row>
           <Row key={index + 2}>
-            <Col xs={4}>{formatDate(schedule.from)}</Col>
-            <Col xs={4}>{formatDate(schedule.to)}</Col>
-            <Col xs={4}>{formatDate(schedule.due)}</Col>
+            <Col xs={4}>
+              <FormattedDate value={schedule.from} />
+            </Col>
+            <Col xs={4}>
+              <FormattedDate value={schedule.to} />
+            </Col>
+            <Col xs={4}>
+              <FormattedDate value={schedule.due} />
+            </Col>
           </Row>
         </div>
       </div>

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -137,7 +137,7 @@ class FixedDueDateScheduleForm extends React.Component {
               onClick={this.beginDelete}
               disabled={confirmDelete}
             >
-              Delete
+              <FormattedMessage id="circulation.settings.staffSlips.delete" />
             </Button>
           </IfPermission>
         }
@@ -155,11 +155,9 @@ class FixedDueDateScheduleForm extends React.Component {
 
   renderPaneTitle() {
     const {
-      initialValues,
+      initialValues: selectedSet = {},
       intl: { formatMessage },
     } = this.props;
-
-    const selectedSet = initialValues || {};
 
     if (selectedSet.id) {
       return (

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { Field, FieldArray } from 'redux-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import {
   Accordion,
@@ -27,6 +27,7 @@ import css from './FixedDueDateSchedule.css';
 class FixedDueDateScheduleForm extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
     onSave: PropTypes.func,
@@ -92,14 +93,18 @@ class FixedDueDateScheduleForm extends React.Component {
   }
 
   addFirstMenu() {
-    const { stripes: { intl } } = this.props;
+    const {
+      intl: { formatMessage },
+      onCancel,
+    } = this.props;
+
     return (
       <PaneMenu>
         <button
           id="clickable-close-fixedDueDateSchedule"
-          onClick={this.props.onCancel}
-          title={intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.close' })}
-          aria-label={intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.closeLabel' })}
+          onClick={onCancel}
+          title={formatMessage({ id: 'ui-circulation.settings.fDDSform.close' })}
+          aria-label={formatMessage({ id: 'ui-circulation.settings.fDDSform.closeLabel' })}
           type="button"
         >
           <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
@@ -109,11 +114,17 @@ class FixedDueDateScheduleForm extends React.Component {
   }
 
   saveLastMenu() {
-    const { pristine, submitting, initialValues, stripes: { intl } } = this.props;
+    const {
+      pristine,
+      submitting,
+      initialValues,
+      intl: { formatMessage },
+    } = this.props;
+
     const { confirmDelete } = this.state;
     const edit = initialValues && initialValues.id;
-    const saveLabel = edit ? intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.saveSchedule' }) :
-      intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.createSchedule' });
+    const saveLabel = edit ? formatMessage({ id: 'ui-circulation.settings.fDDSform.saveSchedule' }) :
+      formatMessage({ id: 'ui-circulation.settings.fDDSform.createSchedule' });
 
     return (
       <PaneMenu>
@@ -121,12 +132,12 @@ class FixedDueDateScheduleForm extends React.Component {
           <IfPermission perm="ui-circulation.settings.loan-rules">
             <Button
               id="clickable-delete-set"
-              title={intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.delete' })}
+              title={formatMessage({ id: 'ui-circulation.settings.fDDSform.delete' })}
               buttonStyle="danger"
               onClick={this.beginDelete}
               disabled={confirmDelete}
             >
-Delete
+              Delete
             </Button>
           </IfPermission>
         }
@@ -143,28 +154,34 @@ Delete
   }
 
   renderPaneTitle() {
-    const { initialValues, stripes: { intl } } = this.props;
+    const {
+      initialValues,
+      intl: { formatMessage },
+    } = this.props;
+
     const selectedSet = initialValues || {};
 
     if (selectedSet.id) {
       return (
         <div>
           <Icon size="small" icon="edit" />
-          <span>{`${intl.formatMessage({ id: 'ui-circulation.settings.fDDS.edit' })}: ${selectedSet.name}`}</span>
+          <span>{`${formatMessage({ id: 'ui-circulation.settings.fDDS.edit' })}: ${selectedSet.name}`}</span>
         </div>
       );
     }
-    return intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.newFixDDSchedule' });
+    return formatMessage({ id: 'ui-circulation.settings.fDDSform.newFixDDSchedule' });
   }
 
   renderSchedules({ fields, meta: { error, submitFailed } }) {
+    const { formatMessage } = this.props.intl;
+
     return (
       <div>
         <Row>
           <Col xs={11} />
           <Col xs={1}>
             <Button type="button" onClick={() => fields.unshift({})}>
-              {this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.new' })}
+              {formatMessage({ id: 'ui-circulation.settings.fDDSform.new' })}
             </Button>
           </Col>
         </Row>
@@ -173,30 +190,30 @@ Delete
           <div key={index} className={css.scheduleItem}>
             <div className={css.scheduleHeader}>
               <h4>
-                {this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.dateRange' })}
+                {formatMessage({ id: 'ui-circulation.settings.fDDSform.dateRange' })}
                 {' '}
-                { index + 1 }
+                {index + 1}
               </h4>
             </div>
             <div className={css.scheduleItemContent}>
               <Row>
                 <Col xs={12} sm={4}>
                   <Field
-                    label={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.dateFrom' })}
+                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dateFrom' })}
                     name={`${schedule}.from`}
                     component={Datepicker}
                   />
                 </Col>
                 <Col xs={12} sm={4}>
                   <Field
-                    label={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.dateTo' })}
+                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dateTo' })}
                     name={`${schedule}.to`}
                     component={Datepicker}
                   />
                 </Col>
                 <Col xs={12} sm={3}>
                   <Field
-                    label={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.dueDate' })}
+                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dueDate' })}
                     name={`${schedule}.due`}
                     component={Datepicker}
                   />
@@ -206,7 +223,7 @@ Delete
                     <Button
                       buttonStyle="transparent slim"
                       style={{ position: 'absolute', bottom: '0' }}
-                      title={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.fDDSform.remove' })}
+                      title={formatMessage({ id: 'ui-circulation.settings.fDDSform.remove' })}
                       onClick={() => { f.remove(index); }}
                     >
                       <Icon icon="trashBin" />
@@ -222,11 +239,15 @@ Delete
   }
 
   render() {
-    const { handleSubmit, initialValues } = this.props;
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const {
+      handleSubmit,
+      initialValues,
+      intl: { formatMessage },
+    } = this.props;
+
     const { confirmDelete, sections } = this.state;
     const selectedSet = initialValues || {};
-    const selectedName = selectedSet.name || formatMsg({ id: 'ui-circulation.settings.fDDSform.untitled' });
+    const selectedName = selectedSet.name || formatMessage({ id: 'ui-circulation.settings.fDDSform.untitled' });
     const confirmationMessage = <FormattedMessage id="ui-circulation.settings.fDDSform.deleteMessage" values={{ name: <strong>{selectedName}</strong>, deleted: <strong>deleted</strong> }} />;
 
     return (
@@ -243,10 +264,10 @@ Delete
                 open={sections.generalInformation}
                 id="generalInformation"
                 onToggle={this.handleSectionToggle}
-                label={formatMsg({ id: 'ui-circulation.settings.fDDSform.about' })}
+                label={formatMessage({ id: 'ui-circulation.settings.fDDSform.about' })}
               >
                 <section className={css.accordionSection}>
-                  { (initialValues && initialValues.metadata && initialValues.metadata.createdDate) &&
+                  {(initialValues && initialValues.metadata && initialValues.metadata.createdDate) &&
                     <this.cViewMetaData metadata={initialValues.metadata} />
                   }
                   <div className={css.smformItem}>
@@ -257,14 +278,14 @@ Delete
                       autoFocus
                       required
                       fullWidth
-                      label={formatMsg({ id: 'ui-circulation.settings.fDDSform.nameRequired' })}
+                      label={formatMessage({ id: 'ui-circulation.settings.fDDSform.nameRequired' })}
                     />
                   </div>
                   <Field
                     name="description"
                     component={TextArea}
                     fullWidth
-                    label={formatMsg({ id: 'ui-circulation.settings.fDDSform.description' })}
+                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.description' })}
                   />
                 </section>
               </Accordion>
@@ -272,7 +293,7 @@ Delete
                 open={sections.schedule}
                 id="schedule"
                 onToggle={this.handleSectionToggle}
-                label={formatMsg({ id: 'ui-circulation.settings.fDDSform.schedule' })}
+                label={formatMessage({ id: 'ui-circulation.settings.fDDSform.schedule' })}
               >
                 <section className={css.accordionSection}>
                   <FieldArray name="schedules" component={this.renderSchedules} />
@@ -281,11 +302,11 @@ Delete
               <ConfirmationModal
                 id="deletefixedduedateschedule-confirmation"
                 open={confirmDelete}
-                heading={formatMsg({ id: 'ui-circulation.settings.fDDSform.deleteHeader' })}
+                heading={formatMessage({ id: 'ui-circulation.settings.fDDSform.deleteHeader' })}
                 message={confirmationMessage}
                 onConfirm={() => { this.confirmDeleteSet(true); }}
                 onCancel={() => { this.confirmDeleteSet(false); }}
-                confirmLabel={formatMsg({ id: 'ui-circulation.settings.fDDSform.delete' })}
+                confirmLabel={formatMessage({ id: 'ui-circulation.settings.fDDSform.delete' })}
                 buttonStyle="danger"
               />
             </div>
@@ -300,4 +321,4 @@ export default stripesForm({
   form: 'FixedDueDateScheduleForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(FixedDueDateScheduleForm);
+})(injectIntl(FixedDueDateScheduleForm));

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
-import { stripesShape } from '@folio/stripes/core';
+import { intlShape, injectIntl } from 'react-intl';
 import { EntryManager } from '@folio/stripes/smart-components';
 import FixedDueDateScheduleDetail from './FixedDueDateScheduleDetail';
 import FixedDueDateScheduleForm from './FixedDueDateScheduleForm';
@@ -34,7 +34,7 @@ class FixedDueDateScheduleManager extends React.Component {
         GET: PropTypes.func,
       }),
     }).isRequired,
-    stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -54,22 +54,26 @@ class FixedDueDateScheduleManager extends React.Component {
   }
 
   validate(values) {
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const {
+      intl: { formatMessage },
+      resources,
+    } = this.props;
+
     const errors = {};
-    const fillInMsg = formatMsg({ id: 'ui-circulation.settings.validate.fillIn' });
+    const fillInMsg = formatMessage({ id: 'ui-circulation.settings.validate.fillIn' });
 
     if (!values.name) {
       errors.name = fillInMsg;
     }
 
     // when searching for a name-match, skip the current record
-    const records = (this.props.resources.fixedDueDateSchedules || {}).records || [];
+    const records = (resources.fixedDueDateSchedules || {}).records || [];
     if (values.name && _.find(records, entry => entry.name === values.name && entry.id !== values.id)) {
-      errors.name = formatMsg({ id: 'ui-circulation.settings.fDDS.validate.uniqueName' });
+      errors.name = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.uniqueName' });
     }
 
     if (!values.schedules || !values.schedules.length) {
-      errors.schedules = { _error: formatMsg({ id: 'ui-circulation.settings.fDDS.validate.oneScheduleMin' }) };
+      errors.schedules = { _error: formatMessage({ id: 'ui-circulation.settings.fDDS.validate.oneScheduleMin' }) };
     } else {
       const schedulesErrors = [];
 
@@ -83,7 +87,7 @@ class FixedDueDateScheduleManager extends React.Component {
             const condA = (s1.from && s2.to) ? moment(s1.from).isBefore(s2.to) : false;
             const condB = (s1.to && s2.from) ? moment(s1.to).isAfter(s2.from) : false;
             if (condA && condB) {
-              errors.schedules = { _error: formatMsg({ id: 'ui-circulation.settings.fDDS.validate.overlappingDateRange' }, { num1: i + 1, num2: j + 1 }) };
+              errors.schedules = { _error: formatMessage({ id: 'ui-circulation.settings.fDDS.validate.overlappingDateRange' }, { num1: i + 1, num2: j + 1 }) };
             }
           }
         }
@@ -109,12 +113,12 @@ class FixedDueDateScheduleManager extends React.Component {
           const from = moment(schedule.from);
           const due = moment(schedule.due);
           if (!to.isAfter(from)) {
-            scheduleErrors.to = formatMsg({ id: 'ui-circulation.settings.fDDS.validate.toDate' });
+            scheduleErrors.to = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.toDate' });
             schedulesErrors[i] = scheduleErrors;
           }
 
           if (!due.isSameOrAfter(to)) {
-            scheduleErrors.due = formatMsg({ id: 'ui-circulation.settings.fDDS.validate.onOrAfter' });
+            scheduleErrors.due = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.onOrAfter' });
             schedulesErrors[i] = scheduleErrors;
           }
         }
@@ -128,17 +132,22 @@ class FixedDueDateScheduleManager extends React.Component {
   }
 
   render() {
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const {
+      intl: { formatMessage },
+      resources,
+      mutator,
+    } = this.props;
+
     return (
       <EntryManager
         {...this.props}
-        parentMutator={this.props.mutator}
-        entryList={_.sortBy((this.props.resources.fixedDueDateSchedules || {}).records || [], ['name'])}
+        parentMutator={mutator}
+        entryList={_.sortBy((resources.fixedDueDateSchedules || {}).records || [], ['name'])}
         resourceKey="fixedDueDateSchedules"
         detailComponent={FixedDueDateScheduleDetail}
         entryFormComponent={FixedDueDateScheduleForm}
-        paneTitle={formatMsg({ id: 'ui-circulation.settings.fDDS.paneTitle' })}
-        entryLabel={formatMsg({ id: 'ui-circulation.settings.fDDSform.entryLabel' })}
+        paneTitle={formatMessage({ id: 'ui-circulation.settings.fDDS.paneTitle' })}
+        entryLabel={formatMessage({ id: 'ui-circulation.settings.fDDSform.entryLabel' })}
         nameKey="name"
         permissions={{
           put: 'ui-circulation.settings.loan-rules',
@@ -147,11 +156,11 @@ class FixedDueDateScheduleManager extends React.Component {
         }}
         validate={this.validate}
         deleteDisabled={this.deleteDisabled}
-        deleteDisabledMessage={formatMsg({ id: 'ui-circulation.settings.fDDS.deleteDisabled' })}
+        deleteDisabledMessage={formatMessage({ id: 'ui-circulation.settings.fDDS.deleteDisabled' })}
         defaultEntry={{ schedules: [{}] }}
       />
     );
   }
 }
 
-export default FixedDueDateScheduleManager;
+export default injectIntl(FixedDueDateScheduleManager);

--- a/settings/LoanPolicyDetail.js
+++ b/settings/LoanPolicyDetail.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
-import { FormattedMessage } from 'react-intl';
 
 import {
   loanProfileTypes,
@@ -17,6 +17,7 @@ import {
 class LoanPolicyDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
+    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
     parentResources: PropTypes.shape({
       fixedDueDateSchedules: PropTypes.object,
@@ -54,15 +55,18 @@ class LoanPolicyDetail extends React.Component {
   }
 
   renderLoans() {
-    const { stripes, initialValues, parentResources } = this.props;
+    const {
+      intl: { formatMessage },
+      initialValues,
+      parentResources,
+    } = this.props;
 
-    const formatMsg = stripes.intl.formatMessage;
     const policy = initialValues || {};
     const fixedDueDateSchedules = ((parentResources || {}).fixedDueDateSchedules || {}).records || [];
 
-    let dueDateScheduleFieldLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
+    let dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
     if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.ROLLING) {
-      dueDateScheduleFieldLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
+      dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
     }
 
     let schedule = {};
@@ -91,7 +95,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
               value={_.get(profile, ['label'], '-')}
             />
           </Col>
@@ -102,7 +106,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.loanPeriod' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanPeriod' })}
                   value={`${_.get(policy, ['loansPolicy', 'period', 'duration'], '')} ${periodInterval}`}
                 />
               </Col>
@@ -122,14 +126,17 @@ class LoanPolicyDetail extends React.Component {
         <br />
         <Row>
           <Col xs={12}>
-            <KeyValue label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })} value={_.get(closedLibraryDueDateManagement, ['label'], '-')} />
+            <KeyValue
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })}
+              value={_.get(closedLibraryDueDateManagement, ['label'], '-')}
+            />
           </Col>
         </Row>
         <br />
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodExisting' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodExisting' })}
               value={`${_.get(policy, ['loansPolicy', 'existingRequestsPeriod', 'duration'], '')} ${exReqPerInterval}`}
             />
           </Col>
@@ -138,7 +145,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.gracePeriod' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.gracePeriod' })}
               value={`${_.get(policy, ['loansPolicy', 'gracePeriod', 'duration'], '')} ${gracePeriodInterval}`}
             />
           </Col>
@@ -149,7 +156,7 @@ class LoanPolicyDetail extends React.Component {
 
   renderAbout() {
     const policy = (this.props.initialValues || {});
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const { formatMessage } = this.props.intl;
 
     return (
       <div>
@@ -164,7 +171,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
               value={_.get(policy, ['name'], '')}
             />
           </Col>
@@ -173,7 +180,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
               value={_.get(policy, ['description'], '-')}
             />
           </Col>
@@ -183,7 +190,7 @@ class LoanPolicyDetail extends React.Component {
   }
 
   renderRenewals() {
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const { formatMessage } = this.props.intl;
     const policy = this.props.initialValues || {};
     const unlimited = (_.get(policy, ['renewalsPolicy', 'unlimited'])) ? 'Yes' : 'No';
     const differentPeriod = (_.get(policy, ['renewalsPolicy', 'differentPeriod'])) ? 'Yes' : 'No';
@@ -203,7 +210,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
               value={unlimited}
             />
           </Col>
@@ -214,7 +221,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.numRenewalsAllowed' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.numRenewalsAllowed' })}
                   value={_.get(policy, ['renewalsPolicy', 'numberAllowed'], 0)}
                 />
               </Col>
@@ -225,7 +232,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
               value={_.get(renewFrom, ['label'], '-')}
             />
           </Col>
@@ -234,7 +241,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
               value={differentPeriod}
             />
           </Col>
@@ -245,7 +252,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals' })}
                   value={`${_.get(policy, ['renewalsPolicy', 'period', 'duration'])} ${interval}`}
                 />
               </Col>
@@ -258,7 +265,7 @@ class LoanPolicyDetail extends React.Component {
 
   render() {
     const policy = this.props.initialValues || {};
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const { formatMessage } = this.props.intl;
     const { sections } = this.state;
 
     return (
@@ -272,7 +279,7 @@ class LoanPolicyDetail extends React.Component {
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
+          label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
         >
           {policy.metadata && policy.metadata.createdDate &&
             <Row>
@@ -294,4 +301,4 @@ class LoanPolicyDetail extends React.Component {
   }
 }
 
-export default LoanPolicyDetail;
+export default injectIntl(LoanPolicyDetail);

--- a/settings/LoanPolicyForm.js
+++ b/settings/LoanPolicyForm.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, getFormValues } from 'redux-form';
 import _ from 'lodash';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import {
   Accordion,
@@ -14,7 +15,6 @@ import {
   TextField
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
-import { FormattedMessage } from 'react-intl';
 
 import {
   loanProfileTypes,
@@ -27,6 +27,7 @@ import {
 
 class LoanPolicyForm extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
     parentResources: PropTypes.shape({
       fixedDueDateSchedules: PropTypes.object,
@@ -50,7 +51,7 @@ class LoanPolicyForm extends React.Component {
   }
 
   getCurrentValues() {
-    const { stripes: { store } } = this.props;
+    const { store } = this.props.stripes;
     const state = store.getState();
     return getFormValues('entryForm')(state) || {};
   }
@@ -103,16 +104,16 @@ class LoanPolicyForm extends React.Component {
   }
 
   render() {
-    const formatMsg = this.props.stripes.intl.formatMessage;
+    const { formatMessage } = this.props.intl;
     const policy = this.getCurrentValues();
     const { sections } = this.state;
 
     // Conditional field labels
-    let dueDateScheduleFieldLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
-    let altRenewalScheduleLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.altFDDSforRenewals' });
+    let dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
+    let altRenewalScheduleLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSforRenewals' });
     if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.ROLLING) {
-      dueDateScheduleFieldLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
-      altRenewalScheduleLabel = formatMsg({ id: 'ui-circulation.settings.loanPolicy.altFDDSDueDateLimit' });
+      dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
+      altRenewalScheduleLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSDueDateLimit' });
     } else if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.FIXED) {
       dueDateScheduleFieldLabel += ' *';
     }
@@ -136,7 +137,7 @@ class LoanPolicyForm extends React.Component {
           open={sections.generalSection}
           id="generalSection"
           onToggle={this.handleSectionToggle}
-          label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
+          label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
         >
           {policy.metadata && policy.metadata.createdDate &&
             <Row>
@@ -149,7 +150,7 @@ class LoanPolicyForm extends React.Component {
           {/* Primary information: policy name and description, plus delete button */}
           <h2 style={{ marginTop: '0' }}>About</h2>
           <Field
-            label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
+            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
             autoFocus
             name="name"
             id="input_policy_name"
@@ -159,7 +160,7 @@ class LoanPolicyForm extends React.Component {
             validate={this.validateField}
           />
           <Field
-            label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
+            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
             name="description"
             component={TextArea}
             fullWidth
@@ -173,7 +174,7 @@ class LoanPolicyForm extends React.Component {
           </h2>
           {/* loanable: boolean determining visibility of all subsequent elements */}
           <Field
-            label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.loanable' })}
+            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanable' })}
             id="loanable"
             name="loanable"
             component={Checkbox}
@@ -182,7 +183,7 @@ class LoanPolicyForm extends React.Component {
           {/* loan profile. Value affects visibility of several subsequent elements */}
           { policy.loanable &&
             <Field
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
               name="loansPolicy.profileId"
               id="input_loan_profile"
               component={Select}
@@ -206,7 +207,7 @@ class LoanPolicyForm extends React.Component {
                     name="loansPolicy.period.intervalId"
                     id="select_policy_period"
                     component={Select}
-                    placeholder={formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
+                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
                     dataOptions={intervalPeriods}
                     validate={this.validateField}
                   />
@@ -223,13 +224,13 @@ class LoanPolicyForm extends React.Component {
               id="input_loansPolicy_fixedDueDateSchedule"
               component={Select}
               normalize={value => (value === '' ? null : value)}
-              dataOptions={[{ label: formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
+              dataOptions={[{ label: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
             />
           }
           {/* closed library due date management - Select */}
           { policy.loanable &&
             <Field
-              label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })}
               name="loansPolicy.closedLibraryDueDateManagementId"
               component={Select}
               dataOptions={dueDateManagementOptions}
@@ -256,7 +257,7 @@ class LoanPolicyForm extends React.Component {
                     label=""
                     name="loansPolicy.existingRequestsPeriod.intervalId"
                     component={Select}
-                    placeholder={formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
+                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
                     dataOptions={intervalPeriods.slice(0, 3)}
                     validate={this.validateField}
                   />
@@ -284,7 +285,7 @@ class LoanPolicyForm extends React.Component {
                     label=""
                     name="loansPolicy.gracePeriod.intervalId"
                     component={Select}
-                    placeholder={formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
+                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
                     dataOptions={intervalPeriods}
                     validate={this.validateField}
                   />
@@ -307,7 +308,7 @@ class LoanPolicyForm extends React.Component {
                 not handled properly -- see https://github.com/erikras/redux-form/issues/1993)
               */}
               <Field
-                label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.renewable' })}
+                label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewable' })}
                 name="renewable"
                 component={Checkbox}
                 id="renewable"
@@ -317,7 +318,7 @@ class LoanPolicyForm extends React.Component {
               {/* unlimited renewals (bool) */}
               { policy.renewable &&
                 <Field
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
                   name="renewalsPolicy.unlimited"
                   id="renewalsPolicy.unlimited"
                   component={Checkbox}
@@ -349,7 +350,7 @@ class LoanPolicyForm extends React.Component {
               { policy.renewable &&
                 policy.loansPolicy.profileId === loanProfileMap.ROLLING &&
                 <Field
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
                   name="renewalsPolicy.renewFromId"
                   id="select_renew_from"
                   component={Select}
@@ -360,7 +361,7 @@ class LoanPolicyForm extends React.Component {
               {/* different renewal period (bool) */}
               { policy.renewable &&
                 <Field
-                  label={formatMsg({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
                   name="renewalsPolicy.differentPeriod"
                   id="renewalsPolicy.differentPeriod"
                   component={Checkbox}
@@ -390,7 +391,7 @@ class LoanPolicyForm extends React.Component {
                         label=""
                         name="renewalsPolicy.period.intervalId"
                         component={Select}
-                        placeholder={formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
+                        placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
                         dataOptions={intervalPeriods}
                         validate={this.validateField}
                       />
@@ -408,7 +409,7 @@ class LoanPolicyForm extends React.Component {
                   name="renewalsPolicy.alternateFixedDueDateScheduleId"
                   component={Select}
                   normalize={value => (value === '' ? null : value)}
-                  dataOptions={[{ label: formatMsg({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
+                  dataOptions={[{ label: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
                 />
               }
             </fieldset>
@@ -419,4 +420,4 @@ class LoanPolicyForm extends React.Component {
   }
 }
 
-export default LoanPolicyForm;
+export default injectIntl(LoanPolicyForm);

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { stripesShape } from '@folio/stripes/core';
+import { intlShape, injectIntl } from 'react-intl';
 import { EntryManager } from '@folio/stripes/smart-components';
 import LoanPolicyDetail from './LoanPolicyDetail';
 import LoanPolicyForm from './LoanPolicyForm';
@@ -48,7 +48,7 @@ class LoanPolicySettings extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -59,31 +59,39 @@ class LoanPolicySettings extends React.Component {
 
   validate(values) {
     const errors = {};
+    const { formatMessage } = this.props.intl;
+
     if (!values.name) {
-      errors.name = this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.validate.fillIn' });
+      errors.name = formatMessage({ id: 'ui-circulation.settings.validate.fillIn' });
     }
 
     const loansPolicy = values.loansPolicy || {};
 
     if (loansPolicy.profileId === loanProfileMap.FIXED
       && !loansPolicy.fixedDueDateSchedule) {
-      errors.loansPolicy = { fixedDueDateSchedule: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectFDDS' }) };
+      errors.loansPolicy = { fixedDueDateSchedule: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectFDDS' }) };
     }
     return errors;
   }
 
   render() {
+    const {
+      intl: { formatMessage },
+      resources,
+      mutator,
+    } = this.props;
+
     return (
       <EntryManager
         {...this.props}
-        parentMutator={this.props.mutator}
-        parentResources={this.props.resources}
-        entryList={_.sortBy((this.props.resources.loanPolicies || {}).records || [], ['name'])}
+        parentMutator={mutator}
+        parentResources={resources}
+        entryList={_.sortBy((resources.loanPolicies || {}).records || [], ['name'])}
         resourceKey="loanPolicies"
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}
-        paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.loanPolicy.paneTitle' })}
-        entryLabel={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.loanPolicy.entryLabel' })}
+        paneTitle={formatMessage({ id: 'ui-circulation.settings.loanPolicy.paneTitle' })}
+        entryLabel={formatMessage({ id: 'ui-circulation.settings.loanPolicy.entryLabel' })}
         nameKey="name"
         defaultEntry={defaultPolicy}
         permissions={{
@@ -97,4 +105,4 @@ class LoanPolicySettings extends React.Component {
   }
 }
 
-export default LoanPolicySettings;
+export default injectIntl(LoanPolicySettings);

--- a/settings/LoanRules.js
+++ b/settings/LoanRules.js
@@ -22,7 +22,6 @@ const editorDefaultProps = {
     m: 'Material Type',
     t: 'Loan Type',
   },
-  intl: intlShape.isRequired,
 };
 
 class LoanRules extends React.Component {
@@ -181,11 +180,11 @@ class LoanRules extends React.Component {
 
   render() {
     const {
-      resources,
+      resources: { loanTypes },
       intl: { formatMessage },
     } = this.props;
 
-    if (!resources.loanTypes) {
+    if (!loanTypes) {
       return (<div />);
     }
 

--- a/settings/LoanRules.js
+++ b/settings/LoanRules.js
@@ -1,6 +1,7 @@
 import { kebabCase } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { intlShape, injectIntl } from 'react-intl';
 import { Callout, Paneset, Pane } from '@folio/stripes/components';
 import fetch from 'isomorphic-fetch';
 
@@ -21,6 +22,7 @@ const editorDefaultProps = {
     m: 'Material Type',
     t: 'Loan Type',
   },
+  intl: intlShape.isRequired,
 };
 
 class LoanRules extends React.Component {
@@ -57,6 +59,7 @@ class LoanRules extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape.isRequired,
     resources: PropTypes.object.isRequired,
     stripes: PropTypes.object.isRequired,
     calloutMessage: PropTypes.string,
@@ -73,7 +76,12 @@ class LoanRules extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { resources: { patronGroups, materialTypes, loanTypes, loanPolicies } } = nextProps;
+    const {
+      patronGroups,
+      materialTypes,
+      loanTypes,
+      loanPolicies,
+    } = nextProps.resources;
 
     return !patronGroups.isPending &&
       !materialTypes.isPending &&
@@ -93,7 +101,12 @@ class LoanRules extends React.Component {
   }
 
   getEditorProps() {
-    const { resources: { patronGroups, materialTypes, loanTypes, loanPolicies } } = this.props;
+    const {
+      patronGroups,
+      materialTypes,
+      loanTypes,
+      loanPolicies,
+    } = this.props.resources;
 
     return Object.assign({}, editorDefaultProps, {
       errors: this.state.errors,
@@ -107,7 +120,12 @@ class LoanRules extends React.Component {
   }
 
   getRecords() {
-    const { resources: { patronGroups, materialTypes, loanTypes, loanPolicies } } = this.props;
+    const {
+      patronGroups,
+      materialTypes,
+      loanTypes,
+      loanPolicies,
+    } = this.props.resources;
 
     return [
       ...patronGroups.records.map(r => ({ name: kebabCase(r.group), id: r.id, prefix: 'g' })),
@@ -137,7 +155,7 @@ class LoanRules extends React.Component {
   // TODO: refactor to use mutator after PUT is changed on the server or stripes-connect supports
   // custom PUT requests without the id attached to the end of the URL.
   saveLoanRules(rules) {
-    const stripes = this.props.stripes;
+    const { stripes } = this.props;
     const headers = Object.assign({}, {
       'X-Okapi-Tenant': stripes.okapi.tenant,
       'X-Okapi-Token': stripes.store.getState().okapi.token,
@@ -162,7 +180,12 @@ class LoanRules extends React.Component {
   }
 
   render() {
-    if (!this.props.resources.loanTypes) {
+    const {
+      resources,
+      intl: { formatMessage },
+    } = this.props;
+
+    if (!resources.loanTypes) {
       return (<div />);
     }
 
@@ -171,7 +194,10 @@ class LoanRules extends React.Component {
 
     return (
       <Paneset>
-        <Pane paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.loanRules.paneTitle' })} defaultWidth="fill">
+        <Pane
+          paneTitle={formatMessage({ id: 'ui-circulation.settings.loanRules.paneTitle' })}
+          defaultWidth="fill"
+        >
           <LoanRulesForm
             onSubmit={this.onSubmit}
             initialValues={{ loanRulesCode }}
@@ -184,4 +210,4 @@ class LoanRules extends React.Component {
   }
 }
 
-export default LoanRules;
+export default injectIntl(LoanRules);

--- a/settings/RequestCancellationReasons.js
+++ b/settings/RequestCancellationReasons.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { intlShape, injectIntl } from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 class RequestCancellationReasons extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
     }).isRequired,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -17,20 +18,22 @@ class RequestCancellationReasons extends React.Component {
   }
 
   render() {
+    const { formatMessage } = this.props.intl;
+
     return (
       <this.connectedControlledVocab
         {...this.props}
         baseUrl="cancellation-reason-storage/cancellation-reasons"
         records="cancellationReasons"
-        label={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.cancelReasons.label' })}
-        labelSingular={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelSingular' })}
+        label={formatMessage({ id: 'ui-circulation.settings.cancelReasons.label' })}
+        labelSingular={formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelSingular' })}
         objectLabel=""
         visibleFields={['name', 'description', 'publicDescription']}
         hiddenFields={['lastUpdated', 'numberOfObjects']}
         columnMapping={{
-          name: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelShort' }),
-          description: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionInternal' }),
-          publicDescription: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionPublic' }),
+          name: formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelShort' }),
+          description: formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionInternal' }),
+          publicDescription: formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionPublic' }),
         }}
         actionSuppressor={{
           edit: () => false,
@@ -43,4 +46,4 @@ class RequestCancellationReasons extends React.Component {
   }
 }
 
-export default RequestCancellationReasons;
+export default injectIntl(RequestCancellationReasons);

--- a/settings/StaffSlips/PreviewModal.js
+++ b/settings/StaffSlips/PreviewModal.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import Barcode from 'react-barcode';
 import HtmlToReact, { Parser } from 'html-to-react';
 import ReactToPrint from 'react-to-print';
+import { injectIntl, intlShape } from 'react-intl';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
 import formats from './formats';
 import { template } from './util';
 
 class PreviewModal extends React.Component {
   static propTypes = {
-    intl: intlShape,
+    intl: intlShape.isRequired,
     onClose: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
     previewTemplate: PropTypes.string,
@@ -39,9 +39,15 @@ class PreviewModal extends React.Component {
   }
 
   render() {
-    const { open, onClose, previewTemplate, intl } = this.props;
-    const closeLabel = intl.formatMessage({ id: 'ui-circulation.settings.staffSlips.close' });
-    const heading = intl.formatMessage({ id: 'ui-circulation.settings.staffSlips.previewLabel' });
+    const {
+      open,
+      onClose,
+      previewTemplate,
+      intl: { formatMessage },
+    } = this.props;
+
+    const closeLabel = formatMessage({ id: 'ui-circulation.settings.staffSlips.close' });
+    const heading = formatMessage({ id: 'ui-circulation.settings.staffSlips.previewLabel' });
 
     const tmpl = template(previewTemplate || '');
     const componentStr = tmpl(this.previewFormat);

--- a/settings/StaffSlips/PreviewModal.js
+++ b/settings/StaffSlips/PreviewModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Barcode from 'react-barcode';
 import HtmlToReact, { Parser } from 'html-to-react';
 import ReactToPrint from 'react-to-print';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
 import formats from './formats';
 import { template } from './util';
@@ -46,7 +46,7 @@ class PreviewModal extends React.Component {
       intl: { formatMessage },
     } = this.props;
 
-    const closeLabel = formatMessage({ id: 'ui-circulation.settings.staffSlips.close' });
+    const closeLabel = <FormattedMessage id="ui-circulation.settings.staffSlips.close" />;
     const heading = formatMessage({ id: 'ui-circulation.settings.staffSlips.previewLabel' });
 
     const tmpl = template(previewTemplate || '');

--- a/settings/StaffSlips/StaffSlipDetail.js
+++ b/settings/StaffSlips/StaffSlipDetail.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Button, Col, KeyValue, Row } from '@folio/stripes/components';
 import HtmlToReact, { Parser } from 'html-to-react';
 
@@ -12,9 +13,9 @@ class StaffSlipDetail extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
     }).isRequired,
     initialValues: PropTypes.object,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -37,7 +38,7 @@ class StaffSlipDetail extends React.Component {
   }
 
   translate(id) {
-    return this.props.stripes.intl.formatMessage({
+    return this.props.intl.formatMessage({
       id: `ui-circulation.settings.staffSlips.${id}`
     });
   }
@@ -52,7 +53,7 @@ class StaffSlipDetail extends React.Component {
 
   render() {
     const { openDialog } = this.state;
-    const staffSlip = this.props.initialValues;
+    const { initialValues: staffSlip } = this.props;
     const contentComponent = this.parser.parseWithInstructions(staffSlip.template, () => true, this.rules);
 
     return (
@@ -104,4 +105,4 @@ class StaffSlipDetail extends React.Component {
   }
 }
 
-export default StaffSlipDetail;
+export default injectIntl(StaffSlipDetail);

--- a/settings/StaffSlips/StaffSlipEditor.js
+++ b/settings/StaffSlips/StaffSlipEditor.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
+import { injectIntl, intlShape } from 'react-intl';
 import { Button, Col, Row } from '@folio/stripes/components';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -17,7 +18,7 @@ class StaffSlipEditor extends Component {
     label: PropTypes.string,
     slipType: PropTypes.string,
     tokens: PropTypes.arrayOf(PropTypes.string),
-    stripes: PropTypes.object,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -90,7 +91,7 @@ class StaffSlipEditor extends Component {
   }
 
   translate(id) {
-    return this.props.stripes.intl.formatMessage({
+    return this.props.intl.formatMessage({
       id: `ui-circulation.settings.staffSlips.${id}`
     });
   }
@@ -141,4 +142,4 @@ class StaffSlipEditor extends Component {
   }
 }
 
-export default StaffSlipEditor;
+export default injectIntl(StaffSlipEditor);

--- a/settings/StaffSlips/StaffSlipForm.js
+++ b/settings/StaffSlips/StaffSlipForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 
 import {
   Button,
@@ -25,7 +26,6 @@ class StaffSlipForm extends React.Component {
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
       connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
     }).isRequired,
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
@@ -33,6 +33,7 @@ class StaffSlipForm extends React.Component {
     onCancel: PropTypes.func,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -45,7 +46,7 @@ class StaffSlipForm extends React.Component {
   }
 
   translate(id) {
-    return this.props.stripes.intl.formatMessage({
+    return this.props.intl.formatMessage({
       id: `ui-circulation.settings.staffSlips.${id}`
     });
   }
@@ -148,4 +149,4 @@ export default stripesForm({
   form: 'staffSlipForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(StaffSlipForm);
+})(injectIntl(StaffSlipForm));

--- a/settings/StaffSlips/StaffSlipManager.js
+++ b/settings/StaffSlips/StaffSlipManager.js
@@ -1,6 +1,7 @@
 import { sortBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { intlShape, injectIntl } from 'react-intl';
 import { EntryManager } from '@folio/stripes/smart-components';
 
 import StaffSlipDetail from './StaffSlipDetail';
@@ -21,9 +22,7 @@ class StaffSlipManager extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    stripes: PropTypes.shape({
-      intl: PropTypes.object.isRequired,
-    }),
+    intl: intlShape.isRequired,
   };
 
   static manifest = Object.freeze({
@@ -57,7 +56,7 @@ class StaffSlipManager extends React.Component {
   }
 
   translate(id) {
-    this.props.stripes.intl.formatMessage({
+    this.props.intl.formatMessage({
       id: `ui-circulation.settings.staffSlips.${id}`
     });
   }
@@ -73,14 +72,20 @@ class StaffSlipManager extends React.Component {
   }
 
   render() {
+    const {
+      mutator,
+      resources,
+      label,
+    } = this.props;
+
     return (
       <EntryManager
         {...this.props}
-        parentMutator={this.props.mutator}
-        entryList={sortBy((this.props.resources.entries || {}).records || [], ['name'])}
+        parentMutator={mutator}
+        entryList={sortBy((resources.entries || {}).records || [], ['name'])}
         detailComponent={StaffSlipDetail}
-        paneTitle={this.props.label}
-        entryLabel={this.props.label}
+        paneTitle={label}
+        entryLabel={label}
         entryFormComponent={StaffSlipForm}
         validate={this.validate}
         nameKey="name"
@@ -94,4 +99,4 @@ class StaffSlipManager extends React.Component {
   }
 }
 
-export default StaffSlipManager;
+export default injectIntl(StaffSlipManager);

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { intlShape, injectIntl } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
-import { stripesShape } from '@folio/stripes/core';
 
 import LoanPolicySettings from './LoanPolicySettings';
 import LoanRules from './LoanRules';
@@ -11,43 +11,44 @@ import StaffSlips from './StaffSlips';
 
 class Circulation extends React.Component {
   static propTypes = {
-    stripes: stripesShape.isRequired,
+    intl: intlShape.isRequired,
   }
 
   constructor(props) {
     super(props);
+    const { formatMessage } = props.intl;
     this.pages = [
       {
         route: 'loan-policies',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.loanPolicies' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.loanPolicies' }),
         component: LoanPolicySettings,
         perm: 'ui-circulation.settings.loan-policies',
       },
       {
         route: 'loan-rules',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.loanRules' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.loanRules' }),
         component: LoanRules,
         perm: 'ui-circulation.settings.loan-rules',
       },
       {
         route: 'fixed-due-date-schedules',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.fdds' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.fdds' }),
         component: FixedDueDateScheduleManager,
         perm: 'ui-circulation.settings.loan-rules',
       },
       {
         route: 'checkout',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.otherSettings' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.otherSettings' }),
         component: CheckoutSettings,
       },
       {
         route: 'staffslips',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.staffSlips' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.staffSlips' }),
         component: StaffSlips,
       },
       {
         route: 'cancellation-reasons',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.requestCancellationReasons' }),
+        label: formatMessage({ id: 'ui-circulation.settings.index.requestCancellationReasons' }),
         component: RequestCancellationReasons,
         perm: 'ui-circulation.settings.cancellation-reasons',
       },
@@ -59,10 +60,10 @@ class Circulation extends React.Component {
       <Settings
         {...this.props}
         pages={this.pages}
-        paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.paneTitle' })}
+        paneTitle={this.props.intl.formatMessage({ id: 'ui-circulation.settings.index.paneTitle' })}
       />
     );
   }
 }
 
-export default Circulation;
+export default injectIntl(Circulation);


### PR DESCRIPTION
## Purpose
Taking into account that retrieving the intl object from this.context.intl or the stripes god object (stripes.intl) is a deprecated pattern.

The purpose of this PR is to update this repo to only use react-intl constructs outlined at https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md

## Learning
React Intl docs: https://github.com/yahoo/react-intl/wiki
