### PR TITLE
UIORG-169: Create settings to anonymize closed loans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update to pane header to include dropdown menu for loan policies. UICIRC-226.
 * Update to pane header to include "Cancel" option in dropdown menu for notice policy. UICIRC-229.
 * Bug fixes: UICIRC-159, UICIRC-160, UICIRC-171, UICIRC-172, UICIRC-175, UICIRC-208, UICIRC-210, UICIRC-216, UICIRC-223, UICIRC-231, UICIRC-232.
+* Create settings in UI for users to anonymize closed loans. UIORG-169.
 
 ## [1.6.0](https://github.com/folio-org/ui-circulation/tree/v1.6.0) (2019-03-17)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.5.0...v1.6.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -297,4 +297,23 @@ export const patronNoticeCategories = [
   },
 ];
 
+export const closingTypesMap = {
+  IMMEDIATELY: 'immediately',
+  INTERVAL: 'interval',
+  NEVER: 'never',
+};
+
+export const closingTypes = [
+  { label: 'Immediately after loan closes', value: 'immediately' },
+  { label: 'After interval after loan closes', value: 'interval' },
+  { label: 'Never', value: 'never' },
+];
+
+export const intervalTypes = [
+  { value: 'Select interval', label: 'Select interval' },
+  { value: 'Day(s)', label: 'Day(s)' },
+  { value: 'Week(s)', label: 'Week(s)' },
+  { value: 'Month(s)', label: 'Month(s)' }
+];
+
 export default '';

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Route, Switch } from '@folio/stripes/core';
 
 import Settings from './settings';
+import LoanHistory from './settings/LoanHistory/LoanHistory';
 import LoanPolicySettings from './settings/LoanPolicy/LoanPolicySettings';
 import CirculationRules from './settings/CirculationRules';
 import RequestCancellationReasons from './settings/RequestCancellationReasons';
