### PR TITLE
UIIN-678 avoid buggy react-to-print version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Retrieve 1000 elements on Settings pages instead of 10. Refs UICIRC-302.
 * Add missing tests for request policy. Part of UICIRC-293.
 * Integrate campus and library menus to circulation rules editor. Refs UICIRC-283.
+* Update `react-to-print` to accept React via `peerDependencies`. UIIN-678.
 
 ## [1.9.0](https://github.com/folio-org/ui-circulation/tree/v1.9.0) (2019-07-25)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.8.0...v1.9.0)

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "react-codemirror2": "^1.0.0",
     "react-intl": "^2.4.0",
     "react-quill": "^1.2.7",
-    "react-to-print": "^1.0.21",
+    "react-to-print": "^2.3.2",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {

--- a/src/settings/components/TemplateEditor/PreviewModal/PreviewModal.js
+++ b/src/settings/components/TemplateEditor/PreviewModal/PreviewModal.js
@@ -64,6 +64,7 @@ class PreviewModal extends React.Component {
           <FormattedMessage id="ui-circulation.settings.common.close" />
         </Button>
         <ReactToPrint
+          removeAfterPrint
           trigger={() => (
             <Button
               data-test-print-modal-template


### PR DESCRIPTION
`react-to-print` v1 depends directly on React with a caret dep on
version 16. This has the effect of pulling in the most-recent React 16.x
build into any bundle that uses this module, even if that module has a
more strict tilde dep on a less-than-current React minor release.
Whatnow? Say an app depends on React ~16.8.0; React 16.9.0 still gets
into the bundle because of the loose (caret) direct dependency in
react-to-print v1. This was fixed in
https://github.com/gregnb/react-to-print/pull/53 and appears to be the
straw that broke the v1.0-camel's back.

v2 also changed from using a `window` to an `iframe` to handle printing,
but does not automatically clean up the iframe after printing is
finished. This appears to be an oversight, but rather than introduce
another breaking change, they just added the prop in release 2.3.0.

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)