### PR TITLE
be lenient with react deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0 IN PROGRESS
 
 * Add new policy types to policy menu in rules editor. Fixes UICIRC-164.
+* React deps should be as lenient as possible.
 
 ## 1.4.0 (https://github.com/folio-org/ui-circulation/tree/v1.4.0) (2018-12-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.3.0...v1.4.0)

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^5.5.0",
-    "react": "~16.7.0",
-    "react-dom": "~16.6.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.6.0",
     "react-redux": "~5.1.1",
     "redux": "~4.0.0",
     "sinon": "^7.2.2"


### PR DESCRIPTION
Workspace builds are all kinds of whacked. It appears that, maybe, we
are getting conflicting versions of react in the bundle because of ~
deps on a version that is older than the one provided by ^ deps from
other modules, maybe? It's not totally clear. But using a ^ dep here
will at least be consistent with other apps. Consistency is good.