@@ -14,6 +15,12 @@ import NoticePolicySettings from './settings/NoticePolicy';
 import RequestPolicySettings from './settings/RequestPolicy';
 
 export const settingsRoutes = [
+  {
+    route: 'loan-history',
+    label: 'ui-circulation.settings.index.loanHistory',
+    component: LoanHistory,
+    perm: 'ui-circulation.settings.loan-history',
+  },
   {
     route: 'loan-policies',
     label: 'ui-circulation.settings.index.loanPolicies',

--- a/src/settings/LoanHistory/LoanHistory.js
+++ b/src/settings/LoanHistory/LoanHistory.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormattedMessage,
+  injectIntl
+} from 'react-intl';
+import {
+  stripesShape,
+  withStripes,
+} from '@folio/stripes/core';
+import { ConfigManager } from '@folio/stripes/smart-components';
+import {
+  isEmpty,
+  isInteger,
+} from 'lodash';
+
+import { closingTypesMap } from '../../constants';
+import LoanHistoryForm from './LoanHistoryForm';
+
+class LoanHistorySettings extends React.Component {
+  static propTypes = {
+    stripes: stripesShape.isRequired,
+    intl: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+    this.configManager = props.stripes.connect(ConfigManager);
+    this.formatMessage = props.intl.formatMessage;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getInitialValues = settings => {
+    const value = settings.length === 0 ? '' : settings[0].value;
+    const defaultConfig = {
+      closingType: '',
+      treatEnabled: false,
+      intervalType: this.formatMessage({ id: 'ui-circulation.settings.loanHistory.selectInterval' }),
+      intervalValue: ''
+    };
+    let config;
+
+    try {
+      config = { ...defaultConfig, ...JSON.parse(value) };
+    } catch (e) {
+      config = defaultConfig;
+    }
+
+    if (config.closingType !== closingTypesMap.INTERVAL) {
+      return defaultConfig;
+    }
+    return config;
+  }
+
+  validate = values => {
+    const errors = {};
+    const isIntervalValueValid = isInteger(+values.intervalValue) && +values.intervalValue > 0;
+    if (!isIntervalValueValid && (values.closingType === closingTypesMap.INTERVAL || !isEmpty(values.intervalValue))) {
+      errors.intervalValue = { _error: <FormattedMessage id="ui-circulation.settings.loanHistory.validate.intervalValue" /> };
+    }
+
+    const isIntervalTypeValid = values.intervalType !== this.formatMessage({ id: 'ui-circulation.settings.loanHistory.selectInterval' });
+    if (!isIntervalTypeValid && values.closingType === closingTypesMap.INTERVAL) {
+      errors.intervalType = { _error: <FormattedMessage id="ui-circulation.settings.loanHistory.validate.selectContinue" /> };
+    }
+    return errors;
+  }
+
+  render() {
+    return (
+      <this.configManager
+        label={<FormattedMessage id="ui-circulation.settings.index.loanHistory" />}
+        moduleName="LOAN_HISTORY"
+        configName="loan_history"
+        getInitialValues={this.getInitialValues}
+        validate={this.validate}
+        configFormComponent={LoanHistoryForm}
+        stripes={this.props.stripes}
+      />
+    );
+  }
+}
+
+export default injectIntl(withStripes(LoanHistorySettings));

--- a/src/settings/LoanHistory/LoanHistoryForm.css
+++ b/src/settings/LoanHistory/LoanHistoryForm.css
@@ -1,0 +1,10 @@
+.intervalSelector{
+  display: -webkit-inline-box;
+  margin: 0;
+}
+.paddingLeft0{
+  padding-left: 0;
+}
+.error {
+  color: #900;
+}

--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -1,0 +1,159 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import stripesForm from '@folio/stripes/form';
+import {
+  Button,
+  Checkbox,
+  Col,
+  Pane,
+  Row,
+  Select,
+  TextField,
+  Headline,
+  RadioButton,
+} from '@folio/stripes/components';
+import {
+  Field,
+  FieldArray,
+} from 'redux-form';
+
+import {
+  closingTypes,
+  intervalTypes,
+} from '../../constants';
+import updateClosingTypes from '../utils/updateClosingTypes';
+import css from './LoanHistoryForm.css';
+
+class LoanHistoryForm extends Component {
+  onSave = data => this.props.onSubmit({ loan_history: JSON.stringify(data) });
+
+  getLastMenu = () => {
+    const { pristine, submitting } = this.props;
+    return (
+      <Button type="submit" disabled={pristine || submitting} id="clickable-loan-history-save-button" marginBottom0>
+        <FormattedMessage id="ui-circulation.settings.loanHistory.save" />
+      </Button>
+    );
+  }
+
+  renderIntervalSelector = () => (
+    <div className={css.intervalSelector}>
+      <Row>
+        <Col xs={3}>
+          <div data-test-interval-value-field>
+            <Field
+              id="intervalValue"
+              name="intervalValue"
+              marginBottom0
+              component={TextField}
+            />
+          </div>
+        </Col>
+        <Col xs={4}>
+          <div data-test-interval-type-field>
+            <Field
+              id="intervalType"
+              name="intervalType"
+              marginBottom0
+              component={Select}
+              dataOptions={intervalTypes}
+            />
+          </div>
+        </Col>
+        <Col xs={5}>
+          <FormattedMessage id="ui-circulation.settings.loanHistory.after" />
+        </Col>
+      </Row>
+    </div>
+  );
+
+  renderClosingTypes = ({ meta }) => {
+    const updatedClosingTypes = updateClosingTypes(
+      closingTypes,
+      { label: this.renderIntervalSelector(), value: 'interval' }
+    );
+    const items = updatedClosingTypes.map((type, index) => (
+      <Row key={`row-${index}`}>
+        <Col xs={12}>
+          <Field
+            component={RadioButton}
+            label={type.label}
+            name="closingType"
+            type="radio"
+            id={`${type.value}-radio-button`}
+            value={type.value}
+            labelClass={css.paddingLeft0}
+          />
+        </Col>
+      </Row>
+    ));
+
+    return (
+      <div>
+        <p>
+          <FormattedMessage id="ui-circulation.settings.loanHistory.anonymize" />
+        </p>
+        {items}
+        {meta.error && <div className={css.error}>{meta.error}</div>}
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      handleSubmit,
+      label,
+    } = this.props;
+
+    return (
+      <form id="loan-history-form" onSubmit={handleSubmit(this.onSave)}>
+        <Pane
+          defaultWidth="fill"
+          fluidContentWidth
+          paneTitle={label}
+          lastMenu={this.getLastMenu()}
+        >
+          <Headline
+            size="large"
+            margin="xx-large"
+            tag="h5"
+          >
+            <FormattedMessage id="ui-circulation.settings.loanHistory.closedLoans" />
+          </Headline>
+          <FieldArray
+            name="closingTypes"
+            component={this.renderClosingTypes}
+          />
+          <br />
+          <Row>
+            <Col xs={12}>
+              <Field
+                label={<FormattedMessage id="ui-circulation.settings.loanHistory.treat" />}
+                id="treatEnabled-checkbox"
+                name="treatEnabled-checkbox"
+                component={Checkbox}
+                type="checkbox"
+                normalize={v => !!v}
+              />
+            </Col>
+          </Row>
+        </Pane>
+      </form>
+    );
+  }
+}
+
+LoanHistoryForm.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  pristine: PropTypes.bool,
+  submitting: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+};
+
+export default stripesForm({
+  form: 'loanHistoryForm',
+  navigationCheck: true,
+  enableReinitialize: true,
+})(LoanHistoryForm);

--- a/src/settings/utils/updateClosingTypes.js
+++ b/src/settings/utils/updateClosingTypes.js
@@ -1,0 +1,8 @@
+export default (closingTypes, updatedType) => {
+  return closingTypes.map(type => {
+    if (type.value === updatedType.value) {
+      return updatedType;
+    }
+    return type;
+  });
+};

--- a/test/bigtest/interactors/loan-history/loan-history-form.js
+++ b/test/bigtest/interactors/loan-history/loan-history-form.js
@@ -1,0 +1,29 @@
+import {
+  interactor,
+  isPresent,
+  clickable,
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
+import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+import SelectInteractor from '@folio/stripes-components/lib/Select/tests/interactor';
+
+  @interactor class LoanHistoryForm {
+    isLoaded = isPresent('#never-radio-button');
+
+    whenLoaded() {
+      return this.when(() => this.isLoaded);
+    }
+
+    clickImmediatelyRadioButton = clickable('#immediately-radio-button');
+    clickIntervalRadioButton = clickable('#interval-radio-button');
+    clickNeverRadioButton = clickable('#never-radio-button');
+    clickTreatEnabledCheckbox = clickable('#treatEnabled-checkbox');
+    calloutIsPresent = isPresent('div[class^="calloutBase---"]');
+    save = clickable('#clickable-loan-history-save-button');
+    saveButton = new ButtonInteractor('#clickable-loan-history-save-button');
+    intervalValue = new TextFieldInteractor('[data-test-interval-value-field]');
+    intervalType = new SelectInteractor('[data-test-interval-type-field]');
+  }
+
+export default new LoanHistoryForm();

--- a/test/bigtest/tests/loan-history/loan-history-form-test.js
+++ b/test/bigtest/tests/loan-history/loan-history-form-test.js
@@ -1,0 +1,75 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../../helpers/setup-application';
+import LoanHistoryForm from '../../interactors/loan-history/loan-history-form';
+
+describe('Loan History Form', () => {
+  setupApplication();
+
+  beforeEach(function () {
+    this.visit('/settings/circulation/loan-history');
+  });
+
+  it('save button is present', () => {
+    expect(LoanHistoryForm.saveButton.isPresent).to.be.true;
+  });
+
+  describe('when click save button', () => {
+    beforeEach(async function () {
+      await LoanHistoryForm.whenLoaded();
+      await LoanHistoryForm
+        .clickImmediatelyRadioButton()
+        .clickIntervalRadioButton()
+        .clickNeverRadioButton()
+        .clickTreatEnabledCheckbox();
+
+      await LoanHistoryForm.save();
+    });
+
+    it('form successfully saves', () => {
+      expect(LoanHistoryForm.calloutIsPresent).to.be.true;
+    });
+  });
+
+  describe('when form is loaded', () => {
+    beforeEach(async () => {
+      await LoanHistoryForm.whenLoaded();
+      await LoanHistoryForm.clickIntervalRadioButton();
+    });
+
+    describe('and "interval closing type" field completely filled', () => {
+      beforeEach(async () => {
+        await LoanHistoryForm.intervalValue.fillAndBlur('2');
+        await LoanHistoryForm.intervalType.selectAndBlur('Week(s)');
+        await LoanHistoryForm.saveButton.click();
+      });
+
+      it('form successfully saves', () => {
+        expect(LoanHistoryForm.calloutIsPresent).to.be.true;
+      });
+    });
+
+    describe('when the interval value is empty', () => {
+      beforeEach(async () => {
+        await LoanHistoryForm.intervalType.selectAndBlur('Day(s)');
+        await LoanHistoryForm.saveButton.click();
+      });
+
+      it('form doesn\'t save', () => {
+        expect(LoanHistoryForm.calloutIsPresent).to.be.false;
+      });
+    });
+
+    describe('when the interval type is not selected', () => {
+      beforeEach(async () => {
+        await LoanHistoryForm.intervalValue.fillAndBlur('3');
+        await LoanHistoryForm.saveButton.click();
+      });
+
+      it('form doesn\'t save', () => {
+        expect(LoanHistoryForm.calloutIsPresent).to.be.false;
+      });
+    });
+  });
+});

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -2,6 +2,7 @@
   "meta.title": "Circulation",
 
   "settings.index.paneTitle": "Circulation",
+  "settings.index.loanHistory": "Loan history",
   "settings.index.loanPolicies": "Loan policies",
   "settings.index.circulationRules": "Circulation rules",
   "settings.index.fdds": "Fixed due date schedules",
@@ -275,5 +276,14 @@
   "settings.noticePolicy.loanNotices.renewed": "Renew",
   "settings.noticePolicy.loanNotices.checkIn": "Check in",
   "settings.noticePolicy.loanNotices.checkOut": "Check out",
-  "settings.noticePolicy.notices.andEvery": "and every"
+  "settings.noticePolicy.notices.andEvery": "and every",
+
+  "settings.loanHistory.validate.intervalValue": "Please enter a whole number greater than zero to continue",
+  "settings.loanHistory.validate.selectContinue": "Please select to continue",
+  "settings.loanHistory.selectInterval": "Select interval",
+  "settings.loanHistory.save": "Save",
+  "settings.loanHistory.closedLoans": "Closed loans",
+  "settings.loanHistory.anonymize": "Anonymize closed loans",
+  "settings.loanHistory.after": "after loan closes",
+  "settings.loanHistory.treat": "Treat closed loans with associated fee/fines differently"
 }


### PR DESCRIPTION
### Purpose
Create settings in UI for users to anonymize closed loans. [Story UIORG-169](https://issues.folio.org/browse/UIORG-169)

![Scenario-1,2](https://user-images.githubusercontent.com/49517355/58712179-bda64880-83c8-11e9-94b1-6389f0ac0f79.png)
![Scenario-3](https://user-images.githubusercontent.com/49517355/58712185-c0a13900-83c8-11e9-869d-c0cf852269a6.png)
![Scenario-4](https://user-images.githubusercontent.com/49517355/58712191-c434c000-83c8-11e9-8745-880a296db5cc.png)
![Scenario-5](https://user-images.githubusercontent.com/49517355/58712197-c5fe8380-83c8-11e9-906f-037c63382214.png)
