### PR TITLE
provide typehint to Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0 (IN PROGRESS)
 
 * Provide `sortby` prop to `<ControlledVocab>`. Refs STSMACOM-139.
+* Provide `type` prop to `<Field>`. Refs PR #697.
 
 ## 1.3.0 (https://github.com/folio-org/ui-circulation/tree/v1.3.0) (2018-10-04)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.2.0...v1.3.0)

--- a/settings/CheckoutSettingsForm.js
+++ b/settings/CheckoutSettingsForm.js
@@ -64,6 +64,7 @@ class CheckoutSettingsForm extends React.Component {
         <Col xs={12}>
           <Field
             component={Checkbox}
+            type="checkbox"
             id={`${iden.queryKey}-checkbox`}
             data-checked={fields.get(index)}
             label={iden.label}
@@ -105,6 +106,7 @@ class CheckoutSettingsForm extends React.Component {
                 id="checkoutTimeout"
                 name="checkoutTimeout"
                 component={Checkbox}
+                type="checkbox"
                 onChange={this.handleCheckoutTimeout}
                 normalize={v => !!v}
               />


### PR DESCRIPTION
Providing `type="checkbox"` to redux-form's `<Field>` kicks it into
boolean mode so it can correctly recognize `value` as a boolean.