### PR TITLE
UICIRC-229 - Added cancel button to actions menu on notice policy edit page.

### DIFF
--- a/src/settings/NoticePolicy/components/HeaderPane/HeaderPane.js
+++ b/src/settings/NoticePolicy/components/HeaderPane/HeaderPane.js
@@ -33,26 +33,43 @@ class HeaderPane extends React.Component {
   renderActionMenuItems = ({ onToggle }) => {
     const {
       permissions,
+      onCancel,
       onRemove,
     } = this.props;
 
-    const handleClick = () => {
+    const handleDeleteClick = () => {
       onRemove(true);
       onToggle();
     };
 
+    const handleCancelClick = (e) => {
+      onCancel(e);
+      onToggle();
+    };
+
     return (
-      <IfPermission perm={permissions.delete}>
+      <React.Fragment>
         <Button
           data-test-cancel-user-form-action
           buttonStyle="dropdownItem"
-          onClick={handleClick}
+          onClick={handleCancelClick}
         >
-          <Icon icon="trash">
-            <FormattedMessage id="ui-circulation.settings.common.delete" />
+          <Icon icon="times">
+            <FormattedMessage id="ui-circulation.settings.common.cancel" />
           </Icon>
         </Button>
-      </IfPermission>
+        <IfPermission perm={permissions.delete}>
+          <Button
+            data-test-delete-user-form-action
+            buttonStyle="dropdownItem"
+            onClick={handleDeleteClick}
+          >
+            <Icon icon="trash">
+              <FormattedMessage id="ui-circulation.settings.common.delete" />
+            </Icon>
+          </Button>
+        </IfPermission>
+      </React.Fragment>
     );
   };
 

--- a/test/bigtest/interactors/notice-policy/notice-policy-form.js
+++ b/test/bigtest/interactors/notice-policy/notice-policy-form.js
@@ -71,6 +71,8 @@ import Period from '../Period';
   deleteNoticePolicyModal = new Interactor('#delete-item-confirmation');
   deleteNoticePolicyCancel= new Interactor('[data-test-confirmation-modal-cancel-button]');
   deleteNoticePolicyConfirm = new Interactor('[data-test-confirmation-modal-confirm-button]');
+  cancelEditingNoticePolicy = new Interactor('[data-test-cancel-user-form-action]');
+  cancelEditingNoticePolicyModal = new Interactor('#cancel-editing-confirmation');
 
   save = clickable('#clickable-save-entry');
   expandAll = scoped('[data-test-expand-all] button')

--- a/test/bigtest/interactors/notice-policy/notice-policy-form.js
+++ b/test/bigtest/interactors/notice-policy/notice-policy-form.js
@@ -67,7 +67,7 @@ import Period from '../Period';
   generalSection = new GeneralSection();
   loanNoticesSection = new NoticesSection('[data-test-notice-policy-form-loan-notices-section]');
   requestNoticesSection = new NoticesSection('[data-test-notice-policy-form-request-notices-section]');
-  deleteNoticePolicy = new Interactor('[data-test-cancel-user-form-action]');
+  deleteNoticePolicy = new Interactor('[data-test-delete-user-form-action]');
   deleteNoticePolicyModal = new Interactor('#delete-item-confirmation');
   deleteNoticePolicyCancel= new Interactor('[data-test-confirmation-modal-cancel-button]');
   deleteNoticePolicyConfirm = new Interactor('[data-test-confirmation-modal-confirm-button]');

--- a/test/bigtest/tests/notice-policy/notice-policy-edit-test.js
+++ b/test/bigtest/tests/notice-policy/notice-policy-edit-test.js
@@ -57,5 +57,26 @@ describe('NoticePolicyEdit', () => {
         expect(NoticePolicyDetail.generalSection.name.value.text).to.equal(newNoticePolicyName);
       });
     });
+
+    describe('Cancel editing for pristine form ', () => {
+      beforeEach(async () => {
+        await NoticePolicyForm.cancelEditingNoticePolicy.click();
+      });
+
+      it('should not show cancel editing confirmation', () => {
+        expect(NoticePolicyForm.cancelEditingNoticePolicyModal.isPresent).to.be.false;
+      });
+    });
+
+    describe('Cancel editing on dirty form', () => {
+      beforeEach(async () => {
+        await NoticePolicyForm.generalSection.policyName.fillAndBlur(newNoticePolicyName);
+        await NoticePolicyForm.cancelEditingNoticePolicy.click();
+      });
+
+      it('should show cancel editing confirmation', () => {
+        expect(NoticePolicyForm.cancelEditingNoticePolicyModal.isPresent).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
# Purpose
To add an ability to cancel editing mode from actions menu.

# Link
https://issues.folio.org/browse/UICIRC-229

# Screenshots
<img width="1432" alt="Screen Shot 2019-04-02 at 11 07 25" src="https://user-images.githubusercontent.com/43472449/55386878-15474580-5539-11e9-9a52-d409e0c7fca6.png">


