### PR TITLE
UICIRC-139

### DIFF
--- a/settings/LoanPolicy/LoanPolicyForm.js
+++ b/settings/LoanPolicy/LoanPolicyForm.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-
-import {
-  getFormValues,
-} from 'redux-form';
+import { getFormValues } from 'redux-form';
 
 import {
   cloneDeep,
@@ -65,6 +63,9 @@ class LoanPolicyForm extends React.Component {
     confirmDelete: false,
     sections: {
       generalSection: true,
+      recallsSection: true,
+      holdsSection: true,
+      pagesSection: true,
     },
   };
 
@@ -104,19 +105,28 @@ class LoanPolicyForm extends React.Component {
 
   render() {
     const {
+      onCancel,
+      onRemove,
       pristine,
       policy,
-      initialValues,
       stripes,
       submitting,
       handleSubmit,
-      onCancel,
-      onRemove,
+      initialValues,
+      change,
     } = this.props;
 
     const {
       sections,
       confirmDelete,
+    } = this.state;
+
+    const {
+      sections: {
+        recallsSection,
+        holdsSection,
+        pagesSection,
+      },
     } = this.state;
 
     const editMode = Boolean(policy.id);
@@ -141,9 +151,10 @@ class LoanPolicyForm extends React.Component {
                 </Col>
               </Row>
               <Accordion
+                id="generalSection"
                 open={sections.generalSection}
-                onToggle={this.handleSectionToggle}
                 label={<FormattedMessage id="ui-circulation.settings.loanPolicy.generalInformation" />}
+                onToggle={this.handleSectionToggle}
               >
                 <Metadata
                   connect={stripes.connect}
@@ -152,8 +163,8 @@ class LoanPolicyForm extends React.Component {
                 <AboutSection />
                 <LoansSection
                   policy={policy}
+                  change={change}
                   schedules={schedules}
-                  change={this.props.change}
                 />
                 <RenewalsSection
                   policy={policy}
@@ -161,15 +172,19 @@ class LoanPolicyForm extends React.Component {
                 />
                 <RequestManagementSection
                   policy={policy}
+                  holdsSectionOpen={holdsSection}
+                  pagesSectionOpen={pagesSection}
+                  recallsSectionOpen={recallsSection}
+                  accordionOnToggle={this.handleSectionToggle}
                 />
               </Accordion>
               {editMode &&
                 <DeleteEntry
-                  confirmDelete={confirmDelete}
+                  onRemove={onRemove}
                   policyName={policy.name}
                   initialValues={initialValues}
+                  confirmDelete={confirmDelete}
                   changeDeleteState={this.changeDeleteState}
-                  onRemove={onRemove}
                 />
               }
             </React.Fragment>

--- a/settings/LoanPolicy/LoanPolicyForm.js
+++ b/settings/LoanPolicy/LoanPolicyForm.js
@@ -36,6 +36,7 @@ import {
   PanelTitle,
   Metadata,
   DeleteEntry,
+  RequestManagementSection,
 } from './components';
 
 class LoanPolicyForm extends React.Component {
@@ -99,7 +100,7 @@ class LoanPolicyForm extends React.Component {
 
   changeDeleteState = (confirmDelete) => {
     this.setState({ confirmDelete });
-  }
+  };
 
   render() {
     const {
@@ -157,6 +158,9 @@ class LoanPolicyForm extends React.Component {
                 <RenewalsSection
                   policy={policy}
                   schedules={schedules}
+                />
+                <RequestManagementSection
+                  policy={policy}
                 />
               </Accordion>
               {editMode &&

--- a/settings/LoanPolicy/components/EditSections/RenewalsSection.js
+++ b/settings/LoanPolicy/components/EditSections/RenewalsSection.js
@@ -127,6 +127,7 @@ class RenewalsSection extends React.Component {
             {schedules}
           </Field>
         }
+        <hr />
       </React.Fragment>
     );
   }

--- a/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
+++ b/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Field } from 'redux-form';
+import PropTypes from 'prop-types';
+
+import {
+  Checkbox,
+  Accordion,
+} from '@folio/stripes/components';
+
+import { intervalPeriods } from '../../../../constants';
+import PolicyPropertySetter from '../PolicyPropertySetter/PolicyPropertySetter';
+
+
+class RenewalsSection extends React.Component {
+  static propTypes = {
+    policy: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { policy } = this.props;
+
+    if (!policy.loanable) {
+      return null;
+    }
+
+    return (
+      <React.Fragment>
+        <h2>
+          <FormattedMessage id="ui-circulation.settings.requestManagement.requestManagement" />
+        </h2>
+        <Accordion
+          label={<FormattedMessage id="ui-circulation.settings.requestManagement.recalls" />}
+        >
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.recallReturnInterval"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.recallReturnInterval.duration"
+            selectValuePath="requestManagement.recallReturnInterval.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.minLoanPeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.minLoanPeriod.duration"
+            selectValuePath="requestManagement.minLoanPeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.alternateGracePeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.alternateGracePeriod.duration"
+            selectValuePath="requestManagement.alternateGracePeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+        </Accordion>
+        <Accordion
+          label={<FormattedMessage id="ui-circulation.settings.requestManagement.holds" />}
+        >
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.alternateCheckoutLoanPeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.alternateCheckoutLoanPeriod.duration"
+            selectValuePath="requestManagement.alternateCheckoutLoanPeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+          <hr />
+          <br />
+          <Field
+            label={<FormattedMessage id="ui-circulation.settings.requestManagement.renewItemsWithRequest" />}
+            name="requestManagement.renewItemsWithRequest"
+            id="requestManagement.renewItemsWithRequest"
+            component={Checkbox}
+            type="checkbox"
+            normalize={v => !!v}
+          />
+          <br />
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
+            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+        </Accordion>
+        <Accordion
+          label={<FormattedMessage id="ui-circulation.settings.requestManagement.holds" />}
+        >
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
+            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+          <Field
+            label={<FormattedMessage id="ui-circulation.settings.requestManagement.renewItemsWithRequest" />}
+            name="requestManagement.renewItemsWithRequest"
+            id="requestManagement.renewItemsWithRequest"
+            component={Checkbox}
+            type="checkbox"
+            normalize={v => !!v}
+          />
+          <br />
+          <PolicyPropertySetter
+            fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
+            selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
+            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
+            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            entity={policy}
+            intervalPeriods={intervalPeriods}
+          />
+        </Accordion>
+      </React.Fragment>
+    );
+  }
+}
+
+export default RenewalsSection;

--- a/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
+++ b/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
-import PropTypes from 'prop-types';
 
 import {
   Checkbox,
@@ -15,10 +15,20 @@ import PolicyPropertySetter from '../PolicyPropertySetter/PolicyPropertySetter';
 class RequestManagementSection extends React.Component {
   static propTypes = {
     policy: PropTypes.object.isRequired,
+    holdsSectionOpen: PropTypes.bool.isRequired,
+    pagesSectionOpen: PropTypes.bool.isRequired,
+    recallsSectionOpen: PropTypes.bool.isRequired,
+    accordionOnToggle: PropTypes.func.isRequired
   };
 
   render() {
-    const { policy } = this.props;
+    const {
+      policy,
+      holdsSectionOpen,
+      pagesSectionOpen,
+      recallsSectionOpen,
+      accordionOnToggle,
+    } = this.props;
 
     if (!policy.loanable) {
       return null;
@@ -30,6 +40,9 @@ class RequestManagementSection extends React.Component {
           <FormattedMessage id="ui-circulation.settings.requestManagement.requestManagement" />
         </h2>
         <Accordion
+          id="recallsSection"
+          open={recallsSectionOpen}
+          onToggle={accordionOnToggle}
           label={<FormattedMessage id="ui-circulation.settings.requestManagement.recalls" />}
         >
           <PolicyPropertySetter
@@ -58,6 +71,9 @@ class RequestManagementSection extends React.Component {
           />
         </Accordion>
         <Accordion
+          id="holdsSection"
+          open={holdsSectionOpen}
+          onToggle={accordionOnToggle}
           label={<FormattedMessage id="ui-circulation.settings.requestManagement.holds" />}
         >
           <PolicyPropertySetter
@@ -89,6 +105,9 @@ class RequestManagementSection extends React.Component {
           />
         </Accordion>
         <Accordion
+          id="pagesSection"
+          open={pagesSectionOpen}
+          onToggle={accordionOnToggle}
           label={<FormattedMessage id="ui-circulation.settings.requestManagement.pages" />}
         >
           <PolicyPropertySetter
@@ -101,7 +120,7 @@ class RequestManagementSection extends React.Component {
           />
           <Field
             label={<FormattedMessage id="ui-circulation.settings.requestManagement.renewItemsWithRequest" />}
-            name="requestManagement.renewItemsWithRequest"
+            name="requestManagement.pages.renewItemsWithRequest"
             id="requestManagement.pages.renewItemsWithRequest"
             component={Checkbox}
             type="checkbox"

--- a/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
+++ b/settings/LoanPolicy/components/EditSections/RequestManagementSection.js
@@ -12,7 +12,7 @@ import { intervalPeriods } from '../../../../constants';
 import PolicyPropertySetter from '../PolicyPropertySetter/PolicyPropertySetter';
 
 
-class RenewalsSection extends React.Component {
+class RequestManagementSection extends React.Component {
   static propTypes = {
     policy: PropTypes.object.isRequired,
   };
@@ -35,24 +35,24 @@ class RenewalsSection extends React.Component {
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.recallReturnInterval"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.recallReturnInterval.duration"
-            selectValuePath="requestManagement.recallReturnInterval.intervalId"
+            inputValuePath="requestManagement.recalls.recallReturnInterval.duration"
+            selectValuePath="requestManagement.recalls.recallReturnInterval.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.minLoanPeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.minLoanPeriod.duration"
-            selectValuePath="requestManagement.minLoanPeriod.intervalId"
+            inputValuePath="requestManagement.recalls.minLoanPeriod.duration"
+            selectValuePath="requestManagement.recalls.minLoanPeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.alternateGracePeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.alternateGracePeriod.duration"
-            selectValuePath="requestManagement.alternateGracePeriod.intervalId"
+            inputValuePath="requestManagement.recalls.alternateGracePeriod.duration"
+            selectValuePath="requestManagement.recalls.alternateGracePeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
@@ -63,8 +63,8 @@ class RenewalsSection extends React.Component {
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.alternateCheckoutLoanPeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.alternateCheckoutLoanPeriod.duration"
-            selectValuePath="requestManagement.alternateCheckoutLoanPeriod.intervalId"
+            inputValuePath="requestManagement.holds.alternateCheckoutLoanPeriod.duration"
+            selectValuePath="requestManagement.holds.alternateCheckoutLoanPeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
@@ -72,8 +72,8 @@ class RenewalsSection extends React.Component {
           <br />
           <Field
             label={<FormattedMessage id="ui-circulation.settings.requestManagement.renewItemsWithRequest" />}
-            name="requestManagement.renewItemsWithRequest"
-            id="requestManagement.renewItemsWithRequest"
+            name="requestManagement.holds.renewItemsWithRequest"
+            id="requestManagement.holds.renewItemsWithRequest"
             component={Checkbox}
             type="checkbox"
             normalize={v => !!v}
@@ -82,27 +82,27 @@ class RenewalsSection extends React.Component {
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
-            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            inputValuePath="requestManagement.holds.alternateRenewalLoanPeriod.duration"
+            selectValuePath="requestManagement.holds.alternateRenewalLoanPeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
         </Accordion>
         <Accordion
-          label={<FormattedMessage id="ui-circulation.settings.requestManagement.holds" />}
+          label={<FormattedMessage id="ui-circulation.settings.requestManagement.pages" />}
         >
           <PolicyPropertySetter
-            fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
+            fieldLabel="ui-circulation.settings.requestManagement.alternateCheckoutLoanPeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
-            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            inputValuePath="requestManagement.pages.alternateCheckoutLoanPeriod.duration"
+            selectValuePath="requestManagement.pages.alternateCheckoutLoanPeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
           <Field
             label={<FormattedMessage id="ui-circulation.settings.requestManagement.renewItemsWithRequest" />}
             name="requestManagement.renewItemsWithRequest"
-            id="requestManagement.renewItemsWithRequest"
+            id="requestManagement.pages.renewItemsWithRequest"
             component={Checkbox}
             type="checkbox"
             normalize={v => !!v}
@@ -111,8 +111,8 @@ class RenewalsSection extends React.Component {
           <PolicyPropertySetter
             fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
             selectPlaceholder="ui-circulation.settings.loanPolicy.selectInterval"
-            inputValuePath="requestManagement.alternateRenewalLoanPeriod.duration"
-            selectValuePath="requestManagement.alternateRenewalLoanPeriod.intervalId"
+            inputValuePath="requestManagement.pages.alternateRenewalLoanPeriod.duration"
+            selectValuePath="requestManagement.pages.alternateRenewalLoanPeriod.intervalId"
             entity={policy}
             intervalPeriods={intervalPeriods}
           />
@@ -122,4 +122,4 @@ class RenewalsSection extends React.Component {
   }
 }
 
-export default RenewalsSection;
+export default RequestManagementSection;

--- a/settings/LoanPolicy/components/EditSections/index.js
+++ b/settings/LoanPolicy/components/EditSections/index.js
@@ -1,3 +1,4 @@
 export { default as AboutSection } from './AboutSection';
 export { default as LoansSection } from './LoansSection';
 export { default as RenewalsSection } from './RenewalsSection';
+export { default as RequestManagementSection } from './RequestManagementSection';

--- a/settings/Models/LoanPolicy.js
+++ b/settings/Models/LoanPolicy.js
@@ -50,6 +50,54 @@ class RenewalsPolicy {
   }
 }
 
+class Recalls {
+  constructor({
+    recallReturnInterval,
+    minLoanPeriod,
+    alternateGracePeriod,
+  } = {}) {
+    this.recallReturnInterval = new Period(recallReturnInterval);
+    this.minLoanPeriod = new Period(minLoanPeriod);
+    this.alternateGracePeriod = new Period(alternateGracePeriod);
+  }
+}
+
+class Holds {
+  constructor({
+    alternateCheckoutLoanPeriod,
+    renewItemsWithRequest,
+    alternateRenewalLoanPeriod,
+  } = {}) {
+    this.alternateCheckoutLoanPeriod = new Period(alternateCheckoutLoanPeriod);
+    this.renewItemsWithRequest = renewItemsWithRequest;
+    this.alternateRenewalLoanPeriod = new Period(alternateRenewalLoanPeriod);
+  }
+}
+
+class Pages {
+  constructor({
+    alternateCheckoutLoanPeriod,
+    renewItemsWithRequest,
+    alternateRenewalLoanPeriod,
+  } = {}) {
+    this.alternateCheckoutLoanPeriod = new Period(alternateCheckoutLoanPeriod);
+    this.renewItemsWithRequest = renewItemsWithRequest;
+    this.alternateRenewalLoanPeriod = new Period(alternateRenewalLoanPeriod);
+  }
+}
+
+class RequestManagement {
+  constructor({
+    recalls,
+    holds,
+    pages,
+  } = {}) {
+    this.recalls = new Recalls(recalls);
+    this.holds = new Holds(holds);
+    this.pages = new Pages(pages);
+  }
+}
+
 export default class LoanPolicy {
   static defaultLoanPolicy() {
     const defaultPolicy = {
@@ -77,6 +125,7 @@ export default class LoanPolicy {
     this.loansPolicy = new LoansPolicy(policy.loansPolicy);
     this.renewalsPolicy = new RenewalsPolicy(policy.renewalsPolicy);
     this.metadata = new Metadata(policy.metadata);
+    this.requestManagement = new RequestManagement(policy.requestManagement);
   }
 
   isShortTermLoan() {

--- a/settings/Validation/FormValidator.js
+++ b/settings/Validation/FormValidator.js
@@ -8,6 +8,7 @@ import {
   isEmpty,
   isNumber,
   isInteger,
+  isUndefined,
 } from 'lodash';
 
 const defaultValidators = {
@@ -18,6 +19,14 @@ const defaultValidators = {
   isIntegerGreaterThanOne: {
     validate: (value) => isInteger(value) && value > 1,
     message: <FormattedMessage id="ui-circulation.settings.validate.greaterThanOne" />,
+  },
+  isIntegerGreaterThanZero: {
+    validate: (value) => isUndefined(value) || (isInteger(value) && value > 0),
+    message: <FormattedMessage id="ui-circulation.settings.validate.greaterThanZero" />,
+  },
+  isPositiveNumber: {
+    validate: (value) => isUndefined(value) || (isInteger(value) && value >= 0),
+    message: <FormattedMessage id="ui-circulation.settings.validate.isPositiveNumber" />,
   },
 };
 

--- a/settings/Validation/LoanPolicy.js
+++ b/settings/Validation/LoanPolicy.js
@@ -25,6 +25,34 @@ export default function (policy) {
       rules: ['isNotEmpty'],
       shouldValidate: loanPolicy.isNumberOfRenewalsAllowedActive(),
     },
+    'requestManagement.recalls.recallReturnInterval.duration': {
+      rules: ['isPositiveNumber'],
+      shouldValidate: true,
+    },
+    'requestManagement.recalls.minLoanPeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
+    'requestManagement.recalls.alternateGracePeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
+    'requestManagement.holds.alternateCheckoutLoanPeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
+    'requestManagement.holds.alternateRenewalLoanPeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
+    'requestManagement.pages.alternateCheckoutLoanPeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
+    'requestManagement.pages.alternateRenewalLoanPeriod.duration': {
+      rules: ['isIntegerGreaterThanZero'],
+      shouldValidate: true,
+    },
   };
   const formValidator = new FormValidator(config);
   return formValidator.validate(policy);

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -55,6 +55,8 @@
 
   "settings.validate.fillIn": "Please fill this in to continue",
   "settings.validate.greaterThanOne": "The value must be integer and greater than 1",
+  "settings.validate.greaterThanZero": "The value must be integer and greater than 0",
+  "settings.validate.isPositiveNumber": "The value must be greater or equal 0",
 
   "settings.fDDS.validate.overlappingDateRange": "Date Range {num1} cannot overlap with Date Range {num2}",
   "settings.fDDS.validate.uniqueName": "Please enter a unique name.",

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -157,5 +157,16 @@
   "settings.staffSlips.previewLabel": "Preview of staff slip - Hold",
   "settings.staffSlips.editLabel": "Edit: Staff slips - {name}",
   "settings.staffSlips.yes": "Yes",
-  "settings.staffSlips.no": "No"
+  "settings.staffSlips.no": "No",
+
+  "settings.requestManagement.requestManagement": "Request Management",
+  "settings.requestManagement.recalls": "Recalls",
+  "settings.requestManagement.recallReturnInterval": "Recall return interval",
+  "settings.requestManagement.minLoanPeriod": "Minimum guaranteed loan period for recalled items",
+  "settings.requestManagement.alternateGracePeriod": "Alternate grace period for recalled items",
+  "settings.requestManagement.alternateCheckoutLoanPeriod": "Alternate loan period at checkout for items with an active, pending hold request",
+  "settings.requestManagement.renewItemsWithRequest": "Allow renewal of items with an active, pending hold request",
+  "settings.requestManagement.alternateRenewalLoanPeriod": "Alternate loan period at renewal for items with an active, pending hold request",
+  "settings.requestManagement.holds": "Holds",
+  "settings.requestManagement.pages": "Pages"
 }


### PR DESCRIPTION
# Purpose
According to UICIRC-139 In order for staff to more clearly distinguish between form fields appropriate only to specific and separate Request Types (e.g., Recalls, Holds, Pages) an accordion element should be added to separate the Request Type subsections and associated form fields appropriately.
# Screenshots
## mockup
![loan_policy_long-term_with_request_mgt_v3](https://user-images.githubusercontent.com/42577309/50450306-28e17f80-093e-11e9-93df-59c70ce6e85e.png)
## Current behavior
![screen shot 2019-01-11 at 1 26 56 pm](https://user-images.githubusercontent.com/42577309/51028505-93ccc080-15a4-11e9-9f27-38ba5fb7029f.png)
