### PR TITLE
Adjust staff slip permissions. Part of UICIRC-194

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -170,4 +170,9 @@ export const requestNoticesSendWhen = [
   { value: requestNoticesSendWhenMap.REQUEST_CANCELATION, label: 'ui-circulation.settings.noticePolicy.requestNotices.requestCancelation' },
 ];
 
+export const staffSlipMap = {
+  HOLD: 'Hold',
+  TRANSIT: 'Transit',
+};
+
 export default '';

--- a/src/settings/StaffSlips/StaffSlipForm.js
+++ b/src/settings/StaffSlips/StaffSlipForm.js
@@ -20,6 +20,7 @@ import { Field } from 'redux-form';
 
 import StaffSlipEditor from './StaffSlipEditor';
 import formats from './formats';
+import { staffSlipMap } from '../../constants';
 
 class StaffSlipForm extends React.Component {
   static propTypes = {
@@ -107,7 +108,7 @@ class StaffSlipForm extends React.Component {
   render() {
     const { stripes, handleSubmit, initialValues } = this.props;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
-    const slipType = (initialValues || {}).name || <FormattedMessage id="ui-circulation.settings.staffSlips.hold" />;
+    const slipType = (initialValues || {}).name || staffSlipMap.HOLD;
 
     return (
       <form id="form-staff-slip" onSubmit={handleSubmit(this.save)}>

--- a/src/settings/StaffSlips/StaffSlipManager.js
+++ b/src/settings/StaffSlips/StaffSlipManager.js
@@ -84,8 +84,8 @@ class StaffSlipManager extends React.Component {
         nameKey="name"
         permissions={{
           put: 'ui-circulation.settings.staff-slips',
-          post: 'ui-circulation.settings.staff-slips',
-          delete: 'ui-circulation.settings.staff-slips',
+          post: 'ui-circulation.settings.staff-slips.post',
+          delete: 'ui-circulation.settings.staff-slips.delete'
         }}
       />
     );


### PR DESCRIPTION
This PR adjusts the CRUD permissions for Staff Slips. Both:

- ui-circulation.settings.staff-slips.post
- ui-circulation.settings.staff-slips.delete

don't exist in the system yet but that's ok for now because adding custom slips is not supported yet. 

https://issues.folio.org/browse/UXPROD-1077