### PR TITLE
Set the appropriate initial state of the flag on the Staff slip form,…

### DIFF
--- a/src/settings/StaffSlips/StaffSlipForm.js
+++ b/src/settings/StaffSlips/StaffSlipForm.js
@@ -133,6 +133,7 @@ class StaffSlipForm extends React.Component {
                   label={<FormattedMessage id="ui-circulation.settings.staffSlips.active" />}
                   name="active"
                   id="input-staff-slip-active"
+                  type="checkbox"
                   component={Checkbox}
                   disabled={disabled}
                 />


### PR DESCRIPTION
… refs UICIRC-171, UICIRC-172

- Checkbox when used via redux-form needs to be passed type="checkbox" so that the checked prop is actually passed down to the input.