### PR TITLE
Opening time offset field visibility fixed on details pane

### DIFF
--- a/settings/LoanPolicyDetail.js
+++ b/settings/LoanPolicyDetail.js
@@ -24,6 +24,8 @@ import {
   renewFromIds,
   shortTermLoansOptions,
   longTermLoansOptions,
+  BEGINNING_OF_THE_NEXT_OPEN_SERVICE_POINT_HOURS,
+  intervalIdsMap,
 } from '../constants';
 
 class LoanPolicyDetail extends React.Component {
@@ -74,6 +76,26 @@ class LoanPolicyDetail extends React.Component {
     return find(availableLoansOptions, loanOption => loanOption.id === selectedItemId);
   };
 
+  isOpeningTimeOffsetVisible = () => {
+    const policy = this.props.initialValues || {};
+    const {
+      loanable,
+      loansPolicy: {
+        closedLibraryDueDateManagementId,
+        profileId,
+        period: {
+          intervalId = '',
+        } = {},
+      },
+    } = policy;
+
+    const isProfileRolling = profileId === loanProfileMap.ROLLING;
+    const isShortTermPeriod = intervalId === intervalIdsMap.MINUTES || intervalId === intervalIdsMap.HOURS;
+    const isBeginningOfNextOpenServicePointHours = closedLibraryDueDateManagementId === BEGINNING_OF_THE_NEXT_OPEN_SERVICE_POINT_HOURS;
+
+    return loanable && isProfileRolling && isShortTermPeriod && isBeginningOfNextOpenServicePointHours;
+  };
+
   renderLoans() {
     const {
       initialValues,
@@ -101,6 +123,7 @@ class LoanPolicyDetail extends React.Component {
     const exReqPerInterval = get(policy, ['loansPolicy', 'existingRequestsPeriod', 'intervalId']);
     const gracePeriodInterval = get(policy, ['loansPolicy', 'gracePeriod', 'intervalId']);
     const timeOffsetInterval = get(policy, ['loansPolicy', 'openingTimeOffset', 'intervalId']);
+    const isOpeningTimeOffsetVisible = this.isOpeningTimeOffsetVisible();
 
     return (
       <div>
@@ -153,15 +176,19 @@ class LoanPolicyDetail extends React.Component {
           </Col>
         </Row>
         <br />
-        <Row>
-          <Col xs={12}>
-            <KeyValue
-              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.openingTimeOffset" />}
-              value={`${get(policy, ['loansPolicy', 'openingTimeOffset', 'duration'], '')} ${timeOffsetInterval}`}
-            />
-          </Col>
-        </Row>
-        <br />
+        {isOpeningTimeOffsetVisible &&
+          <div>
+            <Row>
+              <Col xs={12}>
+                <KeyValue
+                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.openingTimeOffset" />}
+                  value={`${get(policy, ['loansPolicy', 'openingTimeOffset', 'duration'], '')} ${timeOffsetInterval}`}
+                />
+              </Col>
+            </Row>
+            <br />
+          </div>
+        }
         <Row>
           <Col xs={12}>
             <KeyValue

--- a/settings/LoanPolicyForm.js
+++ b/settings/LoanPolicyForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Field, getFormValues } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
@@ -377,6 +377,8 @@ class LoanPolicyForm extends React.Component {
                         name="renewalsPolicy.numberAllowed"
                         id="input_allowed_renewals"
                         component={TextField}
+                        type="number"
+                        min={0}
                         required
                         validate={this.validateField}
                       />
@@ -412,36 +414,19 @@ class LoanPolicyForm extends React.Component {
               { policy.renewable &&
                 policy.renewalsPolicy.differentPeriod &&
                 policy.loansPolicy.profileId === loanProfileMap.ROLLING &&
-                <div>
-                  <p>
-                    <FormattedMessage id="ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals" />
-                  </p>
-                  <Row>
-                    <Col xs={2}>
-                      <Field
-                        label=""
-                        name="renewalsPolicy.period.duration"
-                        component={TextField}
-                        validate={this.validateField}
-                      />
-                    </Col>
-                    <Col>
-                      <FormattedMessage id="ui-circulation.settings.loanPolicy.selectInterval">
-                        {placeholder => (
-                          <Field
-                            label=""
-                            name="renewalsPolicy.period.intervalId"
-                            component={Select}
-                            placeholder={placeholder}
-                            validate={this.validateField}
-                          >
-                            {this.getOptions(intervalPeriods)}
-                          </Field>
-                        )}
-                      </FormattedMessage>
-                    </Col>
-                  </Row>
-                </div>
+                <Fragment>
+                  <br />
+                  <PolicyPropertySetter
+                    loansPolicyNamespace="renewalsPolicy"
+                    loanHeader="alternateLoanPeriodRenewals"
+                    textFieldId="input_alternate_period"
+                    textFieldName="period"
+                    selectFieldId="select_alternate_period"
+                    selectFieldName="period"
+                    intervalPeriods={this.getOptions(intervalPeriods, 'period')}
+                    validator={this.validateField}
+                  />
+                </Fragment>
               }
               {/* alt fixed due date schedule for renewals - appears when profile is
                 "fixed" or "rolling", but with different labels */}

--- a/settings/LoanPolicyForm.js
+++ b/settings/LoanPolicyForm.js
@@ -122,9 +122,13 @@ class LoanPolicyForm extends React.Component {
 
     const openingTimeOffset = (allValues.loansPolicy && allValues.loansPolicy.openingTimeOffset);
     const openingTimeOffsetIsVisible = openingTimeOffset && openingTimeOffset.intervalId && !openingTimeOffset.duration;
+    const openingTimeOffsetIsDefault = openingTimeOffset && openingTimeOffset.duration && !openingTimeOffset.intervalId;
 
     if (openingTimeOffsetIsVisible) {
       this.props.change('loansPolicy.openingTimeOffset.duration', 0);
+    }
+    if (openingTimeOffsetIsDefault) {
+      this.props.change('loansPolicy.openingTimeOffset.intervalId', intervalIdsMap.HOURS);
     }
   }
 
@@ -297,6 +301,7 @@ class LoanPolicyForm extends React.Component {
               selectFieldName="openingTimeOffset"
               intervalPeriods={this.getOptions(intervalPeriods.slice(0, 2).reverse())}
               validator={this.validateField}
+              minInputValue={0}
             />
           }
           {/* alternate loan period */}

--- a/settings/components/PolicyPropertySetter/PolicyPropertySetter.js
+++ b/settings/components/PolicyPropertySetter/PolicyPropertySetter.js
@@ -22,6 +22,7 @@ const PolicyPropertySetter = ({
   loanHeaderNamespace,
   durationDescriptor,
   timeIntervalsUnitsDescriptor,
+  minInputValue,
 }) => (
   <Fragment>
     <Row className={generalStyles.label}>
@@ -34,6 +35,8 @@ const PolicyPropertySetter = ({
         <Field
           label=""
           name={`${loansPolicyNamespace}.${textFieldName}.${durationDescriptor}`}
+          type="number"
+          min={minInputValue}
           component={TextField}
           validate={validator}
         />
@@ -67,6 +70,7 @@ PolicyPropertySetter.propTypes = {
   durationDescriptor: PropTypes.string,
   timeIntervalsUnitsDescriptor: PropTypes.string,
   loanHeaderNamespace: PropTypes.string,
+  minInputValue: PropTypes.number,
 };
 
 // Default string identifiers to set namespaces
@@ -75,6 +79,7 @@ PolicyPropertySetter.defaultProps = {
   durationDescriptor: 'duration',
   timeIntervalsUnitsDescriptor: 'intervalId',
   loanHeaderNamespace: 'ui-circulation.settings.loanPolicy',
+  minInputValue: 1,
 };
 
 export default PolicyPropertySetter;


### PR DESCRIPTION
<h1>Opening time offset field behavior fixed</h1>
<h2>Purpose:</h2>
<ul>
<li>Fix current behavior to match the acceptance criteria</li>
</ul>
<h2>Approach</h2>
<ul><li>Code refactoring</li>
<h2>ToDos</h2>
<ul>
<li>Hide Opening time offset field on details pane if the Closed library due date management field value differs from 'Move to the beginning of the next open service point hours'</li>
<li>Set a default units for the Opening time offset field to Hours</li>
<li>Allow only numbers to be set in `PolicyPropertySetter` input field</li>
<li>Add minimum edge to the inputs</li>
</ul>
</ul>
<h2>Bug links</h2>
<a href="https://issues.folio.org/browse/UICIRC-113">https://issues.folio.org/browse/UICIRC-113</>