### PR TITLE
validate callouts before calling them

### DIFF
--- a/settings/LoanRules.js
+++ b/settings/LoanRules.js
@@ -172,7 +172,7 @@ class LoanRules extends React.Component {
     return fetch(`${stripes.okapi.url}/circulation/loan-rules`, options).then((resp) => {
       if (resp.status >= 400) {
         resp.json().then(json => this.setState({ errors: [json] }));
-      } else {
+      } else if (this.callout) {
         this.callout.sendCallout({ message: this.props.calloutMessage });
       }
     });


### PR DESCRIPTION
Sometimes, Nightmare tests would blow up with an error like this:
```
Uncaught (in promise) TypeError: Cannot read property 'sendCallout' of null
```
which is the result of the delete method being called before the whole
DOM renders, which causes the callout to fail because it relies on a ref
which isn't available yet because the DOM hasn't rendered. Got that?
Good.