### PR TITLE
UICIRC-185 - Not allow user to delete patron notice template if currently in use

### DIFF
--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -390,8 +390,8 @@ class PatronNoticeForm extends React.Component {
             { editMode &&
               <EntityInUseModal
                 isOpen={showEntityInUseModal}
-                labelTranslationKey="ui-circulation.settings.noticePolicy.denyDelete.header"
-                contentTranslationKey="ui-circulation.settings.noticePolicy.denyDelete.body"
+                labelTranslationKey="ui-circulation.settings.patronNotices.denyDelete.header"
+                contentTranslationKey="ui-circulation.settings.patronNotices.denyDelete.body"
                 onClose={this.changeEntityInUseState}
               />
             }

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -22,6 +22,11 @@ class PatronNotices extends React.Component {
       entries: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
+      patronNoticePolicies: PropTypes.shape({
+        entries: PropTypes.shape({
+          records: PropTypes.arrayOf(PropTypes.object),
+        }),
+      }),
     }).isRequired,
     mutator: PropTypes.shape({
       entries: PropTypes.shape({

--- a/src/settings/components/TemplateEditor/TokensModal/TokensModal.js
+++ b/src/settings/components/TemplateEditor/TokensModal/TokensModal.js
@@ -88,7 +88,7 @@ const TokensModal = (props) => {
 
 TokensModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  tokens: PropTypes.arrayOf(PropTypes.string),
+  tokens: PropTypes.object.isRequired,
   list: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   onAdd: PropTypes.func.isRequired,

--- a/test/bigtest/interactors/patron-notice/patron-notice-form.js
+++ b/test/bigtest/interactors/patron-notice/patron-notice-form.js
@@ -36,6 +36,7 @@ import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/i
   deletePatronNoticeTemplateModal = new Interactor('#delete-item-confirmation');
   cancelEditingPatronNoticeTemplate = new Interactor('[data-test-cancel-patron-notice-form-action]');
   cancelEditingPatronNoticeTempateModal = new Interactor('#cancel-editing-confirmation');
+  prohibitDeletion = new Interactor('[data-test-entity-in-use-modal]');
 
   templateBody = new Interactor('#template-editor');
   errorContainer = new Interactor('#patron-notice-error-container');

--- a/test/bigtest/tests/patron-notice/patron-notice-delete-test.js
+++ b/test/bigtest/tests/patron-notice/patron-notice-delete-test.js
@@ -1,0 +1,49 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../../helpers/setup-application';
+import PatronNoticeForm from '../../interactors/patron-notice/patron-notice-form';
+
+describe('Patron notice - prohibit deletion', () => {
+  setupApplication();
+
+  describe('Edit page - delete', () => {
+    beforeEach(async function () {
+      const patronNoticeTemplate = this.server.create('templates', { category: 'Loan' });
+      this.server.create('patronNoticePolicy', {
+        active: true,
+        loanNotices: [{
+          name: 'mockName',
+          templateId: patronNoticeTemplate.id,
+          templateName: 'mockTemplateName',
+          format: 'Email',
+          frequency: 'Recurring',
+          realTime: true,
+          sendOptions: {
+            sendHow: 'After',
+            sendWhen: 'Due date',
+            sendBy: {
+              duration: 2,
+              intervalId: 'Hours'
+            },
+            sendEvery: {
+              duration: 2,
+              intervalId: 'Hours'
+            }
+          }
+        }],
+      });
+      await this.visit(`/settings/circulation/patron-notices/${patronNoticeTemplate.id}?layer=edit`);
+      await PatronNoticeForm.whenLoaded();
+      await PatronNoticeForm.deletePatronNoticeTemplate.click();
+    });
+
+    it('should display prohibit item deletion modal', () => {
+      expect(PatronNoticeForm.prohibitDeletion.isPresent).to.be.true;
+    });
+  });
+});

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -163,8 +163,7 @@
   "settings.patronNotices.form.previewHeader": "Preview of patron notice template",
   "settings.patronNotices.view.previewHeader": "Preview of patron notice template - {name}",
   "settings.patronNotices.denyDelete.header": "Cannot delete Patron notice template",
-  "settings.patronNotices.denyDelete.body": "This Notice policy template cannot be deleted, as it is in use by one or more records.",
-
+  "settings.patronNotices.denyDelete.body": "This Patron notice template cannot be deleted, as it is in use by one or more records.",
 
   "settings.staffSlips.label": "Staff slips",
   "settings.staffSlips.name": "Name",

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -162,6 +162,9 @@
   "settings.patronNotices.loanTokenHeader": "Loan",
   "settings.patronNotices.form.previewHeader": "Preview of patron notice template",
   "settings.patronNotices.view.previewHeader": "Preview of patron notice template - {name}",
+  "settings.patronNotices.denyDelete.header": "Cannot delete Patron notice template",
+  "settings.patronNotices.denyDelete.body": "This Notice policy template cannot be deleted, as it is in use by one or more records.",
+
 
   "settings.staffSlips.label": "Staff slips",
   "settings.staffSlips.name": "Name",


### PR DESCRIPTION
# Purpose
- to prohibit user to delete patron notice template if it's currently in use

# Link
https://issues.folio.org/browse/UICIRC-185

# Screenshots
<img width="1440" alt="Screen Shot 2019-05-24 at 14 22 21" src="https://user-images.githubusercontent.com/43472449/58324421-7ac7fc00-7e2f-11e9-8219-5efb31be093b.png">
<img width="1424" alt="Screen Shot 2019-05-24 at 14 22 34" src="https://user-images.githubusercontent.com/43472449/58324422-7ac7fc00-7e2f-11e9-8fdf-89538542954a.png">


