### PR TITLE
Fix staff slip test

### DIFF
--- a/test/bigtest/tests/staff-slip/staff-slip-settings-test.js
+++ b/test/bigtest/tests/staff-slip/staff-slip-settings-test.js
@@ -8,7 +8,7 @@ describe('StaffSlipSettings', () => {
   setupApplication();
 
   beforeEach(function () {
-    this.server.createList('staffSlips', 3);
+    this.server.createList('staffSlip', 3);
   });
 
   describe('viewing staff slip list', () => {


### PR DESCRIPTION
Found that without the fix the page is crashed while running the test as the slips were created by not using the factory and contained only ids, however, the tests pass.