### PR TITLE
Loan history settings (anonymize closed loans with fees/fines - exception for payment method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix display position of autocompletion popup in circulation rules editor. UICIRC-209
 * Create settings in UI for users to anonymize closed loans with fees/fines. UIORG-175.
 * Add location data fetching to circulation rules editor. UICIRC-272
+* Create settings in UI for users to anonymize closed loans with fees/fines and exception for payment method. UIORG-176.
 
 ## [1.8.0](https://github.com/folio-org/ui-circulation/tree/v1.8.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.7.0...v1.8.0)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       "template-engine": "2.0",
       "patron-notice-policy-storage": "0.7",
       "location-units": "1.1",
-      "locations": "3.0"
+      "locations": "3.0",
+      "feesfines": "15.0"
     },
     "permissionSets": [
       {
@@ -55,8 +56,10 @@
         "permissionName": "ui-circulation.settings.loan-history",
         "displayName": "Settings (Circ): Can view loan history",
         "subPermissions": [
-          "settings.circulation.enabled"
-        ]
+          "settings.circulation.enabled",
+          "payments.collection.get"
+        ],
+        "visible": true
       },
       {
         "permissionName": "ui-circulation.settings.loan-policies",

--- a/src/constants.js
+++ b/src/constants.js
@@ -320,7 +320,7 @@ export const closingTypes = [
 
 export const closedLoansRules = {
   DEFAULT: 'loan',
-  WITH_FEES_FINES: 'fee/fine',
+  WITH_FEES_FINES: 'feeFine',
 };
 
 export default '';

--- a/src/settings/LoanHistory/ExceptionCard.css
+++ b/src/settings/LoanHistory/ExceptionCard.css
@@ -1,0 +1,15 @@
+.exceptionCard {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-top-width: 0;
+  margin: 0 15px 0 0;
+  padding: 0 10px 10px 10px;
+  width: 500px;
+}
+
+.exceptionCard:first-child {
+  border-top-width: 1px;
+}
+
+.exceptionCardHeader {
+  padding-left: 0.5rem;
+}

--- a/src/settings/LoanHistory/ExceptionCard.js
+++ b/src/settings/LoanHistory/ExceptionCard.js
@@ -1,0 +1,119 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import {
+  intlShape,
+  injectIntl,
+  FormattedMessage,
+} from 'react-intl';
+import { forEach } from 'lodash';
+
+import {
+  Col,
+  Row,
+  IconButton,
+  Select,
+} from '@folio/stripes/components';
+
+import AnonymazingTypeSelectContainer from '../components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer';
+import {
+  closingTypes,
+  closedLoansRules,
+} from '../../constants';
+
+import css from './ExceptionCard.css';
+
+class ExceptionCard extends Component {
+  static propTypes = {
+    intl: intlShape.isRequired,
+    pathToException: PropTypes.string.isRequired,
+    paymentMethods: PropTypes.arrayOf(PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })).isRequired,
+    exceptionIndex: PropTypes.number.isRequired,
+    onRemoveException: PropTypes.func.isRequired,
+  }
+
+  onRemove = () => {
+    const {
+      exceptionIndex,
+      onRemoveException,
+    } = this.props;
+
+    onRemoveException(exceptionIndex);
+  };
+
+  getPaymentMethodOptions = (intl, config, placeholder) => {
+    const options = [];
+
+    options.push(this.getSelectOption('', 'x', intl.formatMessage({ id: placeholder })));
+
+    forEach(config, ({ value, label }) => {
+      options.push(this.getSelectOption(value, value, label));
+    });
+
+    return options;
+  }
+
+  getSelectOption(value, key, label) {
+    return (
+      <option
+        value={value}
+        key={key}
+      >
+        { label }
+      </option>
+    );
+  }
+
+  render() {
+    const {
+      pathToException,
+      paymentMethods,
+      intl,
+    } = this.props;
+
+    const selectedPayments = this.getPaymentMethodOptions(intl, paymentMethods, 'ui-circulation.settings.loanHistory.selectPaymentMethod');
+
+    return (
+      <Row
+        className={css.exceptionCard}
+        data-test-exception-card
+      >
+        <Col xs={12}>
+          <Row>
+            <p className={css.exceptionCardHeader}>
+              <FormattedMessage id="ui-circulation.settings.loanHistory.paymentMethodLabel" />
+            </p>
+            <Col
+              xs={11}
+              data-test-payment-method-selector
+            >
+              <Field
+                name={`${pathToException}.paymentMethod`}
+                component={Select}
+              >
+                {selectedPayments}
+              </Field>
+            </Col>
+            <Col xs={1}>
+              <IconButton
+                icon="trash"
+                data-test-remove-exception-icon
+                onClick={this.onRemove}
+              />
+            </Col>
+          </Row>
+          <AnonymazingTypeSelectContainer
+            name={closedLoansRules.WITH_FEES_FINES}
+            path={pathToException}
+            types={closingTypes}
+          />
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default injectIntl(ExceptionCard);

--- a/src/settings/LoanHistory/ExceptionsList.css
+++ b/src/settings/LoanHistory/ExceptionsList.css
@@ -1,0 +1,8 @@
+.exceptionSection {
+  display: flex;
+  align-items: flex-end;
+}
+
+.exceptionAddButton {
+  margin-bottom: 6rem;
+}

--- a/src/settings/LoanHistory/ExceptionsList.js
+++ b/src/settings/LoanHistory/ExceptionsList.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import {
+  uniqBy,
+  get,
+} from 'lodash';
+
+import { stripesConnect } from '@folio/stripes/core';
+import { Button } from '@folio/stripes/components';
+
+import ExceptionCard from './ExceptionCard';
+
+import css from './ExceptionsList.css';
+
+@stripesConnect
+class ExceptionsList extends Component {
+  static manifest = Object.freeze({
+    paymentMethods: {
+      type: 'okapi',
+      path: 'payments',
+      throwsErrors: false,
+    },
+  });
+
+  static propTypes = {
+    fields: PropTypes.object.isRequired,
+    resources: PropTypes.shape({
+      paymentMethods: PropTypes.object,
+    }).isRequired,
+  }
+
+  handleAddField = () => {
+    this.props.fields.push({});
+  };
+
+  handleRemoveField = index => {
+    this.props.fields.remove(index);
+  };
+
+  render() {
+    const payments = get(this.props.resources, 'paymentMethods.records[0].payments', []);
+    const paymentMethods = payments.map(item => ({ value: item.nameMethod, label: item.nameMethod }));
+
+    return (
+      <div>
+        <FormattedMessage
+          tagName="h4"
+          id="ui-circulation.settings.loanHistory.exceptionSectionHeader"
+        />
+        <div className={css.exceptionSection}>
+          <div data-test-exception-list>
+            {this.props.fields.map((pathToException, exceptionIndex) => (
+              <ExceptionCard
+                key={pathToException}
+                pathToException={pathToException}
+                paymentMethods={uniqBy(paymentMethods, 'label')}
+                exceptionIndex={exceptionIndex}
+                onRemoveException={this.handleRemoveField}
+              />))}
+          </div>
+          <div className={css.exceptionAddButton}>
+            <Button
+              type="button"
+              buttonStyle="default"
+              data-test-add-exception-button
+              onClick={this.handleAddField}
+            >
+              <FormattedMessage id="ui-circulation.settings.loanHistory.addExceptionButton" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ExceptionsList;

--- a/src/settings/LoanHistory/LoanHistory.js
+++ b/src/settings/LoanHistory/LoanHistory.js
@@ -4,10 +4,6 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
-import {
-  isInteger,
-  setWith,
-} from 'lodash';
 
 import {
   stripesShape,
@@ -16,10 +12,7 @@ import {
 import { ConfigManager } from '@folio/stripes/smart-components';
 
 import LoanHistoryForm from './LoanHistoryForm';
-import {
-  closingTypesMap,
-  closedLoansRules,
-} from '../../constants';
+import { LoanHistory as validateLoanHistory } from '../Validation';
 
 const selectedPeriodsValues = [
   'Days',
@@ -63,31 +56,6 @@ class LoanHistorySettings extends React.Component {
     return config;
   }
 
-  validate = values => {
-    const errors = {};
-
-    Object.values(closedLoansRules).forEach(item => {
-      const durationValue = values[item] && Number(values[item].duration);
-      const isNumberValid = isInteger(durationValue) && durationValue > 0;
-
-      if (values.closingType[item] === closingTypesMap.INTERVAL && !isNumberValid) {
-        const duration = { _error: <FormattedMessage id="ui-circulation.settings.loanHistory.validate.intervalValue" /> };
-
-        setWith(errors, [item, 'duration'], duration);
-      }
-
-      const isIntervalIdValid = values[item] && values[item].intervalId;
-
-      if (values.closingType[item] === closingTypesMap.INTERVAL && !isIntervalIdValid) {
-        const intervalId = { _error: <FormattedMessage id="ui-circulation.settings.loanHistory.validate.selectContinue" /> };
-
-        setWith(errors, [item, 'intervalId'], intervalId);
-      }
-    });
-
-    return errors;
-  }
-
   render() {
     return (
       <this.configManager
@@ -97,7 +65,7 @@ class LoanHistorySettings extends React.Component {
         configFormComponent={LoanHistoryForm}
         stripes={this.props.stripes}
         getInitialValues={this.getInitialValues}
-        validate={this.validate}
+        validate={validateLoanHistory}
       />
     );
   }

--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -7,12 +7,12 @@ import {
 } from 'react-intl';
 import {
   Field,
+  FieldArray,
   getFormValues,
 } from 'redux-form';
-import { camelCase } from 'lodash';
 
-import { stripesShape } from '@folio/stripes/core';
 import stripesForm from '@folio/stripes/form';
+import { stripesShape } from '@folio/stripes/core';
 import {
   Button,
   Checkbox,
@@ -22,19 +22,14 @@ import {
   Headline,
 } from '@folio/stripes/components';
 
-import {
-  Period,
-  RadioButtons,
-} from '../components';
+import AnonymazingTypeSelectContainer from '../components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer';
+import ExceptionsList from './ExceptionsList';
 import optionsGenerator from '../utils/options-generator';
 import {
   closingTypes,
-  closingTypesMap,
   intervalPeriods,
   closedLoansRules,
 } from '../../constants';
-
-import css from './LoanHistoryForm.css';
 
 class LoanHistoryForm extends Component {
   static propTypes = {
@@ -44,7 +39,7 @@ class LoanHistoryForm extends Component {
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    initialValues: PropTypes.oneOfType([PropTypes.array]),
+    initialValues: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     stripes: stripesShape.isRequired,
   };
 
@@ -91,50 +86,6 @@ class LoanHistoryForm extends Component {
     return getFormValues('loanHistoryForm')(state) || {};
   }
 
-  renderPeriod(name) {
-    return (
-      <div
-        data-test-period-section
-        className={css.periodContainer}
-      >
-        <Period
-          inputValuePath={`${name}.duration`}
-          selectValuePath={`${name}.intervalId`}
-          intervalPeriods={this.generateOptions(this.selectedPeriods, 'ui-circulation.settings.loanHistory.selectInterval')}
-          inputSize={4}
-          selectSize={7}
-        />
-        <div>
-          <FormattedMessage
-            id="ui-circulation.settings.loanHistory.afterClose"
-            values={{ name: <FormattedMessage id={`ui-circulation.settings.loanHistory.${camelCase(name)}`} /> }}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  getClosingTypes(name) {
-    return closingTypes.map(type => {
-      if (type.value !== closingTypesMap.INTERVAL) {
-        return {
-          ...type,
-          label: (
-            <FormattedMessage
-              id={type.label}
-              values={{ name }}
-            />
-          )
-        };
-      }
-
-      return {
-        label: this.renderPeriod(name),
-        value: closingTypesMap.INTERVAL,
-      };
-    });
-  }
-
   render() {
     const {
       handleSubmit,
@@ -166,9 +117,10 @@ class LoanHistoryForm extends Component {
               tagName="p"
               id="ui-circulation.settings.loanHistory.anonymize"
             />
-            <RadioButtons
+            <AnonymazingTypeSelectContainer
               name={closedLoansRules.DEFAULT}
-              types={this.getClosingTypes(closedLoansRules.DEFAULT)}
+              path={closedLoansRules.DEFAULT}
+              types={closingTypes}
             />
           </div>
           <br />
@@ -199,9 +151,15 @@ class LoanHistoryForm extends Component {
                 tagName="p"
                 id="ui-circulation.settings.loanHistory.anonymizeFeesFines"
               />
-              <RadioButtons
+              <AnonymazingTypeSelectContainer
                 name={closedLoansRules.WITH_FEES_FINES}
-                types={this.getClosingTypes(closedLoansRules.WITH_FEES_FINES)}
+                path={closedLoansRules.WITH_FEES_FINES}
+                types={closingTypes}
+              />
+              <br />
+              <FieldArray
+                name="loanExceptions"
+                component={ExceptionsList}
               />
             </div>
           }

--- a/src/settings/Models/LoanHistoryModel.js
+++ b/src/settings/Models/LoanHistoryModel.js
@@ -1,0 +1,25 @@
+export default class LoanHistory {
+  static defaultLoanHistory() {
+    return {};
+  }
+
+  constructor(data = {}) {
+    const {
+      closingType,
+      loan = {},
+      feeFine = {},
+      loanExceptions = [],
+    } = data;
+
+    this.closingType = closingType;
+    this.loan = {
+      duration: loan.duration,
+      intervalId: loan.intervalId,
+    };
+    this.feeFine = {
+      duration: feeFine.duration,
+      intervalId: feeFine.intervalId,
+    };
+    this.loanExceptions = loanExceptions;
+  }
+}

--- a/src/settings/Validation/engine/FormValidator.js
+++ b/src/settings/Validation/engine/FormValidator.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import {
   get,
   set,
@@ -21,11 +23,13 @@ export default class FormValidator {
 
     const validationRules = this.config[pathToField].rules || [];
 
-    some(validationRules, (validationRule) => {
+    some(validationRules, validationRule => {
       const validator = this.validators[validationRule];
 
       if (!validator) {
-        throw new Error(`Validation: no handler to validate - ${validationRule}`);
+        throw new Error(
+          `Validation: no handler to validate - ${validationRule}`
+        );
       }
 
       const valueToValidate = get(data, pathToField);
@@ -47,10 +51,10 @@ export default class FormValidator {
     };
   }
 
-  validate(data) {
+  validate(data, sectionKey) {
     const errors = {};
 
-    forEach(Object.keys(this.config), (pathToField) => {
+    forEach(Object.keys(this.config), pathToField => {
       const {
         isFieldValid,
         validationMessage,
@@ -60,6 +64,24 @@ export default class FormValidator {
         set(errors, pathToField, validationMessage);
       }
     });
+
+    if (data[sectionKey]) {
+      const uniqueValues = {};
+
+      forEach(data[sectionKey], ({ paymentMethod }, index) => {
+        if (paymentMethod) {
+          if (uniqueValues[paymentMethod]) {
+            set(
+              errors,
+              `${sectionKey}[${index}].paymentMethod`,
+              <FormattedMessage id="ui-circulation.settings.loanHistory.errors.paymentMethodSelected" />
+            );
+          } else {
+            uniqueValues[paymentMethod] = {};
+          }
+        }
+      });
+    }
 
     return errors;
   }

--- a/src/settings/Validation/index.js
+++ b/src/settings/Validation/index.js
@@ -1,3 +1,4 @@
+export { default as LoanHistory } from './loan-history';
 export { default as LoanPolicy } from './loan-policy';
 export { default as NoticePolicy } from './notice-policy';
 export { default as RequestPolicy } from './request-policy';

--- a/src/settings/Validation/loan-history/general.js
+++ b/src/settings/Validation/loan-history/general.js
@@ -1,0 +1,22 @@
+import {
+  closedLoansRules,
+  closingTypesMap,
+} from '../../../constants';
+
+export default function (data) {
+  return Object.values(closedLoansRules).reduce((config, item) => {
+    const isClosingTypeIntervalSelected = data.closingType[item] === closingTypesMap.INTERVAL;
+    const ruleConfig = {
+      [`${item}.duration`]: {
+        rules: ['isNotEmpty', 'isIntegerGreaterThanZero', 'isFromOneToHundred'],
+        shouldValidate: isClosingTypeIntervalSelected,
+      },
+      [`${item}.intervalId`]: {
+        rules: ['isNotEmptySelect'],
+        shouldValidate: isClosingTypeIntervalSelected,
+      },
+    };
+
+    return { ...config, ...ruleConfig };
+  }, {});
+}

--- a/src/settings/Validation/loan-history/index.js
+++ b/src/settings/Validation/loan-history/index.js
@@ -1,0 +1,1 @@
+export { default } from './loan-history';

--- a/src/settings/Validation/loan-history/loan-exceptions.js
+++ b/src/settings/Validation/loan-history/loan-exceptions.js
@@ -1,0 +1,25 @@
+import { closingTypesMap } from '../../../constants';
+
+export default function (data, sectionKey) {
+  return data[sectionKey].reduce((config, item, index) => {
+    const section = data.closingType[sectionKey];
+    const isClosingTypeIntervalSelected = section && section[index] === closingTypesMap.INTERVAL;
+
+    const loanExceptionConfig = {
+      [`${sectionKey}[${index}].paymentMethod`]: {
+        rules: ['isNotEmptySelect'],
+        shouldValidate: false,
+      },
+      [`${sectionKey}[${index}].duration`]: {
+        rules: ['isNotEmpty', 'isIntegerGreaterThanZero', 'isFromOneToHundred'],
+        shouldValidate: isClosingTypeIntervalSelected,
+      },
+      [`${sectionKey}[${index}].intervalId`]: {
+        rules: ['isNotEmptySelect'],
+        shouldValidate: isClosingTypeIntervalSelected,
+      }
+    };
+
+    return { ...config, ...loanExceptionConfig };
+  }, {});
+}

--- a/src/settings/Validation/loan-history/loan-history.js
+++ b/src/settings/Validation/loan-history/loan-history.js
@@ -1,0 +1,17 @@
+import LoanHistoryModel from '../../Models/LoanHistoryModel';
+import FormValidator from '../engine/FormValidator';
+import general from './general';
+import loanExceptions from './loan-exceptions';
+
+export default function (data) {
+  const formData = new LoanHistoryModel(data);
+  const sectionKey = 'loanExceptions';
+  const config = {
+    ...general(formData),
+    ...loanExceptions(formData, sectionKey),
+  };
+
+  const formValidator = new FormValidator(config);
+
+  return formValidator.validate(formData, sectionKey);
+}

--- a/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelect.js
+++ b/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelect.js
@@ -8,7 +8,7 @@ import {
   RadioButton,
 } from '@folio/stripes/components';
 
-const RadioButtons = ({ name, types }) => {
+const AnonymazingTypeSelect = ({ name, types }) => {
   return types.map((type, index) => (
     <Row key={`row-${index}`}>
       <Col xs={12}>
@@ -18,7 +18,7 @@ const RadioButtons = ({ name, types }) => {
           label={type.label}
           name={`closingType.${name}`}
           type="radio"
-          id={`${type.value}-${name.replace('/', '')}-radio-button`}
+          id={`${type.value}-${name}-radio-button`}
           value={type.value}
         />
       </Col>
@@ -26,9 +26,9 @@ const RadioButtons = ({ name, types }) => {
   ));
 };
 
-RadioButtons.propTypes = {
+AnonymazingTypeSelect.propTypes = {
   name: PropTypes.string.isRequired,
   types: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
-export default RadioButtons;
+export default AnonymazingTypeSelect;

--- a/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer.css
+++ b/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer.css
@@ -1,13 +1,3 @@
-@import "@folio/stripes-components/lib/variables.css";
-
-.closingTypeField {
-  padding-left: 0;
-}
-
-.error {
-  color: var(--error);
-}
-
 .periodContainer {
   display: flex;
 }

--- a/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer.js
+++ b/src/settings/components/AnonymazingTypeSelect/AnonymazingTypeSelectContainer.js
@@ -1,0 +1,98 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+  injectIntl,
+  intlShape,
+  FormattedMessage,
+} from 'react-intl';
+
+import AnonymazingTypeSelect from './AnonymazingTypeSelect';
+import { Period } from '..';
+import optionsGenerator from '../../utils/options-generator';
+import {
+  closingTypesMap,
+  intervalPeriods,
+} from '../../../constants';
+
+import css from './AnonymazingTypeSelectContainer.css';
+
+const selectedPeriodsValues = [
+  'Days',
+  'Weeks',
+  'Months',
+];
+
+class AnonymazingTypeSelectContainer extends Component {
+  static propTypes = {
+    intl: intlShape.isRequired,
+    name: PropTypes.string.isRequired,
+    path: PropTypes.string.isRequired,
+    types: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.generateOptions = optionsGenerator.bind(null, props.intl.formatMessage);
+    this.selectedPeriods = intervalPeriods.filter(period => selectedPeriodsValues.includes(period.value));
+  }
+
+  renderPeriod(name, path) {
+    return (
+      <div
+        data-test-period-section
+        className={css.periodContainer}
+      >
+        <Period
+          inputValuePath={`${path}.duration`}
+          selectValuePath={`${path}.intervalId`}
+          intervalPeriods={this.generateOptions(this.selectedPeriods, 'ui-circulation.settings.loanHistory.selectInterval')}
+          inputSize={4}
+          selectSize={7}
+        />
+        <FormattedMessage
+          tagName="div"
+          id="ui-circulation.settings.loanHistory.afterClose"
+          values={{ name: <FormattedMessage id={`ui-circulation.settings.loanHistory.${name}`} /> }}
+        />
+      </div>
+    );
+  }
+
+  getClosingTypes(name, path) {
+    return this.props.types.map(type => {
+      if (type.value !== closingTypesMap.INTERVAL) {
+        return {
+          ...type,
+          label: (
+            <FormattedMessage
+              id={type.label}
+              values={{ name: <FormattedMessage id={`ui-circulation.settings.loanHistory.${name}`} /> }}
+            />
+          )
+        };
+      }
+
+      return {
+        label: this.renderPeriod(name, path),
+        value: closingTypesMap.INTERVAL,
+      };
+    });
+  }
+
+  render() {
+    const {
+      name,
+      path,
+    } = this.props;
+
+    return (
+      <AnonymazingTypeSelect
+        name={path}
+        types={this.getClosingTypes(name, path)}
+      />
+    );
+  }
+}
+
+export default injectIntl(AnonymazingTypeSelectContainer);

--- a/src/settings/components/AnonymazingTypeSelect/index.js
+++ b/src/settings/components/AnonymazingTypeSelect/index.js
@@ -1,0 +1,1 @@
+export { default } from './AnonymazingTypeSelectContainer';

--- a/src/settings/components/RadioButtons/index.js
+++ b/src/settings/components/RadioButtons/index.js
@@ -1,1 +1,0 @@
-export { default } from './RadioButtons';

--- a/src/settings/components/index.js
+++ b/src/settings/components/index.js
@@ -4,5 +4,5 @@ export { default as DeleteConfirmationModal } from './DeleteConfirmationModal';
 export { default as Metadata } from './Metadata';
 export { default as Period } from './Period';
 export { default as EntityInUseModal } from './EntityInUseModal';
-export { default as RadioButtons } from './RadioButtons';
+export { default as AnonymazingTypeSelect } from './AnonymazingTypeSelect';
 export { TemplateEditor, PreviewModal, TokensSection } from './TemplateEditor';

--- a/test/bigtest/interactors/loan-history/loan-history-form.js
+++ b/test/bigtest/interactors/loan-history/loan-history-form.js
@@ -4,6 +4,8 @@ import {
   isPresent,
   clickable,
   property,
+  collection,
+  count,
 } from '@bigtest/interactor';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
@@ -20,6 +22,11 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   interval = scoped('[data-test-period-interval]', SelectInteractor);
 }
 
+@interactor class ExceptionSection {
+  cardsCount = count('[data-test-exception-card]');
+  paymentMethods = collection('[data-test-payment-method-selector]', SelectInteractor);
+}
+
 @interactor class LoanHistoryForm {
   isLoaded = isPresent('#treatEnabled-checkbox');
 
@@ -32,8 +39,12 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   callout = new CalloutInteractor();
   saveButton = new ButtonInteractor('[data-test-loan-history-save-button]');
   disabledSaveButton = property('[data-test-loan-history-save-button]', 'disabled');
+  addExceptionButton = new ButtonInteractor('[data-test-add-exception-button]');
+  removeExceptionIcon = new ButtonInteractor('[data-test-remove-exception-icon]');
   loan = new ClosingTypeSelector('[data-test-closed-loans]');
   feeFine = new ClosingTypeSelector('[data-test-closed-loans-feefine]');
+  loanException = new ClosingTypeSelector('[data-test-exception-card]');
+  loanExceptionSection = new ExceptionSection('[data-test-exception-list]');
 }
 
 export default new LoanHistoryForm();

--- a/test/bigtest/network/factories/payments.js
+++ b/test/bigtest/network/factories/payments.js
@@ -1,0 +1,24 @@
+import { Factory, faker, trait } from '@bigtest/mirage';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  nameMethod : (i) => 'Cash' + i,
+  allowedRefundMethod : true,
+  ownerId : (i) => '4dbc74d7-665c-4b66-a296-949107905cb0' + i,
+  metadata : {
+    createdDate: faker.date.past(0.1, faker.date.past(0.1)).toString(),
+    createdByUserId: () => '2d91d36d-618c-5b36-b4b7-986a041bf397',
+    updatedDate: faker.date.past(0.1, faker.date.past(0.1)).toString(),
+    updatedByUserId: () => '2d91d36d-618c-5b36-b4b7-986a041bf397'
+  },
+
+  // eslint-disable-next-line quote-props
+  withAccounts: trait({
+    afterCreate(payments, server) {
+      const owner = server.create('owner');
+
+      payments.update('ownerId', owner.id);
+      payments.save();
+    }
+  })
+});

--- a/test/bigtest/network/models/payments.js
+++ b/test/bigtest/network/models/payments.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/test/bigtest/network/scenarios/testLoanHistory.js
+++ b/test/bigtest/network/scenarios/testLoanHistory.js
@@ -1,0 +1,5 @@
+export default (server) => {
+  server.createList('payments', 3);
+
+  server.get('/payments');
+};

--- a/test/bigtest/tests/loan-history/loan-history-form-test.js
+++ b/test/bigtest/tests/loan-history/loan-history-form-test.js
@@ -11,7 +11,7 @@ import LoanHistoryForm from '../../interactors/loan-history/loan-history-form';
 import { closingTypesMap } from '../../../../src/constants';
 
 describe('Loan History Form', () => {
-  setupApplication();
+  setupApplication({ scenarios: ['testLoanHistory'] });
 
   beforeEach(function () {
     this.visit('/settings/circulation/loan-history');
@@ -35,7 +35,7 @@ describe('Loan History Form', () => {
         await LoanHistoryForm.clickTreatEnabledCheckbox();
       });
 
-      it('"closed loans with associated fees/fines" section is shown', () => {
+      it('section for closed loans with associated fees/fines is shown', () => {
         expect(LoanHistoryForm.feefineSection.isPresent).to.be.true;
       });
 
@@ -57,7 +57,7 @@ describe('Loan History Form', () => {
   });
 
 
-  describe('when form is loaded and "loan interval radio button" selected', () => {
+  describe('when form is loaded and radio button for loan interval is selected', () => {
     beforeEach(async () => {
       await LoanHistoryForm.whenLoaded();
       await LoanHistoryForm.loan.selectRadio(closingTypesMap.INTERVAL);
@@ -67,7 +67,7 @@ describe('Loan History Form', () => {
       expect(LoanHistoryForm.disabledSaveButton).to.be.false;
     });
 
-    describe('when "interval closing type" field completely filled', () => {
+    describe('when the interval closing type field completely filled', () => {
       beforeEach(async () => {
         await LoanHistoryForm.loan.duration.fillAndBlur('2');
         await LoanHistoryForm.loan.interval.selectAndBlur('Week(s)');
@@ -102,7 +102,7 @@ describe('Loan History Form', () => {
     });
   });
 
-  describe('when form is loaded and "fee/fine interval radio button" selected', () => {
+  describe('when form is loaded and radio button for fee/fine interval is selected', () => {
     beforeEach(async () => {
       await LoanHistoryForm.whenLoaded();
       await LoanHistoryForm.clickTreatEnabledCheckbox();
@@ -128,7 +128,7 @@ describe('Loan History Form', () => {
       });
     });
 
-    describe('when "interval closing type" field completely filled', () => {
+    describe('when the interval closing type field completely filled', () => {
       beforeEach(async () => {
         await LoanHistoryForm.feeFine.duration.fillAndBlur('2');
         await LoanHistoryForm.feeFine.interval.selectAndBlur('Week(s)');
@@ -159,6 +159,131 @@ describe('Loan History Form', () => {
 
       it('form doesn\'t save', () => {
         expect(LoanHistoryForm.callout.anyCalloutIsPresent).to.be.false;
+      });
+    });
+  });
+
+  describe('when form is loaded and checkbox for treat closed loans is checked', () => {
+    beforeEach(async () => {
+      await LoanHistoryForm.whenLoaded();
+      await LoanHistoryForm.clickTreatEnabledCheckbox();
+    });
+
+    it('button for add exception is present', () => {
+      expect(LoanHistoryForm.addExceptionButton.isPresent).to.be.true;
+    });
+
+    describe('when button for add exception is clicked', () => {
+      beforeEach(async () => {
+        await LoanHistoryForm.addExceptionButton.click();
+      });
+
+      it('exception card is shown', () => {
+        expect(LoanHistoryForm.loanException.isPresent).to.be.true;
+      });
+
+      describe('when button for delete exception is clicked', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.removeExceptionIcon.click();
+        });
+
+        it('exception card is not shown', () => {
+          expect(LoanHistoryForm.loanException.isPresent).to.be.false;
+        });
+      });
+
+      describe('when user has made changes', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.loanExceptionSection.paymentMethods(0).selectAndBlur('Cash1');
+        });
+
+        it('save button is active', () => {
+          expect(LoanHistoryForm.disabledSaveButton).to.be.false;
+        });
+      });
+
+      describe('when select radio buttons and click save button', () => {
+        beforeEach(async function () {
+          await LoanHistoryForm
+            .loanException.selectRadio(closingTypesMap.IMMEDIATELY)
+            .loanException.selectRadio(closingTypesMap.INTERVAL)
+            .loanException.selectRadio(closingTypesMap.NEVER);
+
+          await LoanHistoryForm.saveButton.click();
+        });
+
+        it('form successfully saves', () => {
+          expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+        });
+      });
+
+      describe('when radio button for interval type is selected', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.loanException.selectRadio(closingTypesMap.INTERVAL);
+        });
+
+        it('save button is active', () => {
+          expect(LoanHistoryForm.disabledSaveButton).to.be.false;
+        });
+
+        describe('when fields completely filled', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.loanException.duration.fillAndBlur('2');
+            await LoanHistoryForm.loanException.interval.selectAndBlur('Week(s)');
+            await LoanHistoryForm.saveButton.click();
+          });
+
+          it('form successfully saves', () => {
+            expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+          });
+        });
+
+        describe('when the duration value is negative', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.loanException.duration.fillAndBlur('-2');
+            await LoanHistoryForm.loanException.interval.selectAndBlur('Day(s)');
+            await LoanHistoryForm.saveButton.click();
+          });
+
+          it('form doesn\'t save', () => {
+            expect(LoanHistoryForm.callout.anyCalloutIsPresent).to.be.false;
+          });
+        });
+
+        describe('when the interval is not selected', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.loanException.duration.fillAndBlur('7');
+            await LoanHistoryForm.saveButton.click();
+          });
+
+          it('form doesn\'t save', () => {
+            expect(LoanHistoryForm.callout.anyCalloutIsPresent).to.be.false;
+          });
+        });
+      });
+    });
+
+    describe('when button for add exception is clicked twice', () => {
+      beforeEach(async () => {
+        await LoanHistoryForm
+          .addExceptionButton.click()
+          .addExceptionButton.click();
+      });
+
+      it('should have 2 exception cards', () => {
+        expect(LoanHistoryForm.loanExceptionSection.cardsCount).to.be.equal(2);
+      });
+
+      describe('when user has selected the same payment method for multiple exceptions', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.loanExceptionSection.paymentMethods(0).selectAndBlur('Cash2');
+          await LoanHistoryForm.loanExceptionSection.paymentMethods(1).selectAndBlur('Cash2');
+          await LoanHistoryForm.saveButton.click();
+        });
+
+        it('form doesn\'t save', () => {
+          expect(LoanHistoryForm.callout.anyCalloutIsPresent).to.be.false;
+        });
       });
     });
   });

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -282,6 +282,7 @@
   "settings.loanHistory.validate.intervalValue": "Please enter a whole number greater than zero to continue",
   "settings.loanHistory.validate.selectContinue": "Please select to continue",
   "settings.loanHistory.selectInterval": "Select interval",
+  "settings.loanHistory.selectPaymentMethod": "Select payment method",
   "settings.loanHistory.closedLoans": "Closed loans",
   "settings.loanHistory.closedLoansFeesFines": "Closed loans with associated fees/fines",
   "settings.loanHistory.anonymize": "Anonymize closed loans",
@@ -292,5 +293,13 @@
   "settings.loanHistory.afterClose": "after {name} closes",
   "settings.loanHistory.treat": "Treat closed loans with associated fee/fines differently",
   "settings.loanHistory.loan": "loan",
-  "settings.loanHistory.feeFine": "fee/fine"
+  "settings.loanHistory.feeFine": "fee/fine",
+  "settings.loanHistory.exceptionSectionHeader": "Exception for payment method",
+  "settings.loanHistory.paymentMethodLabel": "Setting for payment method",
+  "settings.loanHistory.addExceptionButton": "Add exception",
+  "settings.loanHistory.paymentMethod.waive": "Waive",
+  "settings.loanHistory.paymentMethod.transfer": "Transfer",
+  "settings.loanHistory.paymentMethod.replace": "Replace",
+  "settings.loanHistory.paymentMethod.pay": "Pay",
+  "settings.loanHistory.errors.paymentMethodSelected": "This payment method is already selected"
 }


### PR DESCRIPTION
**Purpose**
Create settings in UI for users to anonymize closed loans with fees/fines and exception for payment method according to [story](https://issues.folio.org/browse/UIORG-176).

![loan-history-fees-fines-exception](https://user-images.githubusercontent.com/49517355/60881215-e33b3300-a24d-11e9-8115-747d3771e30e.png)
