### PR TITLE
UICIRC-167 - Notice policies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
         "subPermissions": [
           "circulation-storage.notice-policies.collection.get",
           "circulation-storage.notice-policies.item.get",
-          "circulation-storage.notice-policies.item.create",
-          "circulation-storage.notice-policies.item.update",
+          "circulation-storage.notice-policies.item.post",
+          "circulation-storage.notice-policies.item.put",
           "circulation-storage.notice-policies.item.delete",
           "settings.circulation.enabled"
         ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "circulation": "3.0 4.0 5.0",
       "fixed-due-date-schedules-storage": "2.0",
       "loan-policy-storage": "1.0",
-      "template-engine": "1.0"
+      "template-engine": "1.0",
+      "patron-notice-policy-storage": "0.1"
     },
     "permissionSets": [
       {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,19 @@
         "visible": true
       },
       {
+        "permissionName": "ui-circulation.settings.notice-policies",
+        "displayName": "Settings (Circ): Can create, edit and remove notice policies",
+        "subPermissions": [
+          "circulation-storage.notice-policies.collection.get",
+          "circulation-storage.notice-policies.item.get",
+          "circulation-storage.notice-policies.item.create",
+          "circulation-storage.notice-policies.item.update",
+          "circulation-storage.notice-policies.item.delete",
+          "settings.circulation.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "settings.loan-policies.all",
         "displayName": "Settings (Circ): Can create, edit and remove loan policies [LEGACY]",
         "subPermissions": [

--- a/settings/LoanPolicy/LoanPolicySettings.js
+++ b/settings/LoanPolicy/LoanPolicySettings.js
@@ -10,7 +10,6 @@ import LoanPolicyForm from './LoanPolicyForm';
 import validate from '../Validation/LoanPolicy';
 import LoanPolicy from '../Models/LoanPolicy';
 
-
 class LoanPolicySettings extends React.Component {
   static manifest = Object.freeze({
     loanPolicies: {

--- a/settings/Models/LoanPolicy.js
+++ b/settings/Models/LoanPolicy.js
@@ -5,27 +5,16 @@ import {
 } from 'lodash';
 
 import {
+  Metadata,
+  Period,
+} from './common';
+
+import {
   intervalIdsMap,
   loanProfileMap,
   renewFromIds,
   BEGINNING_OF_THE_NEXT_OPEN_SERVICE_POINT_HOURS,
 } from '../../constants';
-
-class Period {
-  constructor(period = {}) {
-    this.duration = period.duration;
-    this.intervalId = period.intervalId;
-  }
-}
-
-class Metadata {
-  constructor(metadata = {}) {
-    this.createdByUserId = metadata.createdByUserId;
-    this.createdDate = metadata.createdDate;
-    this.updatedByUserId = metadata.updatedByUserId;
-    this.updatedDate = metadata.updatedDate;
-  }
-}
 
 class LoansPolicy {
   constructor(policy = {}) {

--- a/settings/Models/NoticePolicy.js
+++ b/settings/Models/NoticePolicy.js
@@ -37,6 +37,7 @@ export default class NoticePolicy {
     this.metadata = new Metadata(policy.metadata);
     this.loanNotices = policy.loanNotices.reduce((loanNotices, loanNotice) => {
       const ln = new Notice(loanNotice);
+
       return [...loanNotices, ln];
     }, []);
   }

--- a/settings/Models/NoticePolicy.js
+++ b/settings/Models/NoticePolicy.js
@@ -1,0 +1,43 @@
+import {
+  Metadata,
+  Period,
+} from './common';
+
+class NoticeSendOptions {
+  constructor(options) {
+    this.sendHow = options.sendHow;
+    this.sendWhen = options.sendWhen;
+    this.sendBy = new Period(options.sendBy);
+    this.sendEvery = new Period(options.sendEvery);
+  }
+}
+
+class Notice {
+  constructor(notice) {
+    this.name = notice.name;
+    this.templateId = notice.templateId;
+    this.templateName = notice.templateName;
+    this.format = notice.format;
+    this.frequency = notice.frequency;
+    this.realTime = notice.realTime;
+    this.sendOptions = new NoticeSendOptions(notice.sendOptions);
+  }
+}
+
+export default class NoticePolicy {
+  static defaultNoticePolicy() {
+    return {};
+  }
+
+  constructor(policy = {}) {
+    this.id = policy.id;
+    this.name = policy.name;
+    this.descrition = policy.descrition;
+    this.active = policy.active;
+    this.metadata = new Metadata(policy.metadata);
+    this.loanNotices = policy.loanNotices.reduce((loanNotices, loanNotice) => {
+      const ln = new Notice(loanNotice);
+      return [...loanNotices, ln];
+    }, []);
+  }
+}

--- a/settings/Models/common/Metadata.js
+++ b/settings/Models/common/Metadata.js
@@ -1,0 +1,8 @@
+export default class Metadata {
+  constructor(metadata = {}) {
+    this.createdByUserId = metadata.createdByUserId;
+    this.createdDate = metadata.createdDate;
+    this.updatedByUserId = metadata.updatedByUserId;
+    this.updatedDate = metadata.updatedDate;
+  }
+}

--- a/settings/Models/common/Period.js
+++ b/settings/Models/common/Period.js
@@ -1,0 +1,6 @@
+export default class Period {
+  constructor(period = {}) {
+    this.duration = period.duration;
+    this.intervalId = period.intervalId;
+  }
+}

--- a/settings/Models/common/index.js
+++ b/settings/Models/common/index.js
@@ -1,0 +1,2 @@
+export { default as Metadata } from './Metadata';
+export { default as Period } from './Period';

--- a/settings/NoticePolicy/NoticePolicyDetail.js
+++ b/settings/NoticePolicy/NoticePolicyDetail.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class NoticePolicyDetail extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default NoticePolicyDetail;

--- a/settings/NoticePolicy/NoticePolicyForm.js
+++ b/settings/NoticePolicy/NoticePolicyForm.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class NoticePolicyForm extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default NoticePolicyForm;

--- a/settings/NoticePolicy/NoticePolicySettings.js
+++ b/settings/NoticePolicy/NoticePolicySettings.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { sortBy } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+
+import { EntryManager } from '@folio/stripes/smart-components';
+
+import NoticePolicyDetail from './NoticePolicyDetail';
+import NoticePolicyForm from './NoticePolicyForm';
+import validate from '../Validation/NoticePolicy';
+import NoticePolicy from '../Models/NoticePolicy';
+
+class NoticePolicySettings extends React.Component {
+  static manifest = Object.freeze({
+    noticePolicies: {
+      type: 'okapi',
+      records: 'noticePolicies',
+      path: 'notice-policy-storage/notice-policies',
+    },
+  });
+
+  static propTypes = {
+    resources: PropTypes.shape({
+      noticePolicies: PropTypes.object,
+    }).isRequired,
+    mutator: PropTypes.shape({
+      noticePolicies: PropTypes.shape({
+        POST: PropTypes.func,
+        PUT: PropTypes.func,
+        DELETE: PropTypes.func,
+      }),
+    }).isRequired,
+  }
+
+  render() {
+    const {
+      resources,
+      mutator,
+    } = this.props;
+
+    const permissions = {
+      put: 'ui-circulation.settings.notice-policies',
+      post: 'ui-circulation.settings.notice-policies',
+      delete: 'ui-circulation.settings.notice-policies',
+    };
+
+    const entryList = sortBy((resources.noticePolicies || {}).records, ['name']);
+
+    return (
+      <EntryManager
+        {...this.props}
+        parentMutator={mutator}
+        parentResources={resources}
+        entryList={entryList}
+        resourceKey="loanPolicies"
+        detailComponent={NoticePolicyDetail}
+        entryFormComponent={NoticePolicyForm}
+        paneTitle={<FormattedMessage id="ui-circulation.settings.noticePolicy.paneTitle" />}
+        entryLabel={<FormattedMessage id="ui-circulation.settings.noticePolicy.entryLabel" />}
+        nameKey="name"
+        permissions={permissions}
+        validate={validate}
+        defaultEntry={NoticePolicy.defaultNoticePolicy()}
+      />
+    );
+  }
+}
+
+export default NoticePolicySettings;

--- a/settings/NoticePolicy/NoticePolicySettings.js
+++ b/settings/NoticePolicy/NoticePolicySettings.js
@@ -25,9 +25,9 @@ class NoticePolicySettings extends React.Component {
     }).isRequired,
     mutator: PropTypes.shape({
       noticePolicies: PropTypes.shape({
-        POST: PropTypes.func,
-        PUT: PropTypes.func,
-        DELETE: PropTypes.func,
+        POST: PropTypes.func.isRequired,
+        PUT: PropTypes.func.isRequired,
+        DELETE: PropTypes.func.isRequired,
       }),
     }).isRequired,
   }
@@ -52,7 +52,7 @@ class NoticePolicySettings extends React.Component {
         parentMutator={mutator}
         parentResources={resources}
         entryList={entryList}
-        resourceKey="loanPolicies"
+        resourceKey="noticePolicies"
         detailComponent={NoticePolicyDetail}
         entryFormComponent={NoticePolicyForm}
         paneTitle={<FormattedMessage id="ui-circulation.settings.noticePolicy.paneTitle" />}

--- a/settings/NoticePolicy/index.js
+++ b/settings/NoticePolicy/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoticePolicySettings';

--- a/settings/Validation/NoticePolicy.js
+++ b/settings/Validation/NoticePolicy.js
@@ -1,0 +1,3 @@
+export default function () {
+  return true;
+}

--- a/settings/index.js
+++ b/settings/index.js
@@ -10,6 +10,7 @@ import CheckoutSettings from './CheckoutSettings';
 import FixedDueDateScheduleManager from './FixedDueDateScheduleManager';
 import PatronNotices from './PatronNotices';
 import StaffSlips from './StaffSlips';
+import NoticePolicySettings from './NoticePolicy';
 
 class Circulation extends React.Component {
   constructor(props) {
@@ -52,8 +53,14 @@ class Circulation extends React.Component {
       },
       {
         route: 'patron-notices',
-        label: this.props.stripes.intl.formatMessage({ id: 'ui-circulation.settings.index.patronNotices' }),
+        label: <FormattedMessage id="ui-circulation.settings.index.patronNotices" />,
         component: PatronNotices,
+      },
+      {
+        route: 'notice-policies',
+        label: <FormattedMessage id="ui-circulation.settings.index.noticePolicies" />,
+        component: NoticePolicySettings,
+        // perm: 'ui-circulation.settings.notice-policies',
       },
     ];
   }

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -9,6 +9,7 @@
   "settings.index.staffSlips": "Staff slips",
   "settings.index.requestCancellationReasons": "Request cancellation reasons",
   "settings.index.patronNotices": "Patron notice templates",
+  "settings.index.noticePolicies": "Notice policies",
 
   "settings.loanPolicy.entryLabel": "Loan Policy",
   "settings.loanPolicy.paneTitle": "Loan Policies",
@@ -171,5 +172,9 @@
   "settings.requestManagement.renewItemsWithRequest": "Allow renewal of items with an active, pending hold request",
   "settings.requestManagement.alternateRenewalLoanPeriod": "Alternate loan period at renewal for items with an active, pending hold request",
   "settings.requestManagement.holds": "Holds",
-  "settings.requestManagement.pages": "Pages"
+  "settings.requestManagement.pages": "Pages",
+  
+  "settings.noticePolicy.entryLabel": "Notice Policy",
+  "settings.noticePolicy.paneTitle": "Notice Policies"
+
 }


### PR DESCRIPTION
# Purpose
Library staff (administrators) need to be able to setup and configure notice policies to define triggering events and conditions and utilize notice templates.  It this story we are going to create a list of notice policies.

# Link
https://issues.folio.org/browse/UICIRC-167

# Screenshots
<img width="1439" alt="screen shot 2019-01-17 at 12 24 03" src="https://user-images.githubusercontent.com/43472449/51311943-ccf8ab00-1a52-11e9-94b8-ab898a1fb5fc.png">
