### PR TITLE
UITEN-35 restore settings menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
           "circulation-storage.cancellation-reasons.collection.delete",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -56,7 +56,7 @@
         "permissionName": "ui-circulation.settings.loan-history",
         "displayName": "Settings (Circ): Can view loan history",
         "subPermissions": [
-          "settings.circulation.enabled",
+          "settings.enabled",
           "payments.collection.get"
         ],
         "visible": true
@@ -75,7 +75,7 @@
           "circulation-storage.fixed-due-date-schedules.item.get",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -92,7 +92,7 @@
           "templates.item.get",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -122,7 +122,7 @@
           "circulation-storage.patron-notice-policies.item.get",
           "inventory-storage.material-types.item.get",
           "inventory-storage.loan-types.item.get",
-          "settings.circulation.enabled",
+          "settings.enabled",
           "inventory-storage.location-units.institutions.collection.get",
           "inventory-storage.location-units.campuses.collection.get",
           "inventory-storage.location-units.libraries.collection.get",
@@ -142,7 +142,7 @@
           "circulation-storage.fixed-due-date-schedules.collection.delete",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -163,7 +163,7 @@
           "circulation-storage.staff-slips.item.post",
           "circulation-storage.staff-slips.item.put",
           "circulation-storage.staff-slips.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -179,7 +179,7 @@
           "circulation-storage.request-policies.item.put",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -188,7 +188,7 @@
         "displayName": "Settings (Circ): Can create, edit and remove other settings",
         "subPermissions": [
           "configuration.all",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       },
@@ -202,7 +202,7 @@
           "templates.item.put",
           "templates.item.delete",
           "template-request.post",
-          "settings.circulation.enabled"
+          "settings.enabled"
         ],
         "visible": true
       }


### PR DESCRIPTION
When `settings.circulation.enabiled` was removed in #360 under the auspices of
[UITEN-35](https://issues.folio.org/browse/UITEN-35), the permission sets that relied on it should have been updated
to include `settings.enabled` in order to cause Settings to be
accessible.

Removing `settings.circulation.enabled` _was_ the right thing to do; it was
functionally a do-nothing permission because the individual menu items
are controlled by more granular permissions. BUT we do need to make sure
that the top-level Settings menu is displayed when any of those
granular permissions are granted.

Refs [UITEN-35](https://issues.folio.org/browse/UITEN-35)