### PR TITLE
correctly format the dataOptions for a Select

### DIFF
--- a/src/settings/LoanPolicy/LoanPolicyForm.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.js
@@ -88,7 +88,7 @@ class LoanPolicyForm extends React.Component {
     );
 
     const sortedSchedules = sortBy(records, ['name']);
-    return sortedSchedules.map(({ id, name }) => (<option key={id} value={id}>{name}</option>));
+    return sortedSchedules.map(({ id, name }) => ({ value: id, label: name }));
   };
 
   saveForm = (loanPolicy) => {


### PR DESCRIPTION
`<Select>` accepts a `dataOptions` prop that expects to be an array of
key-value pairs with the props `value` and `label`. It was receiving,
instead, an array of `<option>` elements which caused rendered list to
show up as a series of empty `<option />`s. TBH, I'm not sure how this
ever worked.

Refs [STRIPES-602](https://issues.folio.org/browse/STRIPES-602)