### PR TITLE
UICIRC-302 retrieve more elements in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 1.10.0 (IN PROGRESS)
+
+* Retrieve 1000 elements on Settings pages instead of 10. Refs UICIRC-302.
+
 ## [1.9.0](https://github.com/folio-org/ui-circulation/tree/v1.9.0) (2019-07-25)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.8.0...v1.9.0)
 

--- a/src/settings/LoanPolicy/LoanPolicySettings.js
+++ b/src/settings/LoanPolicy/LoanPolicySettings.js
@@ -22,6 +22,10 @@ class LoanPolicySettings extends React.Component {
       records: 'loanPolicies',
       perRequest: 100,
       path: 'loan-policy-storage/loan-policies',
+      params: {
+        query: 'cql.allRecords=1',
+        limit: '1000',
+      },
     },
     fixedDueDateSchedules: {
       type: 'okapi',
@@ -29,6 +33,10 @@ class LoanPolicySettings extends React.Component {
       perRequest: 100,
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
       resourceShouldRefresh: true,
+      params: {
+        query: 'cql.allRecords=1',
+        limit: '1000',
+      },
     },
   });
 

--- a/src/settings/NoticePolicy/NoticePolicySettings.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.js
@@ -25,6 +25,10 @@ class NoticePolicySettings extends React.Component {
       records: 'patronNoticePolicies',
       path: 'patron-notice-policy-storage/patron-notice-policies',
       throwErrors: false,
+      params: {
+        query: 'cql.allRecords=1',
+        limit: '1000',
+      },
     },
     templates: {
       type: 'okapi',

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -62,6 +62,10 @@ class PatronNotices extends React.Component {
       type: 'okapi',
       records: 'patronNoticePolicies',
       path: 'patron-notice-policy-storage/patron-notice-policies',
+      params: {
+        query: 'cql.allRecords=1',
+        limit: '1000',
+      },
       throwErrors: false,
     },
   });

--- a/src/settings/RequestPolicy/RequestPolicySettings.js
+++ b/src/settings/RequestPolicy/RequestPolicySettings.js
@@ -18,6 +18,10 @@ class RequestPolicySettings extends React.Component {
       type: 'okapi',
       records: 'requestPolicies',
       path: 'request-policy-storage/request-policies',
+      params: {
+        query: 'cql.allRecords=1',
+        limit: '1000',
+      },
     },
     nameUniquenessValidator: {
       type: 'okapi',


### PR DESCRIPTION
The default limit for a query is 10. 10 is too small, so now we retrieve
more. More Loan policies, more Patron notice policies, more Patron
notice templates, more Request policies. More is good. More is more.
Often, less is more, but not always, because sometimes most is more.

Refs [UICIRC-302](https://issues.folio.org/browse/UICIRC-302)