### PR TITLE
Increase loan policy limit

### DIFF
--- a/src/settings/FixedDueDateScheduleManager.js
+++ b/src/settings/FixedDueDateScheduleManager.js
@@ -13,11 +13,13 @@ class FixedDueDateScheduleManager extends React.Component {
     fixedDueDateSchedules: {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
+      perRequest: 100,
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
     },
     loanPolicies: {
       type: 'okapi',
       records: 'loanPolicies',
+      perRequest: 100,
       path: 'loan-policy-storage/loan-policies',
       dataKey: 'loan-policies',
     },

--- a/src/settings/LoanPolicy/LoanPolicySettings.js
+++ b/src/settings/LoanPolicy/LoanPolicySettings.js
@@ -15,11 +15,13 @@ class LoanPolicySettings extends React.Component {
     loanPolicies: {
       type: 'okapi',
       records: 'loanPolicies',
+      perRequest: 100,
       path: 'loan-policy-storage/loan-policies',
     },
     fixedDueDateSchedules: {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
+      perRequest: 100,
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
       resourceShouldRefresh: true,
     },


### PR DESCRIPTION
While it would be ideal to implement pagination / infinite scroll here, that currently depends on the `EntryManager` component which is due to be refactored already so for now I've increased the maximum number of loan policies / fixed due date schedules returned in the first request to 100 from the default 10.