### PR TITLE
UICIRC-269 - New notice template of request type not displaying as an option in policy.

### DIFF
--- a/src/settings/NoticePolicy/NoticePolicySettings.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.js
@@ -32,6 +32,7 @@ class NoticePolicySettings extends React.Component {
       path: 'templates',
       params: {
         query: 'cql.allRecords=1 AND category=""',
+        limit: '100',
       },
     },
     circulationRules: {


### PR DESCRIPTION
# Purpose
To increase fetch limit for patron notice templates.

# Link
https://issues.folio.org/browse/UICIRC-269

# Screenshot
<img width="1440" alt="Screen Shot 2019-06-25 at 11 54 39" src="https://user-images.githubusercontent.com/43472449/60084583-78afd080-9740-11e9-9f5e-2e959a6f1a8f.png">
