### PR TITLE
UICIRC-250 - Expand location-specific token list for patron notice templates

### DIFF
--- a/src/settings/PatronNotices/TokensList/TokensList.js
+++ b/src/settings/PatronNotices/TokensList/TokensList.js
@@ -51,6 +51,15 @@ class TokensList extends React.Component {
               />
             </Col>
           </Row>
+          <Row>
+            <Col xs={12}>
+              <TokensSection
+                header={<FormattedMessage id="ui-circulation.settings.patronNotices.effectiveLocationTokenHeader" />}
+                tokens={Object.keys(tokens.effectiveLocation)}
+                onSelect={onSelect}
+              />
+            </Col>
+          </Row>
         </Col>
         <Col xs={4}>
           <Row>

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -37,6 +37,12 @@ const formats = {
     'loan.numberOfRenewalsTaken': '2',
     'loan.numberOfRenewalsRemaining': '8',
   },
+  effectiveLocation: {
+    'item.effectiveLocationSpecific': 'Main Library Reserve',
+    'item.effectiveLocationLibrary': 'Main Library',
+    'item.effectiveLocationCampus': 'South Campus',
+    'item.effectiveLocationInstitution': 'Opentown University',
+  },
 };
 
 export default formats;

--- a/src/settings/components/TemplateEditor/TokensSection/TokensSection.css
+++ b/src/settings/components/TemplateEditor/TokensSection/TokensSection.css
@@ -6,7 +6,3 @@
   list-style-type: none;
   padding: 0;
 }
-
-label {
-  padding-left: 10px;
-}

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -163,6 +163,7 @@
   "settings.patronNotices.view.previewHeader": "Preview of patron notice template - {name}",
   "settings.patronNotices.denyDelete.header": "Cannot delete Patron notice template",
   "settings.patronNotices.denyDelete.body": "This Patron notice template cannot be deleted, as it is in use by one or more records.",
+  "settings.patronNotices.effectiveLocationTokenHeader": "Effective location",
 
   "settings.staffSlips.label": "Staff slips",
   "settings.staffSlips.name": "Name",


### PR DESCRIPTION
# Purpose
Expand location-specific token list for patron notice templates

# Link
https://issues.folio.org/browse/UICIRC-250

# Screenshot
<img width="1325" alt="Screen Shot 2019-06-06 at 11 41 50" src="https://user-images.githubusercontent.com/43472449/59019172-30dc0e80-8850-11e9-8b8e-794b8ba78fd4.png">
