### PR TITLE
UICIRC-209: Fix display position of autocompletion popup in circulation rules editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0
 
 * Remove unnecessary permissions. Refs UIORG-150.
+* Fix display position of autocompletion popup in circulation rules editor. UICIRC-209
 
 ## [1.8.0](https://github.com/folio-org/ui-circulation/tree/v1.8.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.7.0...v1.8.0)

--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -6,6 +6,7 @@
   background: #f4f4f4;
   border: 1px solid #cdcdcd;
   border-radius: 2px;
+  line-height: 23px;
 }
 
 .CodeMirror-scroll {


### PR DESCRIPTION
## Purpose

Fix display position of autocompletion popup in circulation rules editor in the scope of the [issue](https://issues.folio.org/browse/UICIRC-209)

## Screenshots
The hint is displayed for the 17 line. 

![autocompletion_popup_displayed_in_correct_position](https://user-images.githubusercontent.com/50317804/60077731-4cda1e00-9733-11e9-81d4-29a1252b8f59.png)
