### PR TITLE
provide IDs for loan-policy's action menu buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 * Eject from deprecated Settings component and demonstrate new routing guidelines. UICIRC-201.
+* Provide IDs for loan-policy's actionmenu buttons. Refs UICIRC-237.
 
 ## [1.6.0](https://github.com/folio-org/ui-circulation/tree/v1.6.0) (2019-03-17)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.5.0...v1.6.0)

--- a/src/settings/LoanPolicy/components/HeaderPane/HeaderPane.js
+++ b/src/settings/LoanPolicy/components/HeaderPane/HeaderPane.js
@@ -83,6 +83,7 @@ class HeaderPane extends React.Component {
         <Button
           data-test-cancel-loan-policy-form-action
           buttonStyle="dropdownItem"
+          id="dropdown-clickable-cancel-item"
           onClick={handleCancelClick}
         >
           <Icon icon="times">
@@ -93,6 +94,7 @@ class HeaderPane extends React.Component {
           <Button
             data-test-delete-loan-policy-form-action
             buttonStyle="dropdownItem"
+            id="dropdown-clickable-delete-item"
             onClick={handleDeleteClick}
           >
             <Icon icon="trash">


### PR DESCRIPTION
It's much easier to write integration tests when page elements have
unique IDs.

Refs [UICIRC-237](https://issues.folio.org/browse/UICIRC-237)