### PR TITLE
Fix regex for the last item in each rule. Part of UICIRC-210

### DIFF
--- a/src/settings/CirculationRules.js
+++ b/src/settings/CirculationRules.js
@@ -181,8 +181,9 @@ class CirculationRules extends React.Component {
     const records = this.getRecords();
     return records.reduce((memo, r) => {
       // eslint-disable-next-line no-useless-escape
-      const re = new RegExp(`(${r.prefix}\\s+)(${r.name})(?=\\s+[g\s+|m\s+|t\s+|l\s+|r\s+|n\s+|:\s*])`, 'igm');
-      return memo.replace(re, `$1${r.id}`);
+      const re = new RegExp(`(${r.prefix}\\s+)(${r.name})(?=\\s+[g\s+|m\s+|t\s+|l\s+|r\s+|n\s+|:\s*])?`, 'igm');
+      const result = memo.replace(re, `$1${r.id}`);
+      return result;
     }, rulesStr);
   }
 


### PR DESCRIPTION
@zburke started seeing issues with integration tests. It looks like the last item in each rule was not correctly converted to UUID. This PR is trying to address it which hopefully makes the tests happy again.