### PR TITLE
pass entryLabel as a string

### DIFF
--- a/settings/FixedDueDateScheduleManager.js
+++ b/settings/FixedDueDateScheduleManager.js
@@ -141,26 +141,30 @@ class FixedDueDateScheduleManager extends React.Component {
     } = this.props;
 
     return (
-      <EntryManager
-        {...this.props}
-        parentMutator={mutator}
-        entryList={_.sortBy((resources.fixedDueDateSchedules || {}).records || [], ['name'])}
-        resourceKey="fixedDueDateSchedules"
-        detailComponent={FixedDueDateScheduleDetail}
-        entryFormComponent={FixedDueDateScheduleForm}
-        paneTitle={<FormattedMessage id="ui-circulation.settings.fDDS.paneTitle" />}
-        entryLabel={<FormattedMessage id="ui-circulation.settings.fDDSform.entryLabel" />}
-        nameKey="name"
-        permissions={{
-          put: 'ui-circulation.settings.loan-rules',
-          post: 'ui-circulation.settings.loan-rules',
-          delete: 'ui-circulation.settings.loan-rules',
-        }}
-        validate={this.validate}
-        deleteDisabled={this.deleteDisabled}
-        deleteDisabledMessage={<FormattedMessage id="ui-circulation.settings.fDDS.deleteDisabled" />}
-        defaultEntry={{ schedules: [{}] }}
-      />
+      <FormattedMessage id="ui-circulation.settings.fDDSform.entryLabel">
+        { entryLabel => (
+          <EntryManager
+            {...this.props}
+            parentMutator={mutator}
+            entryList={_.sortBy((resources.fixedDueDateSchedules || {}).records || [], ['name'])}
+            resourceKey="fixedDueDateSchedules"
+            detailComponent={FixedDueDateScheduleDetail}
+            entryFormComponent={FixedDueDateScheduleForm}
+            paneTitle={<FormattedMessage id="ui-circulation.settings.fDDS.paneTitle" />}
+            entryLabel={entryLabel}
+            nameKey="name"
+            permissions={{
+              put: 'ui-circulation.settings.loan-rules',
+              post: 'ui-circulation.settings.loan-rules',
+              delete: 'ui-circulation.settings.loan-rules',
+            }}
+            validate={this.validate}
+            deleteDisabled={this.deleteDisabled}
+            deleteDisabledMessage={<FormattedMessage id="ui-circulation.settings.fDDS.deleteDisabled" />}
+            defaultEntry={{ schedules: [{}] }}
+          />
+        )}
+      </FormattedMessage>
     );
   }
 }

--- a/settings/LoanPolicy/LoanPolicySettings.js
+++ b/settings/LoanPolicy/LoanPolicySettings.js
@@ -53,21 +53,25 @@ class LoanPolicySettings extends React.Component {
     const entryList = sortBy((resources.loanPolicies || {}).records, ['name']);
 
     return (
-      <EntryManager
-        {...this.props}
-        parentMutator={mutator}
-        parentResources={resources}
-        entryList={entryList}
-        resourceKey="loanPolicies"
-        detailComponent={LoanPolicyDetail}
-        entryFormComponent={LoanPolicyForm}
-        paneTitle={<FormattedMessage id="ui-circulation.settings.loanPolicy.paneTitle" />}
-        entryLabel={<FormattedMessage id="ui-circulation.settings.loanPolicy.entryLabel" />}
-        nameKey="name"
-        permissions={permissions}
-        validate={validate}
-        defaultEntry={LoanPolicy.defaultLoanPolicy()}
-      />
+      <FormattedMessage id="ui-circulation.settings.loanPolicy.entryLabel">
+        { entryLabel => (
+          <EntryManager
+            {...this.props}
+            parentMutator={mutator}
+            parentResources={resources}
+            entryList={entryList}
+            resourceKey="loanPolicies"
+            detailComponent={LoanPolicyDetail}
+            entryFormComponent={LoanPolicyForm}
+            paneTitle={<FormattedMessage id="ui-circulation.settings.loanPolicy.paneTitle" />}
+            entryLabel={entryLabel}
+            nameKey="name"
+            permissions={permissions}
+            validate={validate}
+            defaultEntry={LoanPolicy.defaultLoanPolicy()}
+          />
+        )}
+      </FormattedMessage>
     );
   }
 }


### PR DESCRIPTION
The entryLabel prop will later be fed through a component where it must
be a string, not a React element or object. Make it so.

Fixes [UICIRC-134](https://issues.folio.org/browse/UICIRC-134)