### PR TITLE
UICIRC-143 - added actions menu for patron notice templates edit page.

### DIFF
--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -251,7 +251,10 @@ class PatronNoticeForm extends React.Component {
             {... editMode ? { actionMenu: this.renderActionMenuItems } : {}}
           >
             <Row>
-              <Col xs={8}>
+              <Col
+                xs={8}
+                data-test-patron-notice-template-name
+              >
                 <Field
                   label={<FormattedMessage id="ui-circulation.settings.patronNotices.notice.name" />}
                   name="name"
@@ -358,6 +361,7 @@ class PatronNoticeForm extends React.Component {
               </Row>
             }
             <ConfirmationModal
+              id="delete-item-confirmation"
               open={this.state.confirming}
               heading={<FormattedMessage id="ui-circulation.settings.patronNotices.deleteHeading" />}
               message={<FormattedMessage id="ui-circulation.settings.patronNotices.deleteConfirm" />}

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -21,8 +21,10 @@ import {
   Select,
   TextArea,
   TextField,
+  Icon,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
+import { IfPermission } from '@folio/stripes/core';
 
 import PatronNoticeEditor from './PatronNoticeEditor';
 // import PreviewModal from './PreviewModal';
@@ -69,6 +71,7 @@ class PatronNoticeForm extends React.Component {
     onSave: PropTypes.func,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
+    permissions: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -174,13 +177,54 @@ class PatronNoticeForm extends React.Component {
     );
   }
 
+  renderActionMenuItems = ({ onToggle }) => {
+    const {
+      permissions,
+      onCancel,
+    } = this.props;
+
+    const handleDeleteClick = () => {
+      this.showConfirm();
+      onToggle();
+    };
+
+    const handleCancelClick = (e) => {
+      onCancel(e);
+      onToggle();
+    };
+
+    return (
+      <React.Fragment>
+        <Button
+          data-test-cancel-patron-notice-form-action
+          buttonStyle="dropdownItem"
+          onClick={handleCancelClick}
+        >
+          <Icon icon="times">
+            <FormattedMessage id="ui-circulation.settings.common.cancel" />
+          </Icon>
+        </Button>
+        <IfPermission perm={permissions.delete}>
+          <Button
+            data-test-delete-patron-notice-form-action
+            buttonStyle="dropdownItem"
+            onClick={handleDeleteClick}
+          >
+            <Icon icon="trash">
+              <FormattedMessage id="ui-circulation.settings.common.delete" />
+            </Icon>
+          </Button>
+        </IfPermission>
+      </React.Fragment>
+    );
+  };
+
   // Synchronous validation functions
   requireName = value => (value ? undefined : <FormattedMessage id="ui-circulation.settings.patronNotices.errors.nameRequired" />);
   requireCategory = value => (value ? undefined : <FormattedMessage id="ui-circulation.settings.patronNotices.errors.categoryRequired" />);
 
   render() {
-    const { handleSubmit, initialValues, pristine, submitting } = this.props;
-    const { confirming } = this.state;
+    const { handleSubmit, initialValues = {} } = this.props;
     const category = initialValues && initialValues.category;
     const isActive = initialValues && initialValues.active;
     const sortedCategories = sortBy(categories, ['label']);
@@ -190,6 +234,8 @@ class PatronNoticeForm extends React.Component {
       selected: category === id
     }));
 
+    const editMode = Boolean(initialValues.id);
+
     return (
       <form
         id="form-patron-notice"
@@ -197,7 +243,13 @@ class PatronNoticeForm extends React.Component {
         onSubmit={handleSubmit(this.save)}
       >
         <Paneset isRoot>
-          <Pane defaultWidth="100%" paneTitle={this.renderPaneTitle()} firstMenu={this.renderCLoseIcon()} lastMenu={this.renderSaveMenu()}>
+          <Pane
+            defaultWidth="100%"
+            paneTitle={this.renderPaneTitle()}
+            firstMenu={this.renderCLoseIcon()}
+            lastMenu={this.renderSaveMenu()}
+            {... editMode ? { actionMenu: this.renderActionMenuItems } : {}}
+          >
             <Row>
               <Col xs={8}>
                 <Field
@@ -298,22 +350,6 @@ class PatronNoticeForm extends React.Component {
                 </Row>
               </Accordion> */}
             </AccordionSet>
-            {initialValues && initialValues.id &&
-              <Row>
-                <Col xs={8}>
-                  <Button
-                    id="clickable-delete-patron-notice"
-                    type="button"
-                    buttonStyle="danger"
-                    onClick={this.showConfirm}
-                    marginBottom0
-                    disabled={!pristine || submitting || confirming || (initialValues && initialValues.predefined)}
-                  >
-                    <FormattedMessage id="ui-circulation.settings.patronNotices.deleteLabel" />
-                  </Button>
-                </Col>
-              </Row>
-            }
             { initialValues && initialValues.predefined &&
               <Row>
                 <Col xs={8}>

--- a/test/bigtest/interactors/patron-notice/patron-notice-form.js
+++ b/test/bigtest/interactors/patron-notice/patron-notice-form.js
@@ -1,12 +1,24 @@
 import {
   interactor,
   scoped,
+  Interactor,
 } from '@bigtest/interactor';
+
+import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
 
 @interactor class PatronNoticeForm {
   static defaultScope = ('[data-test-patron-notice-form]');
 
-  expandAll = scoped('[data-test-expand-all] button')
+  whenLoaded() {
+    return this.when(() => this.templateName.isPresent);
+  }
+
+  expandAll = scoped('[data-test-expand-all] button');
+  templateName = new TextFieldInteractor('[data-test-patron-notice-template-name]');
+  deletePatronNoticeTemplate = new Interactor('[data-test-delete-patron-notice-form-action]');
+  deletePatronNoticeTemplateModal = new Interactor('#delete-item-confirmation');
+  cancelEditingPatronNoticeTemplate = new Interactor('[data-test-cancel-patron-notice-form-action]');
+  cancelEditingPatronNoticeTempateModal = new Interactor('#cancel-editing-confirmation');
 }
 
 export default new PatronNoticeForm();

--- a/test/bigtest/tests/patron-notice/patron-notice-edit-test.js
+++ b/test/bigtest/tests/patron-notice/patron-notice-edit-test.js
@@ -1,0 +1,55 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../../helpers/setup-application';
+import PatronNoticeForm from '../../interactors/patron-notice/patron-notice-form';
+
+describe('Patron notice edit', () => {
+  setupApplication();
+
+  describe('updating an existing notice policy', () => {
+    let patronNoticeTemplate;
+    const newPatronNoticeTemplateName = 'newPatronNoticeTemplateName';
+
+    beforeEach(async function () {
+      patronNoticeTemplate = this.server.create('templates', { category: 'Loan' });
+      await this.visit(`/settings/circulation/patron-notices/${patronNoticeTemplate.id}?layer=edit`);
+      await PatronNoticeForm.whenLoaded();
+    });
+
+    describe('Cancel editing for pristine form ', () => {
+      beforeEach(async () => {
+        await PatronNoticeForm.cancelEditingPatronNoticeTemplate.click();
+      });
+
+      it('should not show cancel editing confirmation', () => {
+        expect(PatronNoticeForm.cancelEditingPatronNoticeTempateModal.isPresent).to.be.false;
+      });
+    });
+
+    describe('Cancel editing on dirty form', () => {
+      beforeEach(async () => {
+        await PatronNoticeForm.templateName.fillAndBlur(newPatronNoticeTemplateName);
+        await PatronNoticeForm.cancelEditingPatronNoticeTemplate.click();
+      });
+
+      it('should show cancel editing confirmation', () => {
+        expect(PatronNoticeForm.cancelEditingPatronNoticeTempateModal.isPresent).to.be.true;
+      });
+    });
+
+    describe('Delete patron notice template', () => {
+      beforeEach(async () => {
+        await PatronNoticeForm.deletePatronNoticeTemplate.click();
+      });
+
+      it('should display confirmation modal delete modal', () => {
+        expect(PatronNoticeForm.deletePatronNoticeTemplateModal.isPresent).to.be.true;
+      });
+    });
+  });
+});

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -141,7 +141,6 @@
   "settings.patronNotices.newLabel": "New patron notice",
   "settings.patronNotices.saveLabel": "Save",
   "settings.patronNotices.saveNewLabel": "Save new",
-  "settings.patronNotices.deleteLabel": "Delete this notice",
   "settings.patronNotices.deleteHeading": "Confirm delete",
   "settings.patronNotices.deleteConfirm": "Are you sure you want to delete this patron notice?",
   "settings.patronNotices.predefinedWarning": "This is a predefined notice and cannot be deleted",


### PR DESCRIPTION
# Purpose
To add action menu for edit page of patron notice templates.
To remove delete patron notice template button from the bottom of the page.

# Link
https://issues.folio.org/browse/UICIRC-143

# Screenshots
<img width="1062" alt="Screen Shot 2019-04-04 at 13 29 57" src="https://user-images.githubusercontent.com/43472449/55549195-f635e880-56dd-11e9-9545-0447d90c5650.png">
