### PR TITLE
UIORG-150 remove unnecessary permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 1.9.0
+
+* Remove unnecessary permissions. Refs UIORG-150.
+
 ## [1.8.0](https://github.com/folio-org/ui-circulation/tree/v1.8.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.7.0...v1.8.0)
 

--- a/package.json
+++ b/package.json
@@ -145,14 +145,6 @@
         ]
       },
       {
-        "permissionName": "settings.circulation.enabled",
-        "displayName": "Settings (Circ): display list of settings pages",
-        "subPermissions": [
-          "settings.enabled"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-circulation.settings.staff-slips",
         "displayName": "Settings (Circ): Can create, edit and remove staff slips",
         "subPermissions": [


### PR DESCRIPTION
Settings permissions are more granular than "settings pages" so this
value was useless.

Refs [UIORG-150](https://issues.folio.org/browse/UIORG-150)