### PR TITLE
UICIRC-160: Change Patron Notice Description field.

### DIFF
--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -177,7 +177,6 @@ class PatronNoticeForm extends React.Component {
   // Synchronous validation functions
   requireName = value => (value ? undefined : <FormattedMessage id="ui-circulation.settings.patronNotices.errors.nameRequired" />);
   requireCategory = value => (value ? undefined : <FormattedMessage id="ui-circulation.settings.patronNotices.errors.categoryRequired" />);
-  requireDescription = value => (value ? undefined : <FormattedMessage id="ui-circulation.settings.patronNotices.errors.descriptionRequired" />);
 
   render() {
     const { handleSubmit, initialValues, pristine, submitting } = this.props;
@@ -226,7 +225,6 @@ class PatronNoticeForm extends React.Component {
                   name="description"
                   id="input-patron-notice-description"
                   component={TextArea}
-                  validate={this.requireDescription}
                 />
               </Col>
             </Row>

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -133,7 +133,6 @@
   "settings.patronNotices.body": "Body",
   "settings.patronNotices.errors.nameRequired": "Name is required",
   "settings.patronNotices.errors.categoryRequired": "Category is required",
-  "settings.patronNotices.errors.descriptionRequired": "Description is required",
   "settings.patronNotices.errors.nameExists": "A patron notice with this name already exists",
   "settings.patronNotices.closeDialog": "Close",
   "settings.patronNotices.editLabel": "Patron notices | {name}",


### PR DESCRIPTION
# Description
## Steps to repro:

1. Log into folio_snapshot
2. Go to Settings > Circulation > Patron Notices
3. Click to create a new notice
4. Attempt to save without specifiying a Patron notice description
5. Note Patron notice description is required
**Expected**: Description doesn't seem like it should be a required field. It isn't required in other forms (e.g. loan policies, fixed due date schedules, locations). If it is supposed to be required, it should have an asterisk to indicate it is required (see UICIRC-159 for similar bug)

**Actual**: Description is required