### PR TITLE
UICIRC-271 - Email notice doesn't render in rich text even though it's defined in template

### DIFF
--- a/src/settings/components/TemplateEditor/Attributors/indent.js
+++ b/src/settings/components/TemplateEditor/Attributors/indent.js
@@ -4,7 +4,7 @@ const Parchment = Quill.import('parchment');
 
 class IndentAttributor extends Parchment.Attributor.Style {
   add(node, value) {
-    if (value === 0) {
+    if (parseInt(value, 10) === 0) {
       this.remove(node);
       return true;
     } else {

--- a/src/settings/components/TemplateEditor/Attributors/indent.js
+++ b/src/settings/components/TemplateEditor/Attributors/indent.js
@@ -1,0 +1,21 @@
+import { Quill } from 'react-quill';
+
+const Parchment = Quill.import('parchment');
+
+class IndentAttributor extends Parchment.Attributor.Style {
+  add(node, value) {
+    if (value === 0) {
+      this.remove(node);
+      return true;
+    } else {
+      return super.add(node, `${value}em`);
+    }
+  }
+}
+
+const IndentStyle = new IndentAttributor('indent', 'text-indent', {
+  scope: Parchment.Scope.BLOCK,
+  whitelist: ['1em', '2em', '3em', '4em', '5em', '6em', '7em', '8em', '9em']
+});
+
+export default IndentStyle;

--- a/src/settings/components/TemplateEditor/Attributors/indent.js
+++ b/src/settings/components/TemplateEditor/Attributors/indent.js
@@ -4,12 +4,7 @@ const Parchment = Quill.import('parchment');
 
 class IndentAttributor extends Parchment.Attributor.Style {
   add(node, value) {
-    if (parseInt(value, 10) === 0) {
-      this.remove(node);
-      return true;
-    } else {
-      return super.add(node, `${value}em`);
-    }
+    return super.add(node, `${value}em`);
   }
 }
 

--- a/src/settings/components/TemplateEditor/EditorToolbar/EditorToolbar.js
+++ b/src/settings/components/TemplateEditor/EditorToolbar/EditorToolbar.js
@@ -18,10 +18,10 @@ const EditorToolbar = () => {
       </span>
       <span className="ql-formats">
         <select className="ql-size">
-          <option value="small" />
+          <option value="10px" />
           <option selected />
-          <option value="large" />
-          <option value="huge" />
+          <option value="18px" />
+          <option value="32px" />
         </select>
       </span>
       <span className="ql-formats">

--- a/src/settings/components/TemplateEditor/EditorToolbar/EditorToolbar.js
+++ b/src/settings/components/TemplateEditor/EditorToolbar/EditorToolbar.js
@@ -14,7 +14,7 @@ const EditorToolbar = () => {
       </span>
       <span className="ql-formats">
         <button type="button" className="ql-indent" value="-1" />
-        <button type="button" className="ql-indent" value="+1" />
+        <button type="button" data-test-increase-indent className="ql-indent" value="+1" />
       </span>
       <span className="ql-formats">
         <select className="ql-size">

--- a/src/settings/components/TemplateEditor/TemplateEditor.js
+++ b/src/settings/components/TemplateEditor/TemplateEditor.js
@@ -28,6 +28,13 @@ import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
 import '!style-loader!css-loader!./quillCustom.css';
 import css from './TemplateEditor.css';
 
+const AlignStyle = Quill.import('attributors/style/align');
+const SizeStyle = Quill.import('attributors/style/size');
+
+Quill.register(IndentStyle, true);
+Quill.register(AlignStyle, true);
+Quill.register(SizeStyle, true);
+
 class TemplateEditor extends React.Component {
   static propTypes = {
     input: PropTypes.object.isRequired,
@@ -45,13 +52,6 @@ class TemplateEditor extends React.Component {
 
   constructor(props) {
     super(props);
-
-    const AlignStyle = Quill.import('attributors/style/align');
-    const SizeStyle = Quill.import('attributors/style/size');
-
-    Quill.register(IndentStyle, true);
-    Quill.register(AlignStyle, true);
-    Quill.register(SizeStyle, true);
 
     this.quill = React.createRef();
 

--- a/src/settings/components/TemplateEditor/TemplateEditor.js
+++ b/src/settings/components/TemplateEditor/TemplateEditor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactQuill from 'react-quill';
+import ReactQuill, { Quill } from 'react-quill';
+
 import {
   isEmpty,
   isNull,
@@ -19,6 +20,7 @@ import ControlHeader from './ControlHeader';
 import ValidationContainer from './ValidationContainer';
 
 import tokensReducer from '../../utils/tokens-reducer';
+import IndentStyle from './Attributors/indent';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
@@ -43,6 +45,13 @@ class TemplateEditor extends React.Component {
 
   constructor(props) {
     super(props);
+
+    const AlignStyle = Quill.import('attributors/style/align');
+    const SizeStyle = Quill.import('attributors/style/size');
+
+    Quill.register(IndentStyle, true);
+    Quill.register(AlignStyle, true);
+    Quill.register(SizeStyle, true);
 
     this.quill = React.createRef();
 

--- a/src/settings/components/TemplateEditor/quillCustom.css
+++ b/src/settings/components/TemplateEditor/quillCustom.css
@@ -10,3 +10,27 @@
 .ql-toolbar {
   border-bottom: none !important;
 }
+
+.ql-picker.ql-size .ql-picker-label[data-value="10px"]::before,
+.ql-picker.ql-size .ql-picker-item[data-value="10px"]::before {
+  content: 'Small';
+}
+.ql-picker.ql-size .ql-picker-item[data-value="10px"]::before {
+  font-size: 10px;
+}
+
+.ql-picker.ql-size .ql-picker-label[data-value="18px"]::before,
+.ql-picker.ql-size .ql-picker-item[data-value="18px"]::before {
+  content: 'Large';
+}
+.ql-picker.ql-size .ql-picker-item[data-value="18px"]::before {
+  font-size: 18px;
+}
+
+.ql-picker.ql-size .ql-picker-label[data-value="32px"]::before,
+.ql-picker.ql-size .ql-picker-item[data-value="32px"]::before {
+  content: 'Huge';
+}
+.ql-picker.ql-size .ql-picker-item[data-value="32px"]::before {
+  font-size: 32px;
+}

--- a/test/bigtest/interactors/patron-notice/patron-notice-form.js
+++ b/test/bigtest/interactors/patron-notice/patron-notice-form.js
@@ -39,6 +39,7 @@ import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/i
   prohibitDeletion = new Interactor('[data-test-entity-in-use-modal]');
 
   templateBody = new Interactor('#template-editor');
+  indentBtn = new Interactor('[data-test-increase-indent]');
   errorContainer = new Interactor('#patron-notice-error-container');
   save = clickable('#clickable-save-patron-notice');
 

--- a/test/bigtest/tests/patron-notice/patron-notice-editor-test.js
+++ b/test/bigtest/tests/patron-notice/patron-notice-editor-test.js
@@ -43,6 +43,7 @@ describe('Patron notice editor', () => {
 
       describe('Tokens modal', () => {
         beforeEach(async () => {
+          await PatronNoticeForm.indentBtn.click();
           await PatronNoticeForm.showAvailbaleTokensBtn.click();
         });
 


### PR DESCRIPTION
# Purpose
To replace class names to inline styles for template editor content.

# Link
https://issues.folio.org/browse/UICIRC-271

# Screenshots
<img width="777" alt="Screen Shot 2019-06-24 at 15 11 18" src="https://user-images.githubusercontent.com/43472449/60017977-b8b87a00-9692-11e9-90fd-0b10e5fbc436.png">
<img width="505" alt="Screen Shot 2019-06-24 at 15 11 54" src="https://user-images.githubusercontent.com/43472449/60017985-bce49780-9692-11e9-8f2d-09e598784592.png">
