### PR TITLE
UCIRC-208 - Loan policies: can't un-select due date schedule

### DIFF
--- a/src/settings/LoanPolicy/LoanPolicyDetail.js
+++ b/src/settings/LoanPolicy/LoanPolicyDetail.js
@@ -262,7 +262,11 @@ class LoanPolicyDetail extends React.Component {
   }
 
   renderRenewals() {
-    const { initialValues: policy = {} } = this.props;
+    const {
+      initialValues: policy = {},
+      parentResources,
+    } = this.props;
+
     const unlimited = (get(policy, ['renewalsPolicy', 'unlimited']))
       ? <FormattedMessage id="ui-circulation.settings.loanPolicy.yes" />
       : <FormattedMessage id="ui-circulation.settings.loanPolicy.no" />;
@@ -272,6 +276,12 @@ class LoanPolicyDetail extends React.Component {
     const renewFromId = get(policy, ['renewalsPolicy', 'renewFromId'], renewFromIds.SYSTEM_DATE);
     const renewFrom = find(renewFromOptions, r => r.value === renewFromId);
     const interval = get(policy, ['renewalsPolicy', 'period', 'intervalId']);
+    const altRenewalScheduleLabel = policy.loanable && policy.loansPolicy.profileId === loanProfileMap.ROLLING
+      ? <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSDueDateLimit" />
+      : <FormattedMessage id="ui-circulation.settings.loanPolicy.view.altFDDSforRenewals" />;
+
+    const fixedDueDateSchedules = get(parentResources, 'fixedDueDateSchedules.records', []);
+    const schedule = fixedDueDateSchedules.find(s => s.id === policy.renewalsPolicy.alternateFixedDueDateScheduleId);
 
     return (
       <div data-test-loan-policy-detail-renewals-section>
@@ -346,6 +356,21 @@ class LoanPolicyDetail extends React.Component {
             </Col>
           </Row>
         </div>
+        }
+        {(policy.renewalsPolicy && policy.renewalsPolicy.differentPeriod) &&
+          <div>
+            <br />
+            <Row>
+              <Col xs={12}>
+                <div data-test-renewals-section-alternate-fixed-due-date-schedule-id>
+                  <KeyValue
+                    label={altRenewalScheduleLabel}
+                    value={get(schedule, ['name'], '-')}
+                  />
+                </div>
+              </Col>
+            </Row>
+          </div>
         }
         <hr />
       </div>

--- a/src/settings/LoanPolicy/LoanPolicyForm.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
 import { getFormValues } from 'redux-form';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 import {
   sortBy,
   get,
@@ -38,6 +42,7 @@ import { Metadata } from '../components';
 
 class LoanPolicyForm extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     stripes: stripesShape.isRequired,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
@@ -81,14 +86,32 @@ class LoanPolicyForm extends React.Component {
   };
 
   generateScheduleOptions = () => {
-    const records = get(
-      this.props,
-      'parentResources.fixedDueDateSchedules.records',
-      [],
+    const {
+      intl: {
+        formatMessage,
+      },
+    } = this.props;
+    const records = get(this.props, 'parentResources.fixedDueDateSchedules.records', []);
+    const sortedSchedules = sortBy(records, ['name']);
+
+    const placeholder = (
+      <option value="" key="x">
+        {formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' })}
+      </option>
     );
 
-    const sortedSchedules = sortBy(records, ['name']);
-    return sortedSchedules.map(({ id, name }) => ({ value: id, label: name }));
+    const schedules = sortedSchedules.map(({ id, name }) => {
+      return (
+        <option
+          value={id}
+          key={id}
+        >
+          {name}
+        </option>
+      );
+    });
+
+    return [placeholder, ...schedules];
   };
 
   saveForm = (loanPolicy) => {
@@ -200,7 +223,7 @@ const mapStateToProps = (state) => ({
   policy: new LoanPolicy(getFormValues('loanPolicyForm')(state)),
 });
 
-const connectedLoanPolicyForm = connect(mapStateToProps)(LoanPolicyForm);
+const connectedLoanPolicyForm = connect(mapStateToProps)(injectIntl(LoanPolicyForm));
 
 export default stripesForm({
   form: 'loanPolicyForm',

--- a/src/settings/LoanPolicy/components/EditSections/LoansSection/LoansSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/LoansSection/LoansSection.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
 
 import {
@@ -22,7 +22,6 @@ import {
 
 class LoansSection extends React.Component {
   static propTypes = {
-    intl: intlShape,
     policy: PropTypes.object.isRequired,
     schedules: PropTypes.arrayOf(PropTypes.node).isRequired,
     change: PropTypes.func.isRequired,
@@ -52,7 +51,6 @@ class LoansSection extends React.Component {
       policy,
       schedules,
       change,
-      intl: { formatMessage },
     } = this.props;
 
     const dueDateScheduleFieldLabel = policy.isProfileRolling()
@@ -113,9 +111,9 @@ class LoansSection extends React.Component {
               name="loansPolicy.fixedDueDateScheduleId"
               id="input_loansPolicy_fixedDueDateSchedule"
               component={Select}
-              placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' })}
-              dataOptions={schedules}
-            />
+            >
+              {schedules}
+            </Field>
           </div>
         }
         { policy.isLoanable() &&
@@ -159,7 +157,7 @@ class LoansSection extends React.Component {
   }
 }
 
-export default injectIntl(withSectionDefaults({
+export default withSectionDefaults({
   component: LoansSection,
   checkMethodName: 'shouldInitLoansPolicy',
   sectionsDefaults: {
@@ -173,4 +171,4 @@ export default injectIntl(withSectionDefaults({
     'loansPolicy.openingTimeOffset': { intervalId: intervalIdsMap.HOURS },
     'loansPolicy.gracePeriod': { intervalId: intervalIdsMap.HOURS },
   },
-}));
+});

--- a/src/settings/LoanPolicy/components/EditSections/RenewalsSection/RenewalsSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RenewalsSection/RenewalsSection.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
 
 import {
@@ -24,7 +20,6 @@ import {
 
 class RenewalsSection extends React.Component {
   static propTypes = {
-    intl: intlShape,
     policy: PropTypes.object.isRequired,
     schedules: PropTypes.arrayOf(PropTypes.node).isRequired,
     change: PropTypes.func.isRequired,
@@ -35,7 +30,6 @@ class RenewalsSection extends React.Component {
       policy,
       schedules,
       change,
-      intl: { formatMessage }
     } = this.props;
 
     if (!policy.isLoanable()) {
@@ -134,16 +128,15 @@ class RenewalsSection extends React.Component {
             </div>
           </React.Fragment>
         }
-        { policy.isRenewable() && policy.isDifferentPeriod()
-          && (policy.isProfileRolling() || policy.isProfileFixed()) &&
+        { policy.isRenewable() && policy.isDifferentPeriod() &&
           <div data-test-renewals-alternate-fixed-due-date-schedule>
             <Field
               label={altRenewalScheduleLabel}
               name="renewalsPolicy.alternateFixedDueDateScheduleId"
               component={Select}
-              placeholder={formatMessage({ id: 'ui-circulation.settings.loanPolicy.selectSchedule' })}
-              dataOptions={schedules}
-            />
+            >
+              {schedules}
+            </Field>
           </div>
         }
         <hr />
@@ -152,9 +145,9 @@ class RenewalsSection extends React.Component {
   }
 }
 
-export default injectIntl(withSectionDefaults({
+export default withSectionDefaults({
   component: RenewalsSection,
   checkMethodName: 'shouldInitRenewalsPolicy',
   sectionsDefaults: { 'renewalsPolicy': defaultLoanPolicy.renewalsPolicy },
   dropdownDefaults: { 'renewalsPolicy.period': { intervalId: intervalIdsMap.DAYS } }
-}));
+});

--- a/src/settings/LoanPolicy/utils/normalize.js
+++ b/src/settings/LoanPolicy/utils/normalize.js
@@ -129,7 +129,27 @@ const checkRenewFrom = (policy) => {
 
   if (isProfileFixed) {
     unset(loanPolicy, 'renewalsPolicy.renewFromId');
+    unset(loanPolicy, 'renewalsPolicy.period');
   }
+
+  return loanPolicy;
+};
+
+const checkSchedules = (policy) => {
+  const loanPolicy = cloneDeep(policy);
+
+  const schedulesList = [
+    'loansPolicy.fixedDueDateScheduleId',
+    'renewalsPolicy.alternateFixedDueDateScheduleId',
+  ];
+
+  forEach(schedulesList, (path) => {
+    const scheduleId = get(loanPolicy, path);
+
+    if (isEmpty(scheduleId)) {
+      unset(loanPolicy, path);
+    }
+  });
 
   return loanPolicy;
 };
@@ -155,6 +175,7 @@ export const normalize = (entity) => {
     checkLoanable,
     checkInvalidPeriods,
     checkRequestManagementSection,
+    checkSchedules,
   ];
 
   return filter(entity, ...callbacks);

--- a/test/bigtest/interactors/loan-policy/loan-policy-detail.js
+++ b/test/bigtest/interactors/loan-policy/loan-policy-detail.js
@@ -34,6 +34,7 @@ import KeyValue from '../KeyValue';
   numRenewalsAllowed = new KeyValue('[data-test-renewals-section-number-renewals-allowed] div');
   renewalPeriodDifferent = new KeyValue('[data-test-renewals-section-renewal-period-different] div');
   alternateLoanPeriodRenewals = new KeyValue('[data-test-renewals-section-alternate-loan-period-renewals] div');
+  alternateFixedDueDateScheduleId = new KeyValue('[data-test-renewals-section-alternate-fixed-due-date-schedule-id] div');
 }
 
 @interactor class RequestManagementSection {

--- a/test/bigtest/tests/loan-policy/loan-policy-detail-test.js
+++ b/test/bigtest/tests/loan-policy/loan-policy-detail-test.js
@@ -434,6 +434,51 @@ describe('LoanPolicyDetail', () => {
             );
           });
         });
+
+        describe('alternate fixed due date schedule id', () => {
+          it('should be displayed', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.isPresent).to.be.true;
+          });
+
+          it('should have a proper label', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.label.text).to.equal(translation['settings.loanPolicy.altFDDSDueDateLimit']);
+          });
+
+          it('should have a proper value', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.value.text).to.equal('-');
+          });
+        });
+      });
+
+      describe('loan policy:\n\t-renewable\n\t-loanable\n\t-different period\n\t-fixed\n', () => {
+        beforeEach(function () {
+          loanPolicy = this.server.create('loanPolicy', {
+            renewable: true,
+            loanable: true,
+            loansPolicy: {
+              profileId: loanProfileMap.FIXED,
+            },
+            renewalsPolicy: {
+              differentPeriod: true,
+            }
+          });
+
+          this.visit(`/settings/circulation/loan-policies/${loanPolicy.id}`);
+        });
+
+        describe('Alternate fixed due date schedule for renewals', () => {
+          it('should be displayed', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.isPresent).to.be.true;
+          });
+
+          it('should have a proper label', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.label.text).to.equal(translation['settings.loanPolicy.view.altFDDSforRenewals']);
+          });
+
+          it('should have a proper value', () => {
+            expect(LoanPolicyDetail.renewalsSection.alternateFixedDueDateScheduleId.value.text).to.equal('-');
+          });
+        });
       });
 
       describe('loan policy:\n\t-renewable\n\t-loanable\n\t-same period\n\t-rolling\n', () => {

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -25,6 +25,7 @@
   "settings.loanPolicy.fDDS": "Fixed due date schedule",
   "settings.loanPolicy.fDDSlimit": "Fixed due date schedule (due date limit)",
   "settings.loanPolicy.closedDueDateMgmt": "Closed library due date management",
+  "settings.loanPolicy.view.altFDDSforRenewals": "Alternate fixed due date schedule for renewals",
   "settings.loanPolicy.altFDDSforRenewals": "Alternate fixed due date schedule for renewals *",
   "settings.loanPolicy.altFDDSDueDateLimit": "Alternate fixed due date schedule (due date limit) for renewals",
   "settings.loanPolicy.alternateLoanPeriodExisting": "Alternate loan period for items with existing requests",


### PR DESCRIPTION
# Purpose
- Add ability to uncheck selected value for select component.
- Add missed schedule name value on loan policy view screen.

# Link
https://issues.folio.org/browse/UICIRC-208

# Screenshots
<img width="1435" alt="Screen Shot 2019-03-19 at 10 23 21" src="https://user-images.githubusercontent.com/43472449/54590559-0c328080-4a31-11e9-948d-f64aee87fcbc.png">
<img width="494" alt="Screen Shot 2019-03-19 at 10 24 12" src="https://user-images.githubusercontent.com/43472449/54590611-2b311280-4a31-11e9-923a-6c65172f8822.png">



