### PR TITLE
UICIRC-97: Apply internationalization to all hardcoded strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Provide `sortby` prop to `<ControlledVocab>`. Refs STSMACOM-139.
 * Provide `type` prop to `<Field>`. Refs PR #697.
 * Support circulation v5.0, requiring service-point information on loans. Refs UICIRC-100.
+* Use documented react-intl patterns instead of stripes.intl, UICIRC-91.
+* Apply internationalization to all hardcodded strings, UICIRC-97.
 
 ## 1.3.0 (https://github.com/folio-org/ui-circulation/tree/v1.3.0) (2018-10-04)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.2.0...v1.3.0)

--- a/settings/CheckoutSettings.js
+++ b/settings/CheckoutSettings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
@@ -12,7 +12,6 @@ class CheckoutSettings extends React.Component {
   static propTypes = {
     label: PropTypes.string,
     stripes: stripesShape.isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -43,12 +42,11 @@ class CheckoutSettings extends React.Component {
   }
 
   validate(values, allthevalues) {
-    const { formatMessage } = this.props.intl;
     const errors = {};
 
     const isValid = values.idents && values.idents.reduce((valid, v) => (valid || v), false);
     if (!isValid) {
-      errors.idents = { _error: formatMessage({ id: 'ui-circulation.settings.checkout.validate.selectContinue' }) };
+      errors.idents = { _error: <FormattedMessage id="ui-circulation.settings.checkout.validate.selectContinue" /> };
     }
 
     if (!values.checkoutTimeout) {
@@ -56,7 +54,7 @@ class CheckoutSettings extends React.Component {
     }
     const checkoutTimeoutDuration = (_.isInteger(+values.checkoutTimeoutDuration) && (+values.checkoutTimeoutDuration > 0));
     if (!checkoutTimeoutDuration) {
-      errors.checkoutTimeoutDuration = { _error: formatMessage({ id: 'ui-circulation.settings.checkout.validate.timeoutDuration' }) };
+      errors.checkoutTimeoutDuration = { _error: <FormattedMessage id="ui-circulation.settings.checkout.validate.timeoutDuration" /> };
     }
     return errors;
   }
@@ -76,4 +74,4 @@ class CheckoutSettings extends React.Component {
   }
 }
 
-export default injectIntl(CheckoutSettings);
+export default CheckoutSettings;

--- a/settings/CheckoutSettingsForm.js
+++ b/settings/CheckoutSettingsForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { Button, Checkbox, Col, Pane, Row, Select, TextField } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
@@ -89,7 +89,6 @@ class CheckoutSettingsForm extends React.Component {
     const {
       handleSubmit,
       label,
-      intl: { formatMessage },
     } = this.props;
 
     const checkoutValues = this.getCurrentValues();
@@ -102,7 +101,7 @@ class CheckoutSettingsForm extends React.Component {
           <Row>
             <Col xs={12}>
               <Field
-                label={formatMessage({ id: 'ui-circulation.settings.checkout.timeout' })}
+                label={<FormattedMessage id="ui-circulation.settings.checkout.timeout" />}
                 id="checkoutTimeout"
                 name="checkoutTimeout"
                 component={Checkbox}
@@ -133,20 +132,17 @@ class CheckoutSettingsForm extends React.Component {
           <Row>
             <Col xs={12}>
               <Field
-                label={formatMessage({ id: 'ui-circulation.settings.checkout.audioAlerts' })}
+                label={<FormattedMessage id="ui-circulation.settings.checkout.audioAlerts" />}
                 name="audioAlertsEnabled"
                 component={Select}
-                dataOptions={[
-                  {
-                    label: formatMessage({ id: 'ui-circulation.settings.checkout.no' }),
-                    value: false,
-                  },
-                  {
-                    label: formatMessage({ id: 'ui-circulation.settings.checkout.yes' }),
-                    value: true,
-                  },
-                ]}
-              />
+              >
+                <FormattedMessage id="ui-circulation.settings.checkout.no">
+                  {(message) => <option value="false">{message}</option>}
+                </FormattedMessage>
+                <FormattedMessage id="ui-circulation.settings.checkout.yes">
+                  {(message) => <option value="true">{message}</option>}
+                </FormattedMessage>
+              </Field>
             </Col>
           </Row>
         </Pane>
@@ -162,11 +158,10 @@ CheckoutSettingsForm.propTypes = {
   submitting: PropTypes.bool,
   label: PropTypes.string,
   stripes: stripesShape.isRequired,
-  intl: intlShape.isRequired,
 };
 
 export default stripesForm({
   form: 'checkoutForm',
   navigationCheck: true,
   enableReinitialize: true,
-})(injectIntl(CheckoutSettingsForm));
+})(CheckoutSettingsForm);

--- a/settings/FixedDueDateScheduleDetail.js
+++ b/settings/FixedDueDateScheduleDetail.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+
+import {
+  FormattedMessage,
+  FormattedDate,
+} from 'react-intl';
+
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { stripesShape } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';

--- a/settings/FixedDueDateScheduleDetail.js
+++ b/settings/FixedDueDateScheduleDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { FormattedMessage, FormattedDate, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage, FormattedDate } from 'react-intl';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { stripesShape } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -10,7 +10,6 @@ import css from './FixedDueDateSchedule.css';
 class FixedDueDateScheduleDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
-    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
   }
 
@@ -45,7 +44,6 @@ class FixedDueDateScheduleDetail extends React.Component {
 
   render() {
     const {
-      intl: { formatMessage },
       initialValues: fixedDueDateSchedule,
     } = this.props;
 
@@ -56,7 +54,7 @@ class FixedDueDateScheduleDetail extends React.Component {
           <h4>
             <FormattedMessage id="ui-circulation.settings.fDDSform.dateRange" />
             {' '}
-            { index + 1 }
+            {index + 1}
           </h4>
         </div>
         <div className={css.scheduleItemContent}>
@@ -87,7 +85,6 @@ class FixedDueDateScheduleDetail extends React.Component {
     ));
     return (
       <div>
-
         <Row end="xs">
           <Col xs>
             <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
@@ -97,24 +94,24 @@ class FixedDueDateScheduleDetail extends React.Component {
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label="General information"
+          label={<FormattedMessage id="ui-circulation.settings.fDDSform.about" />}
         >
           <section className={css.accordionSection}>
-            { (fixedDueDateSchedule.metadata && fixedDueDateSchedule.metadata.createdDate) &&
+            {(fixedDueDateSchedule.metadata && fixedDueDateSchedule.metadata.createdDate) &&
               <this.cViewMetaData metadata={fixedDueDateSchedule.metadata} />
             }
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMessage({ id: 'ui-circulation.settings.fDDSform.name' })}
-                  value={_.get(fixedDueDateSchedule, ['name'], formatMessage({ id: 'ui-circulation.settings.fDDSform.untitled' }))}
+                  label={<FormattedMessage id="ui-circulation.settings.fDDSform.name" />}
+                  value={_.get(fixedDueDateSchedule, ['name'], <FormattedMessage id="ui-circulation.settings.fDDSform.untitled" />)}
                 />
               </Col>
             </Row>
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMessage({ id: 'ui-circulation.settings.fDDSform.description' })}
+                  label={<FormattedMessage id="ui-circulation.settings.fDDSform.description" />}
                   value={_.get(fixedDueDateSchedule, ['description'], '')}
                 />
               </Col>
@@ -125,7 +122,7 @@ class FixedDueDateScheduleDetail extends React.Component {
           open={sections.fixedDueDateSchedule}
           id="fixedDueDateSchedule"
           onToggle={this.handleSectionToggle}
-          label="Schedule"
+          label={<FormattedMessage id="ui-circulation.settings.fDDSform.schedule" />}
         >
           <section className={css.accordionSection}>
             {renderSchedules}
@@ -136,4 +133,4 @@ class FixedDueDateScheduleDetail extends React.Component {
   }
 }
 
-export default injectIntl(FixedDueDateScheduleDetail);
+export default FixedDueDateScheduleDetail;

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -124,8 +124,9 @@ class FixedDueDateScheduleForm extends React.Component {
 
     const { confirmDelete } = this.state;
     const edit = initialValues && initialValues.id;
-    const saveLabel = edit ? <FormattedMessage id="ui-circulation.settings.fDDSform.saveSchedule" /> :
-    <FormattedMessage id="ui-circulation.settings.fDDSform.createSchedule" />;
+    const saveLabel = edit
+      ? <FormattedMessage id="ui-circulation.settings.fDDSform.saveSchedule" />
+      : <FormattedMessage id="ui-circulation.settings.fDDSform.createSchedule" />;
 
     return (
       <PaneMenu>
@@ -164,7 +165,10 @@ class FixedDueDateScheduleForm extends React.Component {
         <div>
           <Icon size="small" icon="edit" />
           <span>
-            <FormattedMessage id="ui-circulation.settings.fDDS.editLabel" values={{ name: selectedSet.name }} />
+            <FormattedMessage
+              id="ui-circulation.settings.fDDS.editLabel"
+              values={{ name: selectedSet.name }}
+            />
           </span>
         </div>
       );

--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { Field, FieldArray } from 'redux-form';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import {
   Accordion,
@@ -12,6 +12,7 @@ import {
   Datepicker,
   ExpandAllButton,
   Icon,
+  IconButton,
   IfPermission,
   Pane,
   PaneMenu,
@@ -27,7 +28,6 @@ import css from './FixedDueDateSchedule.css';
 class FixedDueDateScheduleForm extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
-    intl: intlShape.isRequired,
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
     onSave: PropTypes.func,
@@ -78,9 +78,13 @@ class FixedDueDateScheduleForm extends React.Component {
   }
 
   confirmDeleteSet(confirmation) {
-    const selectedSet = this.props.initialValues;
+    const {
+      initialValues: selectedSet,
+      onRemove,
+    } = this.props;
+
     if (confirmation) {
-      this.props.onRemove(selectedSet);
+      onRemove(selectedSet);
     } else {
       this.setState({ confirmDelete: false });
     }
@@ -94,21 +98,19 @@ class FixedDueDateScheduleForm extends React.Component {
 
   addFirstMenu() {
     const {
-      intl: { formatMessage },
       onCancel,
     } = this.props;
 
     return (
       <PaneMenu>
-        <button
-          id="clickable-close-fixedDueDateSchedule"
+        <IconButton
           onClick={onCancel}
-          title={formatMessage({ id: 'ui-circulation.settings.fDDSform.close' })}
-          aria-label={formatMessage({ id: 'ui-circulation.settings.fDDSform.closeLabel' })}
-          type="button"
-        >
-          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
-        </button>
+          icon="closeX"
+          size="medium"
+          iconClassName="closeIcon"
+          title={<FormattedMessage id="ui-circulation.settings.fDDSform.close" />}
+          aria-label={<FormattedMessage id="ui-circulation.settings.fDDSform.closeLabel" />}
+        />
       </PaneMenu>
     );
   }
@@ -118,13 +120,12 @@ class FixedDueDateScheduleForm extends React.Component {
       pristine,
       submitting,
       initialValues,
-      intl: { formatMessage },
     } = this.props;
 
     const { confirmDelete } = this.state;
     const edit = initialValues && initialValues.id;
-    const saveLabel = edit ? formatMessage({ id: 'ui-circulation.settings.fDDSform.saveSchedule' }) :
-      formatMessage({ id: 'ui-circulation.settings.fDDSform.createSchedule' });
+    const saveLabel = edit ? <FormattedMessage id="ui-circulation.settings.fDDSform.saveSchedule" /> :
+    <FormattedMessage id="ui-circulation.settings.fDDSform.createSchedule" />;
 
     return (
       <PaneMenu>
@@ -132,12 +133,12 @@ class FixedDueDateScheduleForm extends React.Component {
           <IfPermission perm="ui-circulation.settings.loan-rules">
             <Button
               id="clickable-delete-item"
-              title={formatMessage({ id: 'ui-circulation.settings.fDDSform.delete' })}
+              title={<FormattedMessage id="ui-circulation.settings.fDDSform.delete" />}
               buttonStyle="danger"
               onClick={this.beginDelete}
               disabled={confirmDelete}
             >
-              <FormattedMessage id="circulation.settings.staffSlips.delete" />
+              <FormattedMessage id="ui-circulation.settings.staffSlips.delete" />
             </Button>
           </IfPermission>
         }
@@ -156,30 +157,30 @@ class FixedDueDateScheduleForm extends React.Component {
   renderPaneTitle() {
     const {
       initialValues: selectedSet = {},
-      intl: { formatMessage },
     } = this.props;
 
     if (selectedSet.id) {
       return (
         <div>
           <Icon size="small" icon="edit" />
-          <span>{`${formatMessage({ id: 'ui-circulation.settings.fDDS.edit' })}: ${selectedSet.name}`}</span>
+          <span>
+            <FormattedMessage id="ui-circulation.settings.fDDS.editLabel" values={{ name: selectedSet.name }} />
+          </span>
         </div>
       );
     }
-    return formatMessage({ id: 'ui-circulation.settings.fDDSform.newFixDDSchedule' });
+
+    return <FormattedMessage id="ui-circulation.settings.fDDSform.newFixDDSchedule" />;
   }
 
   renderSchedules({ fields, meta: { error, submitFailed } }) {
-    const { formatMessage } = this.props.intl;
-
     return (
       <div>
         <Row>
           <Col xs={11} />
           <Col xs={1}>
             <Button type="button" onClick={() => fields.unshift({})}>
-              {formatMessage({ id: 'ui-circulation.settings.fDDSform.new' })}
+              <FormattedMessage id="ui-circulation.settings.fDDSform.new" />
             </Button>
           </Col>
         </Row>
@@ -188,7 +189,7 @@ class FixedDueDateScheduleForm extends React.Component {
           <div key={index} className={css.scheduleItem}>
             <div className={css.scheduleHeader}>
               <h4>
-                {formatMessage({ id: 'ui-circulation.settings.fDDSform.dateRange' })}
+                <FormattedMessage id="ui-circulation.settings.fDDSform.dateRange" />
                 {' '}
                 {index + 1}
               </h4>
@@ -197,21 +198,21 @@ class FixedDueDateScheduleForm extends React.Component {
               <Row>
                 <Col xs={12} sm={4}>
                   <Field
-                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dateFrom' })}
+                    label={<FormattedMessage id="ui-circulation.settings.fDDSform.dateFrom" />}
                     name={`${schedule}.from`}
                     component={Datepicker}
                   />
                 </Col>
                 <Col xs={12} sm={4}>
                   <Field
-                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dateTo' })}
+                    label={<FormattedMessage id="ui-circulation.settings.fDDSform.dateTo" />}
                     name={`${schedule}.to`}
                     component={Datepicker}
                   />
                 </Col>
                 <Col xs={12} sm={3}>
                   <Field
-                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.dueDate' })}
+                    label={<FormattedMessage id="ui-circulation.settings.fDDSform.dueDate" />}
                     name={`${schedule}.due`}
                     component={Datepicker}
                   />
@@ -221,7 +222,7 @@ class FixedDueDateScheduleForm extends React.Component {
                     <Button
                       buttonStyle="transparent slim"
                       style={{ position: 'absolute', bottom: '0' }}
-                      title={formatMessage({ id: 'ui-circulation.settings.fDDSform.remove' })}
+                      title={<FormattedMessage id="ui-circulation.settings.fDDSform.remove" />}
                       onClick={() => { f.remove(index); }}
                     >
                       <Icon icon="trashBin" />
@@ -240,18 +241,25 @@ class FixedDueDateScheduleForm extends React.Component {
     const {
       handleSubmit,
       initialValues,
-      intl: { formatMessage },
     } = this.props;
 
     const { confirmDelete, sections } = this.state;
     const selectedSet = initialValues || {};
-    const selectedName = selectedSet.name || formatMessage({ id: 'ui-circulation.settings.fDDSform.untitled' });
-    const confirmationMessage = <FormattedMessage id="ui-circulation.settings.fDDSform.deleteMessage" values={{ name: <strong>{selectedName}</strong>, deleted: <strong>deleted</strong> }} />;
+    const selectedName = selectedSet.name || <FormattedMessage id="ui-circulation.settings.fDDSform.untitled" />;
+    const confirmationMessage = <FormattedMessage
+      id="ui-circulation.settings.fDDSform.deleteMessage"
+      values={{ name: <strong>{selectedName}</strong>, deleted: <strong>deleted</strong> }}
+    />;
 
     return (
       <form id="form-fixedDueDateSchedule" onSubmit={handleSubmit(this.saveSet)}>
         <Paneset isRoot>
-          <Pane defaultWidth="100%" firstMenu={this.addFirstMenu()} lastMenu={this.saveLastMenu()} paneTitle={this.renderPaneTitle()}>
+          <Pane
+            defaultWidth="100%"
+            firstMenu={this.addFirstMenu()}
+            lastMenu={this.saveLastMenu()}
+            paneTitle={this.renderPaneTitle()}
+          >
             <div>
               <Row end="xs">
                 <Col xs>
@@ -262,7 +270,7 @@ class FixedDueDateScheduleForm extends React.Component {
                 open={sections.generalInformation}
                 id="generalInformation"
                 onToggle={this.handleSectionToggle}
-                label={formatMessage({ id: 'ui-circulation.settings.fDDSform.about' })}
+                label={<FormattedMessage id="ui-circulation.settings.fDDSform.about" />}
               >
                 <section className={css.accordionSection}>
                   {(initialValues && initialValues.metadata && initialValues.metadata.createdDate) &&
@@ -276,14 +284,14 @@ class FixedDueDateScheduleForm extends React.Component {
                       autoFocus
                       required
                       fullWidth
-                      label={formatMessage({ id: 'ui-circulation.settings.fDDSform.nameRequired' })}
+                      label={<FormattedMessage id="ui-circulation.settings.fDDSform.nameRequired" />}
                     />
                   </div>
                   <Field
                     name="description"
                     component={TextArea}
                     fullWidth
-                    label={formatMessage({ id: 'ui-circulation.settings.fDDSform.description' })}
+                    label={<FormattedMessage id="ui-circulation.settings.fDDSform.description" />}
                   />
                 </section>
               </Accordion>
@@ -291,7 +299,7 @@ class FixedDueDateScheduleForm extends React.Component {
                 open={sections.schedule}
                 id="schedule"
                 onToggle={this.handleSectionToggle}
-                label={formatMessage({ id: 'ui-circulation.settings.fDDSform.schedule' })}
+                label={<FormattedMessage id="ui-circulation.settings.fDDSform.schedule" />}
               >
                 <section className={css.accordionSection}>
                   <FieldArray name="schedules" component={this.renderSchedules} />
@@ -300,11 +308,11 @@ class FixedDueDateScheduleForm extends React.Component {
               <ConfirmationModal
                 id="deletefixedduedateschedule-confirmation"
                 open={confirmDelete}
-                heading={formatMessage({ id: 'ui-circulation.settings.fDDSform.deleteHeader' })}
+                heading={<FormattedMessage id="ui-circulation.settings.fDDSform.deleteHeader" />}
                 message={confirmationMessage}
                 onConfirm={() => { this.confirmDeleteSet(true); }}
                 onCancel={() => { this.confirmDeleteSet(false); }}
-                confirmLabel={formatMessage({ id: 'ui-circulation.settings.fDDSform.delete' })}
+                confirmLabel={<FormattedMessage id="ui-circulation.settings.fDDSform.delete" />}
                 buttonStyle="danger"
               />
             </div>
@@ -319,4 +327,4 @@ export default stripesForm({
   form: 'FixedDueDateScheduleForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(injectIntl(FixedDueDateScheduleForm));
+})(FixedDueDateScheduleForm);

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
-import { intlShape, injectIntl } from 'react-intl';
+
+import {
+  FormattedMessage,
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
+
 import { EntryManager } from '@folio/stripes/smart-components';
 import FixedDueDateScheduleDetail from './FixedDueDateScheduleDetail';
 import FixedDueDateScheduleForm from './FixedDueDateScheduleForm';
@@ -55,12 +62,11 @@ class FixedDueDateScheduleManager extends React.Component {
 
   validate(values) {
     const {
-      intl: { formatMessage },
       resources,
     } = this.props;
 
     const errors = {};
-    const fillInMsg = formatMessage({ id: 'ui-circulation.settings.validate.fillIn' });
+    const fillInMsg = <FormattedMessage id="ui-circulation.settings.validate.fillIn" />;
 
     if (!values.name) {
       errors.name = fillInMsg;
@@ -69,11 +75,11 @@ class FixedDueDateScheduleManager extends React.Component {
     // when searching for a name-match, skip the current record
     const records = (resources.fixedDueDateSchedules || {}).records || [];
     if (values.name && _.find(records, entry => entry.name === values.name && entry.id !== values.id)) {
-      errors.name = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.uniqueName' });
+      errors.name = <FormattedMessage id="ui-circulation.settings.fDDS.validate.uniqueName" />;
     }
 
     if (!values.schedules || !values.schedules.length) {
-      errors.schedules = { _error: formatMessage({ id: 'ui-circulation.settings.fDDS.validate.oneScheduleMin' }) };
+      errors.schedules = { _error: <FormattedMessage id="ui-circulation.settings.fDDS.validate.oneScheduleMin" /> };
     } else {
       const schedulesErrors = [];
 
@@ -87,7 +93,8 @@ class FixedDueDateScheduleManager extends React.Component {
             const condA = (s1.from && s2.to) ? moment(s1.from).isBefore(s2.to) : false;
             const condB = (s1.to && s2.from) ? moment(s1.to).isAfter(s2.from) : false;
             if (condA && condB) {
-              errors.schedules = { _error: formatMessage({ id: 'ui-circulation.settings.fDDS.validate.overlappingDateRange' }, { num1: i + 1, num2: j + 1 }) };
+              const overlappingDateRangeMessage = <FormattedMessage id="ui-circulation.settings.fDDS.validate.overlappingDateRange" values={{ num1: i + 1, num2: j + 1 }} />;
+              errors.schedules = { _error: overlappingDateRangeMessage };
             }
           }
         }
@@ -113,12 +120,12 @@ class FixedDueDateScheduleManager extends React.Component {
           const from = moment(schedule.from);
           const due = moment(schedule.due);
           if (!to.isAfter(from)) {
-            scheduleErrors.to = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.toDate' });
+            scheduleErrors.to = <FormattedMessage id="ui-circulation.settings.fDDS.validate.toDate" />;
             schedulesErrors[i] = scheduleErrors;
           }
 
           if (!due.isSameOrAfter(to)) {
-            scheduleErrors.due = formatMessage({ id: 'ui-circulation.settings.fDDS.validate.onOrAfter' });
+            scheduleErrors.due = <FormattedMessage id="ui-circulation.settings.fDDS.validate.onOrAfter" />;
             schedulesErrors[i] = scheduleErrors;
           }
         }
@@ -133,9 +140,9 @@ class FixedDueDateScheduleManager extends React.Component {
 
   render() {
     const {
-      intl: { formatMessage },
       resources,
       mutator,
+      intl: { formatMessage },
     } = this.props;
 
     return (
@@ -146,7 +153,7 @@ class FixedDueDateScheduleManager extends React.Component {
         resourceKey="fixedDueDateSchedules"
         detailComponent={FixedDueDateScheduleDetail}
         entryFormComponent={FixedDueDateScheduleForm}
-        paneTitle={formatMessage({ id: 'ui-circulation.settings.fDDS.paneTitle' })}
+        paneTitle={<FormattedMessage id="ui-circulation.settings.fDDS.paneTitle" />}
         entryLabel={formatMessage({ id: 'ui-circulation.settings.fDDSform.entryLabel' })}
         nameKey="name"
         permissions={{
@@ -156,7 +163,7 @@ class FixedDueDateScheduleManager extends React.Component {
         }}
         validate={this.validate}
         deleteDisabled={this.deleteDisabled}
-        deleteDisabledMessage={formatMessage({ id: 'ui-circulation.settings.fDDS.deleteDisabled' })}
+        deleteDisabledMessage={<FormattedMessage id="ui-circulation.settings.fDDS.deleteDisabled" />}
         defaultEntry={{ schedules: [{}] }}
       />
     );

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -93,7 +93,10 @@ class FixedDueDateScheduleManager extends React.Component {
             const condA = (s1.from && s2.to) ? moment(s1.from).isBefore(s2.to) : false;
             const condB = (s1.to && s2.from) ? moment(s1.to).isAfter(s2.from) : false;
             if (condA && condB) {
-              const overlappingDateRangeMessage = <FormattedMessage id="ui-circulation.settings.fDDS.validate.overlappingDateRange" values={{ num1: i + 1, num2: j + 1 }} />;
+              const overlappingDateRangeMessage = <FormattedMessage
+                id="ui-circulation.settings.fDDS.validate.overlappingDateRange"
+                values={{ num1: i + 1, num2: j + 1 }}
+              />;
               errors.schedules = { _error: overlappingDateRangeMessage };
             }
           }

--- a/settings/LoanPolicyDetail.js
+++ b/settings/LoanPolicyDetail.js
@@ -200,12 +200,12 @@ class LoanPolicyDetail extends React.Component {
 
   renderRenewals() {
     const { initialValues: policy = {} } = this.props;
-    const unlimited = (_.get(policy, ['renewalsPolicy', 'unlimited'])) ?
-      <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" /> :
-      <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
-    const differentPeriod = (_.get(policy, ['renewalsPolicy', 'differentPeriod'])) ?
-      <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" /> :
-      <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
+    const unlimited = (_.get(policy, ['renewalsPolicy', 'unlimited']))
+      ? <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" />
+      : <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
+    const differentPeriod = (_.get(policy, ['renewalsPolicy', 'differentPeriod']))
+      ? <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" />
+      : <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
     const renewFromId = _.get(policy, ['renewalsPolicy', 'renewFromId'], renewFromIds.SYSTEM_DATE);
     const renewFrom = _.find(renewFromOptions, r => r.value === renewFromId);
     const interval = _.get(policy, ['renewalsPolicy', 'period', 'intervalId']);

--- a/settings/LoanPolicyDetail.js
+++ b/settings/LoanPolicyDetail.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -18,7 +18,6 @@ import {
 class LoanPolicyDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
-    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
     parentResources: PropTypes.shape({
       fixedDueDateSchedules: PropTypes.object,
@@ -66,7 +65,6 @@ class LoanPolicyDetail extends React.Component {
 
   renderLoans() {
     const {
-      intl: { formatMessage },
       initialValues,
       parentResources,
     } = this.props;
@@ -74,9 +72,9 @@ class LoanPolicyDetail extends React.Component {
     const policy = initialValues || {};
     const fixedDueDateSchedules = ((parentResources || {}).fixedDueDateSchedules || {}).records || [];
 
-    let dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
+    let dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDS" />;
     if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.ROLLING) {
-      dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
+      dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDSlimit" />;
     }
 
     let schedule = {};
@@ -105,7 +103,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.loanProfile" />}
               value={_.get(profile, ['label'], '-')}
             />
           </Col>
@@ -116,7 +114,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanPeriod' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.loanPeriod" />}
                   value={`${_.get(policy, ['loansPolicy', 'period', 'duration'], '')} ${periodInterval}`}
                 />
               </Col>
@@ -137,7 +135,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.closedDueDateMgmt" />}
               value={_.get(closedLibraryDueDateManagementItem, ['label'], '-')}
             />
           </Col>
@@ -146,7 +144,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodExisting' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.alternateLoanPeriodExisting" />}
               value={`${_.get(policy, ['loansPolicy', 'existingRequestsPeriod', 'duration'], '')} ${exReqPerInterval}`}
             />
           </Col>
@@ -155,7 +153,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.gracePeriod' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.gracePeriod" />}
               value={`${_.get(policy, ['loansPolicy', 'gracePeriod', 'duration'], '')} ${gracePeriodInterval}`}
             />
           </Col>
@@ -165,8 +163,9 @@ class LoanPolicyDetail extends React.Component {
   }
 
   renderAbout() {
-    const policy = (this.props.initialValues || {});
-    const { formatMessage } = this.props.intl;
+    const {
+      initialValues: policy = {},
+    } = this.props;
 
     return (
       <div>
@@ -181,7 +180,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyName" />}
               value={_.get(policy, ['name'], '')}
             />
           </Col>
@@ -190,7 +189,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyDescription" />}
               value={_.get(policy, ['description'], '-')}
             />
           </Col>
@@ -200,10 +199,13 @@ class LoanPolicyDetail extends React.Component {
   }
 
   renderRenewals() {
-    const { formatMessage } = this.props.intl;
-    const policy = this.props.initialValues || {};
-    const unlimited = (_.get(policy, ['renewalsPolicy', 'unlimited'])) ? 'Yes' : 'No';
-    const differentPeriod = (_.get(policy, ['renewalsPolicy', 'differentPeriod'])) ? 'Yes' : 'No';
+    const { initialValues: policy = {} } = this.props;
+    const unlimited = (_.get(policy, ['renewalsPolicy', 'unlimited'])) ?
+      <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" /> :
+      <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
+    const differentPeriod = (_.get(policy, ['renewalsPolicy', 'differentPeriod'])) ?
+      <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" /> :
+      <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
     const renewFromId = _.get(policy, ['renewalsPolicy', 'renewFromId'], renewFromIds.SYSTEM_DATE);
     const renewFrom = _.find(renewFromOptions, r => r.value === renewFromId);
     const interval = _.get(policy, ['renewalsPolicy', 'period', 'intervalId']);
@@ -220,7 +222,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.unlimitedRenewals" />}
               value={unlimited}
             />
           </Col>
@@ -231,7 +233,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.numRenewalsAllowed' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.numRenewalsAllowed" />}
                   value={_.get(policy, ['renewalsPolicy', 'numberAllowed'], 0)}
                 />
               </Col>
@@ -242,7 +244,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewFrom" />}
               value={_.get(renewFrom, ['label'], '-')}
             />
           </Col>
@@ -251,7 +253,7 @@ class LoanPolicyDetail extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewalPeriodDifferent" />}
               value={differentPeriod}
             />
           </Col>
@@ -262,7 +264,7 @@ class LoanPolicyDetail extends React.Component {
             <Row>
               <Col xs={12}>
                 <KeyValue
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals" />}
                   value={`${_.get(policy, ['renewalsPolicy', 'period', 'duration'])} ${interval}`}
                 />
               </Col>
@@ -274,8 +276,7 @@ class LoanPolicyDetail extends React.Component {
   }
 
   render() {
-    const policy = this.props.initialValues || {};
-    const { formatMessage } = this.props.intl;
+    const { initialValues: policy = {} } = this.props;
     const { sections } = this.state;
 
     return (
@@ -289,7 +290,7 @@ class LoanPolicyDetail extends React.Component {
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
+          label={<FormattedMessage id="ui-circulation.settings.loanPolicy.generalInformation" />}
         >
           {policy.metadata && policy.metadata.createdDate &&
             <Row>
@@ -311,4 +312,4 @@ class LoanPolicyDetail extends React.Component {
   }
 }
 
-export default injectIntl(LoanPolicyDetail);
+export default LoanPolicyDetail;

--- a/settings/LoanPolicyForm.js
+++ b/settings/LoanPolicyForm.js
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, getFormValues } from 'redux-form';
 import _ from 'lodash';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+
+import {
+  FormattedMessage,
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
 import { stripesShape } from '@folio/stripes/core';
 import {
   Accordion,
@@ -28,12 +34,12 @@ import {
 
 class LoanPolicyForm extends React.Component {
   static propTypes = {
-    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
     parentResources: PropTypes.shape({
       fixedDueDateSchedules: PropTypes.object,
     }).isRequired,
     change: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -131,28 +137,39 @@ class LoanPolicyForm extends React.Component {
     });
   }
 
+  getOptions(options) {
+    return options.map(({ value, label }) => (
+      <FormattedMessage id={label}>
+        {(message) => <option value={value}>{message}</option>}
+      </FormattedMessage>
+    ));
+  }
+
   render() {
-    const { formatMessage } = this.props.intl;
     const policy = this.getCurrentValues();
     const { sections } = this.state;
+    const {
+      intl: { formatMessage },
+      parentResources,
+    } = this.props;
 
     // Conditional field labels
-    let dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDS' });
-    let altRenewalScheduleLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSforRenewals' });
+    let dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDS" />;
+    let altRenewalScheduleLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSforRenewals" />;
+
     if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.ROLLING) {
-      dueDateScheduleFieldLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.fDDSlimit' });
-      altRenewalScheduleLabel = formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSDueDateLimit' });
+      dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDSlimit" />;
+      altRenewalScheduleLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSDueDateLimit" />;
     } else if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.FIXED) {
-      dueDateScheduleFieldLabel += ' *';
+      dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDSRequired" />;
     }
 
-    const schedules = _.sortBy((this.props.parentResources.fixedDueDateSchedules || {}).records || [], ['name'])
+    const schedules = _.sortBy((parentResources.fixedDueDateSchedules || {}).records || [], ['name'])
       .map(schedule => (
-        {
-          id: schedule.id,
-          value: schedule.id,
-          label: schedule.name,
-        }));
+        <FormattedMessage id={schedule.name}>
+          {(message) => <option value={schedule.id}>{message}</option>}
+        </FormattedMessage>
+      ));
 
     return (
       <div>
@@ -165,7 +182,7 @@ class LoanPolicyForm extends React.Component {
           open={sections.generalSection}
           id="generalSection"
           onToggle={this.handleSectionToggle}
-          label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
+          label={<FormattedMessage id="ui-circulation.settings.loanPolicy.generalInformation" />}
         >
           {policy.metadata && policy.metadata.createdDate &&
             <Row>
@@ -178,7 +195,7 @@ class LoanPolicyForm extends React.Component {
           {/* Primary information: policy name and description, plus delete button */}
           <h2 style={{ marginTop: '0' }}>About</h2>
           <Field
-            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyName' })}
+            label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyName" />}
             autoFocus
             name="name"
             id="input_policy_name"
@@ -188,7 +205,7 @@ class LoanPolicyForm extends React.Component {
             validate={this.validateField}
           />
           <Field
-            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.policyDescription' })}
+            label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyDescription" />}
             name="description"
             component={TextArea}
             fullWidth
@@ -202,7 +219,7 @@ class LoanPolicyForm extends React.Component {
           </h2>
           {/* loanable: boolean determining visibility of all subsequent elements */}
           <Field
-            label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanable' })}
+            label={<FormattedMessage id="ui-circulation.settings.loanPolicy.loanable" />}
             id="loanable"
             name="loanable"
             component={Checkbox}
@@ -211,7 +228,7 @@ class LoanPolicyForm extends React.Component {
           {/* loan profile. Value affects visibility of several subsequent elements */}
           { policy.loanable &&
             <Field
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.loanProfile' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.loanProfile" />}
               name="loansPolicy.profileId"
               id="input_loan_profile"
               component={Select}
@@ -236,9 +253,10 @@ class LoanPolicyForm extends React.Component {
                     id="select_policy_period"
                     component={Select}
                     placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    dataOptions={intervalPeriods}
                     validate={this.validateField}
-                  />
+                  >
+                    {this.getOptions(intervalPeriods)}
+                  </Field>
                 </Col>
               </Row>
             </div>
@@ -252,18 +270,23 @@ class LoanPolicyForm extends React.Component {
               id="input_loansPolicy_fixedDueDateSchedule"
               component={Select}
               normalize={value => (value === '' ? null : value)}
-              dataOptions={[{ label: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
-            />
+            >
+              <FormattedMessage id="ui-circulation.settings.loanPolicy.selectSchedule">
+                {(message) => <option value="" disabled>{message}</option>}
+              </FormattedMessage>
+              {schedules}
+            </Field>
           }
           {/* closed library due date management - Select */}
           { policy.loanable &&
             <Field
-              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.closedDueDateMgmt' })}
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.closedDueDateMgmt" />}
               name="loansPolicy.closedLibraryDueDateManagementId"
               component={Select}
-              dataOptions={this.getDueDateManagementOptions()}
               validate={this.validateField}
-            />
+            >
+              {this.getOptions(this.getDueDateManagementOptions())}
+            </Field>
           }
           {/* alternate loan period */}
           { policy.loanable &&
@@ -286,9 +309,10 @@ class LoanPolicyForm extends React.Component {
                     name="loansPolicy.existingRequestsPeriod.intervalId"
                     component={Select}
                     placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    dataOptions={intervalPeriods.slice(0, 3)}
                     validate={this.validateField}
-                  />
+                  >
+                    {this.getOptions(intervalPeriods.slice(0, 3))}
+                  </Field>
                 </Col>
               </Row>
             </div>
@@ -314,9 +338,10 @@ class LoanPolicyForm extends React.Component {
                     name="loansPolicy.gracePeriod.intervalId"
                     component={Select}
                     placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    dataOptions={intervalPeriods}
                     validate={this.validateField}
-                  />
+                  >
+                    {this.getOptions(intervalPeriods)}
+                  </Field>
                 </Col>
               </Row>
             </div>
@@ -336,7 +361,7 @@ class LoanPolicyForm extends React.Component {
                 not handled properly -- see https://github.com/erikras/redux-form/issues/1993)
               */}
               <Field
-                label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewable' })}
+                label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewable" />}
                 name="renewable"
                 component={Checkbox}
                 id="renewable"
@@ -346,7 +371,7 @@ class LoanPolicyForm extends React.Component {
               {/* unlimited renewals (bool) */}
               { policy.renewable &&
                 <Field
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.unlimitedRenewals" />}
                   name="renewalsPolicy.unlimited"
                   id="renewalsPolicy.unlimited"
                   component={Checkbox}
@@ -378,7 +403,7 @@ class LoanPolicyForm extends React.Component {
               { policy.renewable &&
                 policy.loansPolicy.profileId === loanProfileMap.ROLLING &&
                 <Field
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewFrom" />}
                   name="renewalsPolicy.renewFromId"
                   id="select_renew_from"
                   component={Select}
@@ -389,7 +414,7 @@ class LoanPolicyForm extends React.Component {
               {/* different renewal period (bool) */}
               { policy.renewable &&
                 <Field
-                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewalPeriodDifferent" />}
                   name="renewalsPolicy.differentPeriod"
                   id="renewalsPolicy.differentPeriod"
                   component={Checkbox}
@@ -420,9 +445,10 @@ class LoanPolicyForm extends React.Component {
                         name="renewalsPolicy.period.intervalId"
                         component={Select}
                         placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                        dataOptions={intervalPeriods}
                         validate={this.validateField}
-                      />
+                      >
+                        {this.getOptions(intervalPeriods)}
+                      </Field>
                     </Col>
                   </Row>
                 </div>
@@ -437,8 +463,12 @@ class LoanPolicyForm extends React.Component {
                   name="renewalsPolicy.alternateFixedDueDateScheduleId"
                   component={Select}
                   normalize={value => (value === '' ? null : value)}
-                  dataOptions={[{ label: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' }), value: '' }, ...schedules]}
-                />
+                >
+                  <FormattedMessage id="ui-circulation.settings.loanPolicy.selectSchedule">
+                    {(message) => <option value="" disabled>{message}</option>}
+                  </FormattedMessage>
+                  {schedules}
+                </Field>
               }
             </fieldset>
           }

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { intlShape, injectIntl } from 'react-intl';
+
+import {
+  FormattedMessage,
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
 import { EntryManager } from '@folio/stripes/smart-components';
 import LoanPolicyDetail from './LoanPolicyDetail';
 import LoanPolicyForm from './LoanPolicyForm';
@@ -59,26 +65,25 @@ class LoanPolicySettings extends React.Component {
 
   validate(values) {
     const errors = {};
-    const { formatMessage } = this.props.intl;
 
     if (!values.name) {
-      errors.name = formatMessage({ id: 'ui-circulation.settings.validate.fillIn' });
+      errors.name = <FormattedMessage id="ui-circulation.settings.validate.fillIn" />;
     }
 
     const loansPolicy = values.loansPolicy || {};
 
     if (loansPolicy.profileId === loanProfileMap.FIXED
       && !loansPolicy.fixedDueDateSchedule) {
-      errors.loansPolicy = { fixedDueDateSchedule: formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectFDDS' }) };
+      errors.loansPolicy = { fixedDueDateSchedule: <FormattedMessage id="ui-circulation.settings.loanPolicy.selectFDDS" /> };
     }
     return errors;
   }
 
   render() {
     const {
-      intl: { formatMessage },
       resources,
       mutator,
+      intl: { formatMessage },
     } = this.props;
 
     return (
@@ -90,7 +95,7 @@ class LoanPolicySettings extends React.Component {
         resourceKey="loanPolicies"
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}
-        paneTitle={formatMessage({ id: 'ui-circulation.settings.loanPolicy.paneTitle' })}
+        paneTitle={<FormattedMessage id="ui-circulation.settings.loanPolicy.paneTitle" />}
         entryLabel={formatMessage({ id: 'ui-circulation.settings.loanPolicy.entryLabel' })}
         nameKey="name"
         defaultEntry={defaultPolicy}

--- a/settings/LoanRules.js
+++ b/settings/LoanRules.js
@@ -1,7 +1,7 @@
 import { kebabCase } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Callout, Paneset, Pane } from '@folio/stripes/components';
 import fetch from 'isomorphic-fetch';
 
@@ -58,14 +58,8 @@ class LoanRules extends React.Component {
   });
 
   static propTypes = {
-    intl: intlShape.isRequired,
     resources: PropTypes.object.isRequired,
     stripes: PropTypes.object.isRequired,
-    calloutMessage: PropTypes.string,
-  };
-
-  static defaultProps = {
-    calloutMessage: 'Rules were successfully updated.',
   };
 
   constructor(props) {
@@ -154,7 +148,10 @@ class LoanRules extends React.Component {
   // TODO: refactor to use mutator after PUT is changed on the server or stripes-connect supports
   // custom PUT requests without the id attached to the end of the URL.
   saveLoanRules(rules) {
-    const { stripes } = this.props;
+    const {
+      stripes,
+    } = this.props;
+
     const headers = Object.assign({}, {
       'X-Okapi-Tenant': stripes.okapi.tenant,
       'X-Okapi-Token': stripes.store.getState().okapi.token,
@@ -173,7 +170,7 @@ class LoanRules extends React.Component {
       if (resp.status >= 400) {
         resp.json().then(json => this.setState({ errors: [json] }));
       } else if (this.callout) {
-        this.callout.sendCallout({ message: this.props.calloutMessage });
+        this.callout.sendCallout({ message: <FormattedMessage id="ui-circulation.settings.loanRules.rulesUpdated" /> });
       }
     });
   }
@@ -181,7 +178,6 @@ class LoanRules extends React.Component {
   render() {
     const {
       resources: { loanTypes },
-      intl: { formatMessage },
     } = this.props;
 
     if (!loanTypes) {
@@ -194,7 +190,7 @@ class LoanRules extends React.Component {
     return (
       <Paneset>
         <Pane
-          paneTitle={formatMessage({ id: 'ui-circulation.settings.loanRules.paneTitle' })}
+          paneTitle={<FormattedMessage id="ui-circulation.settings.loanRules.paneTitle" />}
           defaultWidth="fill"
         >
           <LoanRulesForm
@@ -209,4 +205,4 @@ class LoanRules extends React.Component {
   }
 }
 
-export default injectIntl(LoanRules);
+export default LoanRules;

--- a/settings/RequestCancellationReasons.js
+++ b/settings/RequestCancellationReasons.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape, injectIntl } from 'react-intl';
+
+import {
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 class RequestCancellationReasons extends React.Component {
@@ -18,7 +23,7 @@ class RequestCancellationReasons extends React.Component {
   }
 
   render() {
-    const { formatMessage } = this.props.intl;
+    const { intl: { formatMessage } } = this.props;
 
     return (
       <this.connectedControlledVocab

--- a/settings/StaffSlips/PreviewModal.js
+++ b/settings/StaffSlips/PreviewModal.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import Barcode from 'react-barcode';
 import HtmlToReact, { Parser } from 'html-to-react';
 import ReactToPrint from 'react-to-print';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
 import formats from './formats';
 import { template } from './util';
 
 class PreviewModal extends React.Component {
   static propTypes = {
-    intl: intlShape.isRequired,
     onClose: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
     previewTemplate: PropTypes.string,
@@ -38,16 +37,20 @@ class PreviewModal extends React.Component {
     this.parser = new Parser();
   }
 
+  getButtonPrint = () => {
+    return (
+      <Button buttonStyle="primary">
+        <FormattedMessage id="ui-circulation.settings.staffSlips.print" />
+      </Button>
+    );
+  }
+
   render() {
     const {
       open,
       onClose,
       previewTemplate,
-      intl: { formatMessage },
     } = this.props;
-
-    const closeLabel = <FormattedMessage id="ui-circulation.settings.staffSlips.close" />;
-    const heading = formatMessage({ id: 'ui-circulation.settings.staffSlips.previewLabel' });
 
     const tmpl = template(previewTemplate || '');
     const componentStr = tmpl(this.previewFormat);
@@ -56,7 +59,7 @@ class PreviewModal extends React.Component {
     return (
       <Modal
         open={open}
-        label={heading}
+        label={<FormattedMessage id="ui-circulation.settings.staffSlips.previewLabel" />}
         id="preview-modal"
         scope="module"
         size="medium"
@@ -68,8 +71,16 @@ class PreviewModal extends React.Component {
         <br />
         <Row>
           <Col xs>
-            <ReactToPrint trigger={() => <Button buttonStyle="primary">Print</Button>} content={() => this.editorRef.current} />
-            <Button onClick={onClose} id="clickable-close-preview">{closeLabel}</Button>
+            <ReactToPrint
+              trigger={this.getButtonPrint}
+              content={() => this.editorRef.current}
+            />
+            <Button
+              onClick={onClose}
+              id="clickable-close-preview"
+            >
+              <FormattedMessage id="ui-circulation.settings.staffSlips.close" />
+            </Button>
           </Col>
         </Row>
       </Modal>
@@ -77,4 +88,4 @@ class PreviewModal extends React.Component {
   }
 }
 
-export default injectIntl(PreviewModal);
+export default PreviewModal;

--- a/settings/StaffSlips/StaffSlipDetail.js
+++ b/settings/StaffSlips/StaffSlipDetail.js
@@ -48,8 +48,9 @@ class StaffSlipDetail extends React.Component {
     const { openDialog } = this.state;
     const { initialValues: staffSlip } = this.props;
     const contentComponent = this.parser.parseWithInstructions(staffSlip.template, () => true, this.rules);
-    const isActiveValue = staffSlip.active ? <FormattedMessage id="ui-circulation.settings.staffSlips.yes" /> :
-    <FormattedMessage id="ui-circulation.settings.staffSlips.no" />;
+    const isActiveValue = staffSlip.active
+      ? <FormattedMessage id="ui-circulation.settings.staffSlips.yes" />
+      : <FormattedMessage id="ui-circulation.settings.staffSlips.no" />;
 
     return (
       <div>

--- a/settings/StaffSlips/StaffSlipDetail.js
+++ b/settings/StaffSlips/StaffSlipDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Button, Col, KeyValue, Row } from '@folio/stripes/components';
 import HtmlToReact, { Parser } from 'html-to-react';
 
@@ -15,7 +15,6 @@ class StaffSlipDetail extends React.Component {
       connect: PropTypes.func.isRequired,
     }).isRequired,
     initialValues: PropTypes.object,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -37,12 +36,6 @@ class StaffSlipDetail extends React.Component {
     this.parser = new Parser();
   }
 
-  translate(id) {
-    return this.props.intl.formatMessage({
-      id: `ui-circulation.settings.staffSlips.${id}`
-    });
-  }
-
   openPreviewDialog() {
     this.setState({ openDialog: true });
   }
@@ -55,32 +48,45 @@ class StaffSlipDetail extends React.Component {
     const { openDialog } = this.state;
     const { initialValues: staffSlip } = this.props;
     const contentComponent = this.parser.parseWithInstructions(staffSlip.template, () => true, this.rules);
+    const isActiveValue = staffSlip.active ? <FormattedMessage id="ui-circulation.settings.staffSlips.yes" /> :
+    <FormattedMessage id="ui-circulation.settings.staffSlips.no" />;
 
     return (
       <div>
         <Row>
           <Col xs={8}>
-            <KeyValue label={this.translate('name')} value={staffSlip.name} />
+            <KeyValue
+              label={<FormattedMessage id="ui-circulation.settings.staffSlips.name" />}
+              value={staffSlip.name}
+            />
           </Col>
         </Row>
         <Row>
           <Col xs={8}>
-            <KeyValue label={this.translate('active')} value={staffSlip.active ? this.translate('yes') : this.translate('no')} />
+            <KeyValue
+              label={<FormattedMessage id="ui-circulation.settings.staffSlips.active" />}
+              value={isActiveValue}
+            />
           </Col>
         </Row>
         <Row>
           <Col xs={8}>
-            <KeyValue label={this.translate('description')} value={staffSlip.description} />
+            <KeyValue
+              label={<FormattedMessage id="ui-circulation.settings.staffSlips.description" />}
+              value={staffSlip.description}
+            />
           </Col>
         </Row>
         <Row bottom="xs">
           <Col xs={9}>
-            {this.translate('display')}
+            <FormattedMessage id="ui-circulation.settings.staffSlips.display" />
           </Col>
           <Col xs={3}>
             <Row className={css.preview}>
               <Col>
-                <Button bottomMargin0 onClick={this.openPreviewDialog}>Preview</Button>
+                <Button bottomMargin0 onClick={this.openPreviewDialog}>
+                  <FormattedMessage id="ui-circulation.settings.staffSlips.preview" />
+                </Button>
               </Col>
             </Row>
           </Col>
@@ -105,4 +111,4 @@ class StaffSlipDetail extends React.Component {
   }
 }
 
-export default injectIntl(StaffSlipDetail);
+export default StaffSlipDetail;

--- a/settings/StaffSlips/StaffSlipEditor.js
+++ b/settings/StaffSlips/StaffSlipEditor.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Button, Col, Row } from '@folio/stripes/components';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -18,7 +18,6 @@ class StaffSlipEditor extends Component {
     label: PropTypes.string,
     slipType: PropTypes.string,
     tokens: PropTypes.arrayOf(PropTypes.string),
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -90,12 +89,6 @@ class StaffSlipEditor extends Component {
     editor.setSelection(cursorPosition + tag.length);
   }
 
-  translate(id) {
-    return this.props.intl.formatMessage({
-      id: `ui-circulation.settings.staffSlips.${id}`
-    });
-  }
-
   render() {
     const { template, openDialog } = this.state;
     const { label, input: { value } } = this.props;
@@ -106,12 +99,16 @@ class StaffSlipEditor extends Component {
           <Col xs={12}>
             <Row bottom="xs">
               <Col xs={9}>
-                <label htmlFor="editor" className={css.label}>{label}</label>
+                <label htmlFor="editor" className={css.label}>
+                  {label}
+                </label>
               </Col>
               <Col xs={3}>
                 <Row className={css.preview}>
                   <Col>
-                    <Button bottomMargin0 onClick={this.openPreviewDialog}>Preview</Button>
+                    <Button bottomMargin0 onClick={this.openPreviewDialog}>
+                      <FormattedMessage id="ui-circulation.settings.staffSlips.preview" />
+                    </Button>
                   </Col>
                 </Row>
               </Col>
@@ -142,4 +139,4 @@ class StaffSlipEditor extends Component {
   }
 }
 
-export default injectIntl(StaffSlipEditor);
+export default StaffSlipEditor;

--- a/settings/StaffSlips/StaffSlipForm.js
+++ b/settings/StaffSlips/StaffSlipForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Button,
@@ -33,7 +33,6 @@ class StaffSlipForm extends React.Component {
     onCancel: PropTypes.func,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -45,12 +44,6 @@ class StaffSlipForm extends React.Component {
     this.props.onSave(data);
   }
 
-  translate(id) {
-    return this.props.intl.formatMessage({
-      id: `ui-circulation.settings.staffSlips.${id}`
-    });
-  }
-
   addFirstMenu() {
     return (
       <PaneMenu>
@@ -58,8 +51,8 @@ class StaffSlipForm extends React.Component {
           id="clickable-close-staff-slip"
           onClick={this.props.onCancel}
           icon="closeX"
-          title="close"
-          aria-label={this.translate('closeStaffSlipDialog')}
+          title={<FormattedMessage id="ui-circulation.settings.staffSlips.closeStaffSlipDialog" />}
+          aria-label={<FormattedMessage id="ui-circulation.settings.staffSlips.closeStaffSlipDialog" />}
         />
       </PaneMenu>
     );
@@ -68,14 +61,15 @@ class StaffSlipForm extends React.Component {
   saveLastMenu() {
     const { pristine, submitting, initialValues } = this.props;
     const edit = initialValues && initialValues.id;
-    const saveLabel = edit ? this.translate('saveAndClose') : this.translate('createStaffSlip');
+    const saveLabel = edit ? <FormattedMessage id="ui-circulation.settings.staffSlips.saveAndClose" /> :
+    <FormattedMessage id="ui-circulation.settings.staffSlips.createStaffSlip" />;
 
     return (
       <PaneMenu>
         <Button
           id="clickable-save-staff-slip"
           type="submit"
-          title={this.translate('saveAndClose')}
+          title={<FormattedMessage id="ui-circulation.settings.staffSlips.saveAndClose" />}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0
           disabled={(pristine || submitting)}
@@ -87,50 +81,73 @@ class StaffSlipForm extends React.Component {
   }
 
   renderPaneTitle() {
-    const { initialValues } = this.props;
-    const staffSlip = initialValues || {};
+    const {
+      initialValues: staffSlip = {},
+    } = this.props;
 
     if (staffSlip.id) {
       return (
         <div>
           <Icon size="small" icon="edit" />
-          <span>{`${this.translate('edit')}: ${this.translate('label')} - ${staffSlip.name}`}</span>
+          <span>
+            <FormattedMessage id="ui-circulation.settings.staffSlips.editLabel" values={{ name: staffSlip.name }} />
+          </span>
         </div>
       );
     }
-
-    return this.translate('new');
+    return <FormattedMessage id="ui-circulation.settings.staffSlips.new" />;
   }
 
   render() {
     const { stripes, handleSubmit, initialValues } = this.props;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
-    const slipType = (initialValues || {}).name || 'Hold';
+    const slipType = (initialValues || {}).name || <FormattedMessage id="ui-circulation.settings.staffSlips.hold" />;
 
     return (
       <form id="form-staff-slip" onSubmit={handleSubmit(this.save)}>
         <Paneset isRoot>
-          <Pane defaultWidth="100%" firstMenu={this.addFirstMenu()} lastMenu={this.saveLastMenu()} paneTitle={this.renderPaneTitle()}>
+          <Pane
+            defaultWidth="100%"
+            firstMenu={this.addFirstMenu()}
+            lastMenu={this.saveLastMenu()}
+            paneTitle={this.renderPaneTitle()}
+          >
             <Row>
               <Col xs={8}>
-                <KeyValue label={this.translate('name')} value={(initialValues || {}).name} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={8}>
-                <Field label={`${this.translate('active')}`} name="active" id="input-staff-slip-active" component={Checkbox} disabled={disabled} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={8}>
-                <Field label={this.translate('description')} name="description" id="input-staff-slip-description" component={TextArea} fullWidth disabled={disabled} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-circulation.settings.staffSlips.name" />}
+                  value={(initialValues || {}).name}
+                />
               </Col>
             </Row>
             <Row>
               <Col xs={8}>
                 <Field
-                  label={this.translate('display')}
+                  label={<FormattedMessage id="ui-circulation.settings.staffSlips.active" />}
+                  name="active"
+                  id="input-staff-slip-active"
+                  component={Checkbox}
+                  disabled={disabled}
+                />
+              </Col>
+            </Row>
+            <br />
+            <Row>
+              <Col xs={8}>
+                <Field
+                  label={<FormattedMessage id="ui-circulation.settings.staffSlips.description" />}
+                  name="description"
+                  id="input-staff-slip-description"
+                  component={TextArea}
+                  fullWidth
+                  disabled={disabled}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={8}>
+                <Field
+                  label={<FormattedMessage id="ui-circulation.settings.staffSlips.display" />}
                   component={StaffSlipEditor}
                   tokens={Object.keys(formats[slipType])}
                   name="template"
@@ -149,4 +166,4 @@ export default stripesForm({
   form: 'staffSlipForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(injectIntl(StaffSlipForm));
+})(StaffSlipForm);

--- a/settings/StaffSlips/StaffSlipForm.js
+++ b/settings/StaffSlips/StaffSlipForm.js
@@ -61,8 +61,9 @@ class StaffSlipForm extends React.Component {
   saveLastMenu() {
     const { pristine, submitting, initialValues } = this.props;
     const edit = initialValues && initialValues.id;
-    const saveLabel = edit ? <FormattedMessage id="ui-circulation.settings.staffSlips.saveAndClose" /> :
-    <FormattedMessage id="ui-circulation.settings.staffSlips.createStaffSlip" />;
+    const saveLabel = edit
+      ? <FormattedMessage id="ui-circulation.settings.staffSlips.saveAndClose" />
+      : <FormattedMessage id="ui-circulation.settings.staffSlips.createStaffSlip" />;
 
     return (
       <PaneMenu>
@@ -90,7 +91,10 @@ class StaffSlipForm extends React.Component {
         <div>
           <Icon size="small" icon="edit" />
           <span>
-            <FormattedMessage id="ui-circulation.settings.staffSlips.editLabel" values={{ name: staffSlip.name }} />
+            <FormattedMessage
+              id="ui-circulation.settings.staffSlips.editLabel"
+              values={{ name: staffSlip.name }}
+            />
           </span>
         </div>
       );

--- a/settings/StaffSlips/StaffSlipManager.js
+++ b/settings/StaffSlips/StaffSlipManager.js
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { EntryManager } from '@folio/stripes/smart-components';
 
 import StaffSlipDetail from './StaffSlipDetail';
@@ -22,7 +22,6 @@ class StaffSlipManager extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    intl: intlShape.isRequired,
   };
 
   static manifest = Object.freeze({
@@ -55,17 +54,11 @@ class StaffSlipManager extends React.Component {
     });
   }
 
-  translate(id) {
-    this.props.intl.formatMessage({
-      id: `ui-circulation.settings.staffSlips.${id}`
-    });
-  }
-
   validate(values) {
     const errors = {};
 
     if (!values.name) {
-      errors.name = this.translate('validation.required');
+      errors.name = <FormattedMessage id="ui-circulation.settings.staffSlips.validation.required" />;
     }
 
     return errors;
@@ -99,4 +92,4 @@ class StaffSlipManager extends React.Component {
   }
 }
 
-export default injectIntl(StaffSlipManager);
+export default StaffSlipManager;

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { intlShape, injectIntl } from 'react-intl';
+
+import {
+  FormattedMessage,
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
 import { Settings } from '@folio/stripes/smart-components';
 
 import LoanPolicySettings from './LoanPolicySettings';
@@ -12,33 +18,37 @@ import StaffSlips from './StaffSlips';
 class Circulation extends React.Component {
   static propTypes = {
     intl: intlShape.isRequired,
-  }
+  };
 
   constructor(props) {
     super(props);
-    const { formatMessage } = props.intl;
+
+    const {
+      intl: { formatMessage },
+    } = this.props;
+
     this.pages = [
       {
         route: 'loan-policies',
-        label: formatMessage({ id: 'ui-circulation.settings.index.loanPolicies' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.loanPolicies" />,
         component: LoanPolicySettings,
         perm: 'ui-circulation.settings.loan-policies',
       },
       {
         route: 'loan-rules',
-        label: formatMessage({ id: 'ui-circulation.settings.index.loanRules' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.loanRules" />,
         component: LoanRules,
         perm: 'ui-circulation.settings.loan-rules',
       },
       {
         route: 'fixed-due-date-schedules',
-        label: formatMessage({ id: 'ui-circulation.settings.index.fdds' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.fdds" />,
         component: FixedDueDateScheduleManager,
         perm: 'ui-circulation.settings.loan-rules',
       },
       {
         route: 'checkout',
-        label: formatMessage({ id: 'ui-circulation.settings.index.otherSettings' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.otherSettings" />,
         component: CheckoutSettings,
       },
       {
@@ -48,7 +58,7 @@ class Circulation extends React.Component {
       },
       {
         route: 'cancellation-reasons',
-        label: formatMessage({ id: 'ui-circulation.settings.index.requestCancellationReasons' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.requestCancellationReasons" />,
         component: RequestCancellationReasons,
         perm: 'ui-circulation.settings.cancellation-reasons',
       },
@@ -60,7 +70,7 @@ class Circulation extends React.Component {
       <Settings
         {...this.props}
         pages={this.pages}
-        paneTitle={this.props.intl.formatMessage({ id: 'ui-circulation.settings.index.paneTitle' })}
+        paneTitle={<FormattedMessage id="ui-circulation.settings.index.paneTitle" />}
       />
     );
   }

--- a/settings/lib/RuleEditor/LoanRulesEditor.js
+++ b/settings/lib/RuleEditor/LoanRulesEditor.js
@@ -6,6 +6,8 @@ import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import Codemirror from 'codemirror';
 import CodeMirror from 'react-codemirror2';
+import { intlShape, injectIntl } from 'react-intl';
+
 import initLoanRulesCMM from './LoanRulesCMM';
 import 'codemirror/addon/fold/foldcode';
 import initFoldRules from './fold-rules';
@@ -62,6 +64,7 @@ const propTypes = {
       })),
   showAssist: PropTypes.bool,
   filter: PropTypes.string,
+  intl: intlShape.isRequired,
 };
 
 const defaultProps = {
@@ -266,7 +269,7 @@ class LoanRulesEditor extends React.Component {
   componentDidMount() {
     this.cm = this.cmComponent.editor;
     //set up hinting
-    loanRulesHint(Codemirror);
+    loanRulesHint(Codemirror, this.props);
 
     // prettymuch always show the auto-complete.
     this.cm.on('cursorActivity', this.showHelp);
@@ -421,4 +424,4 @@ class LoanRulesEditor extends React.Component {
 LoanRulesEditor.propTypes = propTypes;
 LoanRulesEditor.defaultProps = defaultProps;
 
-export default LoanRulesEditor;
+export default injectIntl(LoanRulesEditor);

--- a/settings/lib/RuleEditor/LoanRulesForm.js
+++ b/settings/lib/RuleEditor/LoanRulesForm.js
@@ -6,11 +6,22 @@ import {
   TextField
 } from '@folio/stripes/components';
 import { Field } from 'redux-form';
+
+import {
+  FormattedMessage,
+  intlShape,
+  injectIntl,
+} from 'react-intl';
+
 import stripesForm from '@folio/stripes/form';
 
 import LoanRulesField from './LoanRulesField';
 
 class LoanRulesForm extends React.Component {
+  static propTypes = {
+    intl: intlShape.isRequired,
+  };
+
   constructor(props) {
     super(props);
 
@@ -33,22 +44,35 @@ class LoanRulesForm extends React.Component {
       handleSubmit,
       submitting,
       editorProps,
+      intl: { formatMessage },
     } = this.props;
 
     const containerStyle = {
       height: '100%',
       display: 'flex',
-      flexDirection:'column',
+      flexDirection: 'column',
     };
 
     return (
       <form id="form-loan-rules" style={containerStyle} onSubmit={handleSubmit}>
         <Row end="xs">
           <Col xs={3}>
-            <TextField value={this.state.ruleFilter} onChange={this.filterRules} validationEnabled={false} placeholder="filter rules" />
+            <TextField
+              value={this.state.ruleFilter}
+              onChange={this.filterRules}
+              validationEnabled={false}
+              placeholder={formatMessage({ id: 'ui-circulation.settings.checkout.filterRules' })}
+            />
           </Col>
           <Col xs={3}>
-            <Button fullWidth id="clickable-save-loan-rules" type="submit" disabled={pristine || submitting}>Save</Button>
+            <Button
+              fullWidth
+              id="clickable-save-loan-rules"
+              type="submit"
+              disabled={pristine || submitting}
+            >
+              <FormattedMessage id="ui-circulation.settings.checkout.save" />
+            </Button>
           </Col>
         </Row>
         <Row>
@@ -65,4 +89,4 @@ export default stripesForm({
   form: 'loanRulesForm',
   navigationCheck: true,
   enableReinitialize: true,
-})(LoanRulesForm);
+})(injectIntl(LoanRulesForm));

--- a/settings/lib/RuleEditor/loan-rules-show-hint.js
+++ b/settings/lib/RuleEditor/loan-rules-show-hint.js
@@ -406,8 +406,8 @@
   });
 
   CodeMirror.registerHelper('hint', 'fromList', (cm, options) => {
-    const cur = cm.getCursor(); const
-      token = cm.getTokenAt(cur);
+    const cur = cm.getCursor(); 
+    const token = cm.getTokenAt(cur);
     const to = CodeMirror.Pos(cur.line, token.end);
     if (token.string && /\w/.test(token.string[token.string.length - 1])) {
       var term = token.string; var

--- a/settings/lib/RuleEditor/loanRules-hint.js
+++ b/settings/lib/RuleEditor/loanRules-hint.js
@@ -7,7 +7,7 @@
 */
 import Codemirror from 'codemirror';
 
-export default function loanRulesHint(cm) {
+export default function loanRulesHint(cm, props) {
   Codemirror.registerHelper('hint', 'loanRulesCMM', (cm) => {
     const cur = cm.getCursor();
     const token = cm.getTokenAt(cur);
@@ -19,7 +19,6 @@ export default function loanRulesHint(cm) {
     // debug - can be used to render debug info to the dom for inspection.
     // let stateDiv = document.getElementById('ParserState');
     // stateDiv.innerHTML= JSON.stringify(token, null, 3);
-
     const currentLine = cm.getLine(cur.line);
     const start = cur.ch;
     const end = start;
@@ -43,7 +42,7 @@ export default function loanRulesHint(cm) {
       }
       result.push({
         text: newRuleText,
-        displayText: 'New Rule (#)',
+        displayText: props.intl.formatMessage({ id: 'ui-circulation.settings.loanRules.newRule' }),
         className: 'loan-rule-hint-major',
         completeOnSingleClick: true,
       });

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -17,6 +17,7 @@
   "settings.loanPolicy.loanProfile": "Loan profile",
   "settings.loanPolicy.fDDS": "Fixed due date schedule",
   "settings.loanPolicy.fDDSlimit": "Fixed due date schedule (due date limit)",
+  "settings.loanPolicy.fDDSRequired": "Fixed due date schedule *",
   "settings.loanPolicy.closedDueDateMgmt": "Closed library due date management",
   "settings.loanPolicy.altFDDSforRenewals": "Alternate fixed due date schedule for renewals",
   "settings.loanPolicy.altFDDSDueDateLimit": "Alternate fixed due date schedule (due date limit) for renewals",
@@ -36,8 +37,12 @@
   "settings.loanPolicy.selectInterval": "Select interval",
   "settings.loanPolicy.selectSchedule": "Select schedule",
   "settings.loanPolicy.generalInformation": "General information",
+  "settings.loanPolicy.yes": "Yes",
+  "settings.loanPolicy.no": "No",
 
   "settings.loanRules.paneTitle": "Loan Rules Editor",
+  "settings.loanRules.rulesUpdated": "Rules were successfully updated.",
+  "settings.loanRules.newRule": "New Rule (#)",
 
   "settings.validate.fillIn": "Please fill this in to continue",
 
@@ -51,6 +56,7 @@
   "settings.fDDS.successfulDelete": "The fixed due date schedule {name} was successfully {deleted}.",
   "settings.fDDS.successfulDeleteVerb": "deleted",
   "settings.fDDS.edit": "Edit",
+  "settings.fDDS.editLabel": "Edit: {name}",
   "settings.fDDSform.delete": "Delete",
   "settings.fDDSform.deleteMessage": "The fixed due date schedule {name} will be {deleted}.",
   "settings.fDDSform.deleteHeader": "Delete fixed due date schedule?",
@@ -89,6 +95,7 @@
   "settings.checkout.timeout": "Automatically end checkout session after period of inactivity",
   "settings.checkout.minutes": "minutes",
   "settings.checkout.validate.timeoutDuration": "Please enter a whole number greater than zero to continue",
+  "settings.checkout.filterRules": "filter rules",
 
   "settings.staffSlips.label": "Staff slips",
   "settings.staffSlips.name": "Name",
@@ -102,11 +109,14 @@
   "settings.staffSlips.delete": "Delete",
   "settings.staffSlips.preview": "Preview",
   "settings.staffSlips.active": "Active",
+  "settings.staffSlips.hold": "Hold",
   "settings.staffSlips.untitledStaffSlip": "Staff slip name",
   "settings.staffSlips.deleteStaffSlipMessage": "The staff slip <strong>{name}</strong> will be <strong>deleted</strong>.",
   "settings.staffSlips.validation.required": "Please fill this in to continue",
   "settings.staffSlips.close": "Close",
+  "settings.staffSlips.print": "Print",
   "settings.staffSlips.previewLabel": "Preview of staff slip - Hold",
+  "settings.staffSlips.editLabel": "Edit: Staff slips - {name}",
   "settings.staffSlips.yes": "Yes",
   "settings.staffSlips.no": "No"
 }


### PR DESCRIPTION
## Purpose
Regarding [UICIRC-97](https://issues.folio.org/browse/UICIRC-97), all the hardcoded strings should be internationalized using the react-intl pattern constructs outlined [here](https://github.com/folio-org/stripes/blob/master/doc/i18n.md).

[React Intl docs](https://github.com/yahoo/react-intl/wiki)