### PR TITLE
UICIRC-91 Replace formatMessage() with FormattedMessage

### DIFF
--- a/settings/FixedDueDateScheduleForm.js
+++ b/settings/FixedDueDateScheduleForm.js
@@ -103,14 +103,17 @@ class FixedDueDateScheduleForm extends React.Component {
 
     return (
       <PaneMenu>
-        <IconButton
-          onClick={onCancel}
-          icon="closeX"
-          size="medium"
-          iconClassName="closeIcon"
-          title={<FormattedMessage id="ui-circulation.settings.fDDSform.close" />}
-          aria-label={<FormattedMessage id="ui-circulation.settings.fDDSform.closeLabel" />}
-        />
+        <FormattedMessage id="ui-circulation.settings.fDDSform.closeLabel">
+          {ariaLabel => (
+            <IconButton
+              onClick={onCancel}
+              icon="closeX"
+              size="medium"
+              iconClassName="closeIcon"
+              aria-label={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
@@ -134,7 +137,6 @@ class FixedDueDateScheduleForm extends React.Component {
           <IfPermission perm="ui-circulation.settings.loan-rules">
             <Button
               id="clickable-delete-item"
-              title={<FormattedMessage id="ui-circulation.settings.fDDSform.delete" />}
               buttonStyle="danger"
               onClick={this.beginDelete}
               disabled={confirmDelete}
@@ -146,7 +148,6 @@ class FixedDueDateScheduleForm extends React.Component {
         <Button
           id="clickable-save-fixedDueDateSchedule"
           type="submit"
-          title={saveLabel}
           disabled={(pristine || submitting)}
         >
           {saveLabel}
@@ -223,14 +224,18 @@ class FixedDueDateScheduleForm extends React.Component {
                 </Col>
                 <Col xs={12} sm={1}>
                   <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-                    <Button
-                      buttonStyle="transparent slim"
-                      style={{ position: 'absolute', bottom: '0' }}
-                      title={<FormattedMessage id="ui-circulation.settings.fDDSform.remove" />}
-                      onClick={() => { f.remove(index); }}
-                    >
-                      <Icon icon="trashBin" />
-                    </Button>
+                    <FormattedMessage id="ui-circulation.settings.fDDSform.remove">
+                      {ariaLabel => (
+                        <Button
+                          buttonStyle="transparent slim"
+                          style={{ position: 'absolute', bottom: '0' }}
+                          ariaLabel={ariaLabel}
+                          onClick={() => { f.remove(index); }}
+                        >
+                          <Icon icon="trashBin" />
+                        </Button>
+                      )}
+                    </FormattedMessage>
                   </div>
                 </Col>
               </Row>

--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -2,13 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import moment from 'moment';
-
-import {
-  FormattedMessage,
-  intlShape,
-  injectIntl,
-} from 'react-intl';
-
+import { FormattedMessage } from 'react-intl';
 
 import { EntryManager } from '@folio/stripes/smart-components';
 import FixedDueDateScheduleDetail from './FixedDueDateScheduleDetail';
@@ -41,7 +35,6 @@ class FixedDueDateScheduleManager extends React.Component {
         GET: PropTypes.func,
       }),
     }).isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -145,7 +138,6 @@ class FixedDueDateScheduleManager extends React.Component {
     const {
       resources,
       mutator,
-      intl: { formatMessage },
     } = this.props;
 
     return (
@@ -157,7 +149,7 @@ class FixedDueDateScheduleManager extends React.Component {
         detailComponent={FixedDueDateScheduleDetail}
         entryFormComponent={FixedDueDateScheduleForm}
         paneTitle={<FormattedMessage id="ui-circulation.settings.fDDS.paneTitle" />}
-        entryLabel={formatMessage({ id: 'ui-circulation.settings.fDDSform.entryLabel' })}
+        entryLabel={<FormattedMessage id="ui-circulation.settings.fDDSform.entryLabel" />}
         nameKey="name"
         permissions={{
           put: 'ui-circulation.settings.loan-rules',
@@ -173,4 +165,4 @@ class FixedDueDateScheduleManager extends React.Component {
   }
 }
 
-export default injectIntl(FixedDueDateScheduleManager);
+export default FixedDueDateScheduleManager;

--- a/settings/LoanPolicyForm.js
+++ b/settings/LoanPolicyForm.js
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types';
 import { Field, getFormValues } from 'redux-form';
 import _ from 'lodash';
 
-import {
-  FormattedMessage,
-  intlShape,
-  injectIntl,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { stripesShape } from '@folio/stripes/core';
 import {
@@ -39,7 +35,6 @@ class LoanPolicyForm extends React.Component {
       fixedDueDateSchedules: PropTypes.object,
     }).isRequired,
     change: PropTypes.func.isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -149,14 +144,12 @@ class LoanPolicyForm extends React.Component {
     const policy = this.getCurrentValues();
     const { sections } = this.state;
     const {
-      intl: { formatMessage },
       parentResources,
     } = this.props;
 
     // Conditional field labels
     let dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDS" />;
     let altRenewalScheduleLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSforRenewals" />;
-
     if (policy.loansPolicy && policy.loansPolicy.profileId === loanProfileMap.ROLLING) {
       dueDateScheduleFieldLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.fDDSlimit" />;
       altRenewalScheduleLabel = <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSDueDateLimit" />;
@@ -247,16 +240,20 @@ class LoanPolicyForm extends React.Component {
                   <Field label="" name="loansPolicy.period.duration" id="input_loan_period" component={TextField} validate={this.validateField} />
                 </Col>
                 <Col>
-                  <Field
-                    label=""
-                    name="loansPolicy.period.intervalId"
-                    id="select_policy_period"
-                    component={Select}
-                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    validate={this.validateField}
-                  >
-                    {this.getOptions(intervalPeriods)}
-                  </Field>
+                  <FormattedMessage id="ui-circulation.settings.loanPolicy.selectInterval">
+                    {placeholder => (
+                      <Field
+                        label=""
+                        name="loansPolicy.period.intervalId"
+                        id="select_policy_period"
+                        component={Select}
+                        placeholder={placeholder}
+                        validate={this.validateField}
+                      >
+                        {this.getOptions(intervalPeriods)}
+                      </Field>
+                    )}
+                  </FormattedMessage>
                 </Col>
               </Row>
             </div>
@@ -304,15 +301,19 @@ class LoanPolicyForm extends React.Component {
                   />
                 </Col>
                 <Col>
-                  <Field
-                    label=""
-                    name="loansPolicy.existingRequestsPeriod.intervalId"
-                    component={Select}
-                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    validate={this.validateField}
-                  >
-                    {this.getOptions(intervalPeriods.slice(0, 3))}
-                  </Field>
+                  <FormattedMessage id="ui-circulation.settings.loanPolicy.selectInterval">
+                    {placeholder => (
+                      <Field
+                        label=""
+                        name="loansPolicy.existingRequestsPeriod.intervalId"
+                        component={Select}
+                        placeholder={placeholder}
+                        validate={this.validateField}
+                      >
+                        {this.getOptions(intervalPeriods.slice(0, 3))}
+                      </Field>
+                    )}
+                  </FormattedMessage>
                 </Col>
               </Row>
             </div>
@@ -333,15 +334,19 @@ class LoanPolicyForm extends React.Component {
                   />
                 </Col>
                 <Col>
-                  <Field
-                    label=""
-                    name="loansPolicy.gracePeriod.intervalId"
-                    component={Select}
-                    placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                    validate={this.validateField}
-                  >
-                    {this.getOptions(intervalPeriods)}
-                  </Field>
+                  <FormattedMessage id="ui-circulation.settings.loanPolicy.selectInterval">
+                    {placeholder => (
+                      <Field
+                        label=""
+                        name="loansPolicy.gracePeriod.intervalId"
+                        component={Select}
+                        placeholder={placeholder}
+                        validate={this.validateField}
+                      >
+                        {this.getOptions(intervalPeriods)}
+                      </Field>
+                    )}
+                  </FormattedMessage>
                 </Col>
               </Row>
             </div>
@@ -440,15 +445,19 @@ class LoanPolicyForm extends React.Component {
                       />
                     </Col>
                     <Col>
-                      <Field
-                        label=""
-                        name="renewalsPolicy.period.intervalId"
-                        component={Select}
-                        placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectInterval' })}
-                        validate={this.validateField}
-                      >
-                        {this.getOptions(intervalPeriods)}
-                      </Field>
+                      <FormattedMessage id="ui-circulation.settings.loanPolicy.selectInterval">
+                        {placeholder => (
+                          <Field
+                            label=""
+                            name="renewalsPolicy.period.intervalId"
+                            component={Select}
+                            placeholder={placeholder}
+                            validate={this.validateField}
+                          >
+                            {this.getOptions(intervalPeriods)}
+                          </Field>
+                        )}
+                      </FormattedMessage>
                     </Col>
                   </Row>
                 </div>
@@ -478,4 +487,4 @@ class LoanPolicyForm extends React.Component {
   }
 }
 
-export default injectIntl(LoanPolicyForm);
+export default LoanPolicyForm;

--- a/settings/LoanPolicySettings.js
+++ b/settings/LoanPolicySettings.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-
-import {
-  FormattedMessage,
-  intlShape,
-  injectIntl,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { EntryManager } from '@folio/stripes/smart-components';
 import LoanPolicyDetail from './LoanPolicyDetail';
@@ -54,7 +49,6 @@ class LoanPolicySettings extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -83,7 +77,6 @@ class LoanPolicySettings extends React.Component {
     const {
       resources,
       mutator,
-      intl: { formatMessage },
     } = this.props;
 
     return (
@@ -96,7 +89,7 @@ class LoanPolicySettings extends React.Component {
         detailComponent={LoanPolicyDetail}
         formComponent={LoanPolicyForm}
         paneTitle={<FormattedMessage id="ui-circulation.settings.loanPolicy.paneTitle" />}
-        entryLabel={formatMessage({ id: 'ui-circulation.settings.loanPolicy.entryLabel' })}
+        entryLabel={<FormattedMessage id="ui-circulation.settings.loanPolicy.entryLabel" />}
         nameKey="name"
         defaultEntry={defaultPolicy}
         permissions={{
@@ -110,4 +103,4 @@ class LoanPolicySettings extends React.Component {
   }
 }
 
-export default injectIntl(LoanPolicySettings);
+export default LoanPolicySettings;

--- a/settings/RequestCancellationReasons.js
+++ b/settings/RequestCancellationReasons.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import {
-  intlShape,
-  injectIntl,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
@@ -13,7 +9,6 @@ class RequestCancellationReasons extends React.Component {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }).isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
@@ -23,22 +18,20 @@ class RequestCancellationReasons extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage } } = this.props;
-
     return (
       <this.connectedControlledVocab
         {...this.props}
         baseUrl="cancellation-reason-storage/cancellation-reasons"
         records="cancellationReasons"
-        label={formatMessage({ id: 'ui-circulation.settings.cancelReasons.label' })}
-        labelSingular={formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelSingular' })}
+        label={<FormattedMessage id="ui-circulation.settings.cancelReasons.label" />}
+        labelSingular={<FormattedMessage id="ui-circulation.settings.cancelReasons.labelSingular" />}
         objectLabel=""
         visibleFields={['name', 'description', 'publicDescription']}
         hiddenFields={['lastUpdated', 'numberOfObjects']}
         columnMapping={{
-          name: formatMessage({ id: 'ui-circulation.settings.cancelReasons.labelShort' }),
-          description: formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionInternal' }),
-          publicDescription: formatMessage({ id: 'ui-circulation.settings.cancelReasons.descriptionPublic' }),
+          name: <FormattedMessage id="ui-circulation.settings.cancelReasons.labelShort" />,
+          description: <FormattedMessage id="ui-circulation.settings.cancelReasons.descriptionInternal" />,
+          publicDescription: <FormattedMessage id="ui-circulation.settings.cancelReasons.descriptionPublic" />,
         }}
         actionSuppressor={{
           edit: () => false,
@@ -52,4 +45,4 @@ class RequestCancellationReasons extends React.Component {
   }
 }
 
-export default injectIntl(RequestCancellationReasons);
+export default RequestCancellationReasons;

--- a/settings/StaffSlips/StaffSlipForm.js
+++ b/settings/StaffSlips/StaffSlipForm.js
@@ -47,13 +47,16 @@ class StaffSlipForm extends React.Component {
   addFirstMenu() {
     return (
       <PaneMenu>
-        <IconButton
-          id="clickable-close-staff-slip"
-          onClick={this.props.onCancel}
-          icon="closeX"
-          title={<FormattedMessage id="ui-circulation.settings.staffSlips.closeStaffSlipDialog" />}
-          aria-label={<FormattedMessage id="ui-circulation.settings.staffSlips.closeStaffSlipDialog" />}
-        />
+        <FormattedMessage id="ui-circulation.settings.staffSlips.closeStaffSlipDialog">
+          {ariaLabel => (
+            <IconButton
+              id="clickable-close-staff-slip"
+              onClick={this.props.onCancel}
+              icon="closeX"
+              aria-label={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
@@ -70,7 +73,6 @@ class StaffSlipForm extends React.Component {
         <Button
           id="clickable-save-staff-slip"
           type="submit"
-          title={<FormattedMessage id="ui-circulation.settings.staffSlips.saveAndClose" />}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0
           disabled={(pristine || submitting)}

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,10 +1,6 @@
 import React from 'react';
 
-import {
-  FormattedMessage,
-  intlShape,
-  injectIntl,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Settings } from '@folio/stripes/smart-components';
 
@@ -16,16 +12,8 @@ import FixedDueDateScheduleManager from './FixedDueDateScheduleManager';
 import StaffSlips from './StaffSlips';
 
 class Circulation extends React.Component {
-  static propTypes = {
-    intl: intlShape.isRequired,
-  };
-
   constructor(props) {
     super(props);
-
-    const {
-      intl: { formatMessage },
-    } = this.props;
 
     this.pages = [
       {
@@ -53,7 +41,7 @@ class Circulation extends React.Component {
       },
       {
         route: 'staffslips',
-        label: formatMessage({ id: 'ui-circulation.settings.index.staffSlips' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.staffSlips" />,
         component: StaffSlips,
       },
       {
@@ -76,4 +64,4 @@ class Circulation extends React.Component {
   }
 }
 
-export default injectIntl(Circulation);
+export default Circulation;

--- a/settings/lib/RuleEditor/LoanRulesEditor.js
+++ b/settings/lib/RuleEditor/LoanRulesEditor.js
@@ -6,7 +6,6 @@ import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import Codemirror from 'codemirror';
 import CodeMirror from 'react-codemirror2';
-import { intlShape, injectIntl } from 'react-intl';
 
 import initLoanRulesCMM from './LoanRulesCMM';
 import 'codemirror/addon/fold/foldcode';
@@ -64,7 +63,6 @@ const propTypes = {
       })),
   showAssist: PropTypes.bool,
   filter: PropTypes.string,
-  intl: intlShape.isRequired,
 };
 
 const defaultProps = {
@@ -424,4 +422,4 @@ class LoanRulesEditor extends React.Component {
 LoanRulesEditor.propTypes = propTypes;
 LoanRulesEditor.defaultProps = defaultProps;
 
-export default injectIntl(LoanRulesEditor);
+export default LoanRulesEditor;

--- a/settings/lib/RuleEditor/LoanRulesForm.js
+++ b/settings/lib/RuleEditor/LoanRulesForm.js
@@ -6,22 +6,13 @@ import {
   TextField
 } from '@folio/stripes/components';
 import { Field } from 'redux-form';
-
-import {
-  FormattedMessage,
-  intlShape,
-  injectIntl,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import stripesForm from '@folio/stripes/form';
 
 import LoanRulesField from './LoanRulesField';
 
 class LoanRulesForm extends React.Component {
-  static propTypes = {
-    intl: intlShape.isRequired,
-  };
-
   constructor(props) {
     super(props);
 
@@ -44,7 +35,6 @@ class LoanRulesForm extends React.Component {
       handleSubmit,
       submitting,
       editorProps,
-      intl: { formatMessage },
     } = this.props;
 
     const containerStyle = {
@@ -57,12 +47,16 @@ class LoanRulesForm extends React.Component {
       <form id="form-loan-rules" style={containerStyle} onSubmit={handleSubmit}>
         <Row end="xs">
           <Col xs={3}>
-            <TextField
-              value={this.state.ruleFilter}
-              onChange={this.filterRules}
-              validationEnabled={false}
-              placeholder={formatMessage({ id: 'ui-circulation.settings.checkout.filterRules' })}
-            />
+            <FormattedMessage id="ui-circulation.settings.checkout.filterRules">
+              {placeholder => (
+                <TextField
+                  value={this.state.ruleFilter}
+                  onChange={this.filterRules}
+                  validationEnabled={false}
+                  placeholder={placeholder}
+                />
+              )}
+            </FormattedMessage>
           </Col>
           <Col xs={3}>
             <Button
@@ -89,4 +83,4 @@ export default stripesForm({
   form: 'loanRulesForm',
   navigationCheck: true,
   enableReinitialize: true,
-})(injectIntl(LoanRulesForm));
+})(LoanRulesForm);

--- a/settings/lib/RuleEditor/loanRules-hint.js
+++ b/settings/lib/RuleEditor/loanRules-hint.js
@@ -42,7 +42,7 @@ export default function loanRulesHint(cm, props) {
       }
       result.push({
         text: newRuleText,
-        displayText: props.intl.formatMessage({ id: 'ui-circulation.settings.loanRules.newRule' }),
+        displayText: <FormattedMessage id="ui-circulation.settings.loanRules.newRule" />,
         className: 'loan-rule-hint-major',
         completeOnSingleClick: true,
       });


### PR DESCRIPTION
## Purpose
- Same pattern as https://github.com/folio-org/ui-checkout/pull/201
- Related to https://github.com/folio-org/stripes-components/pull/696 and https://github.com/folio-org/stripes-smart-components/pull/331

## Approach
- Exclusively use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` from `react-intl`. 
- Discontinue using `intl.formatMessage()`, `intl.formatDate()`, and `intl.formatTime()`.
