### PR TITLE
UICIRC-285: Add backward moving feature to organization hierarchy menus in circulation rules editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Integrate campus and library menus to circulation rules editor. Refs UICIRC-283.
 * Update `react-to-print` to accept React via `peerDependencies`. UIIN-678.
 * Normalize a non alpha-numeric characters from Location Codes in circulation rules editor. Refs UICIRC-260.
+* Add backward moving feature to organization hierarchy menus in circulation rules editor. Refs UICIRC-285.
 
 ## [1.9.0](https://github.com/folio-org/ui-circulation/tree/v1.9.0) (2019-07-25)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.8.0...v1.9.0)

--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -70,18 +70,23 @@
 
 .CodeMirror-hint {
   padding: 0 14px;
+
+  &:hover {
+    background-color: #d7d7d7;
+  }
 }
-.CodeMirror-hint:hover {
-  background-color: #d7d7d7;
-}
+
 .rule-hint-major {
   background-color: #fff;
 }
+
 .rule-hint-strong {
   font-weight: bold;
   background-color: #d7d7d7;
 }
+
 /* Codemirror foldgutter styles */
+
 .Rules-foldmarker {
   color: blue;
   text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px,
@@ -90,17 +95,21 @@
   line-height: 0.3;
   cursor: pointer;
 }
+
 .Rules-foldgutter {
   width: 24px;
 }
+
 .Rules-foldgutter-open,
 .Rules-foldgutter-folded {
   cursor: pointer;
   text-align: center;
 }
+
 .Rules-foldgutter-open:after {
   content: "\25BC";
 }
+
 .Rules-foldgutter-folded:after {
   content: "\25B6";
 }
@@ -125,15 +134,25 @@
   min-width: 100% !important;
 }
 
-.cm-a:before {
+.cm-a:before,
+.cm-b:before,
+.cm-c:before,
+.cm-g:before,
+.cm-m:before,
+.cm-s:before,
+.cm-t:before,
+.cm-comment:before {
   content: "";
   display: inline-block;
   vertical-align: middle;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='4 4 18 18'%3E%3Cpolygon points='19.4 11.6 13.5 8.2 13.5 4.3 12.5 4.3 12.5 8.2 6.6 11.6 ' fill='%23006400'/%3E%3Cpath d='M11.8 7.7c-1.6 0.7-1.7 0.7-2.9 0.3 0-0.9-0.8-1.2-0.4-2.7 1.9 0.7 3.3-0.8 3.3-0.8S11.8 6.4 11.8 7.7z' fill='%23006400'/%3E%3Cpath d='M17.9 18.4v-5.7H8.1v3.2h0v3.3c0 0.7 2.2 1.3 4.9 1.3s4.9-0.6 4.9-1.3h0.1v-0.9L17.9 18.4 17.9 18.4zM13 14.4c1 0 1.8 0.8 1.8 1.8S14 18 13 18c-1 0-1.8-0.8-1.8-1.8S12 14.4 13 14.4z' fill='%23006400'/%3E%3C/svg%3E");
   repeat: no-repeat;
   width: 20px;
   height: 20px;
   background-size: 20px 20px;
+}
+
+.cm-a:before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='4 4 18 18'%3E%3Cpolygon points='19.4 11.6 13.5 8.2 13.5 4.3 12.5 4.3 12.5 8.2 6.6 11.6 ' fill='%23006400'/%3E%3Cpath d='M11.8 7.7c-1.6 0.7-1.7 0.7-2.9 0.3 0-0.9-0.8-1.2-0.4-2.7 1.9 0.7 3.3-0.8 3.3-0.8S11.8 6.4 11.8 7.7z' fill='%23006400'/%3E%3Cpath d='M17.9 18.4v-5.7H8.1v3.2h0v3.3c0 0.7 2.2 1.3 4.9 1.3s4.9-0.6 4.9-1.3h0.1v-0.9L17.9 18.4 17.9 18.4zM13 14.4c1 0 1.8 0.8 1.8 1.8S14 18 13 18c-1 0-1.8-0.8-1.8-1.8S12 14.4 13 14.4z' fill='%23006400'/%3E%3C/svg%3E");
 }
 
 .cm-b,
@@ -142,14 +161,7 @@
 }
 
 .cm-b:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M8.7 0.5c-3.5 0-6.4 2.5-6.4 5.6 0 3.1 2.8 5.6 6.4 5.6 3.5 0 6.4-2.5 6.4-5.6C15.1 3 12.3 0.5 8.7 0.5zM10 6H9.9V5.9h0.1V6z' fill='%23AABC68'/%3E%3Cpath d='M14.4 3.7c0.1 1 0.1 1.3-0.1 2.5 -0.2 1.1-1.2 2.3-2.2 2.9 -0.9 0.9-2.1 1.5-3.5 1.5 -0.9 0-1.7-0.3-2.5-0.7C5.1 9.7 4.1 9.3 3.3 8.5 3.1 8.3 3 8.2 2.9 8 2.8 8 2.8 8 2.7 8c0.8 2.2 3.2 3.9 6 3.9 3.5 0 6.4-2.5 6.4-5.6C15.1 5.3 14.8 4.5 14.4 3.7z' fill='%23489B00'/%3E%3Cpath d='M5.8 10.2c0 0 0.4 0.3 0.9 0.6 0.4 0.3 1.3 0.8 1.4 1.1 0.1 0.3 0.2 1.8 0.1 2.3 -0.1 0.5-0.5 0.8-0.9 1.4 -0.4 0.6-0.2 0.8-0.2 0.8h5c0 0-0.3-1-0.8-1.1s-0.7-0.2-1.2-0.7c-0.5-0.5-0.8-1.9-0.9-2.5 -0.1-0.6-0.1-0.2 0.3-0.8 0.4-0.6 0.9-0.8 1.2-1 0.5-0.5 0.5-0.8 0.5-0.8s-0.3 0.3-0.9 0.6c-0.3 0.2-0.9 0.3-1 0.3 -0.7-0.1-1.4-1-1.4-1s0.2 0.8-0.1 0.9c-0.2 0.1-0.6 0.3-0.9 0.1C6.6 10.3 5.8 10.2 5.8 10.2z' fill='%23A3694D'/%3E%3Cpath d='M11.3 15.3c-0.5-0.1-0.7-0.2-1.2-0.7 -0.5-0.5-0.8-1.9-0.9-2.5 -0.1-0.6-0.1-0.2 0.3-0.8 0.4-0.6 0.9-0.8 1.2-1 0.4-0.4 0.5-0.7 0.5-0.8 -0.3 0.4-0.7 0.7-1.1 1 -0.1 0.1-0.2 0.1-0.4 0.2 -0.2 0.3-0.5 0.6-0.8 0.9 0 0 0 0 0 0 0.1 0.5 0.2 1 0.3 1.6 0 0.1 0 0.3 0 0.4 0.1 0.2 0.2 0.4 0.2 0.6 0 0 0 0.1 0 0.1 0.2 0.2 0.3 0.4 0.5 0.6 0.3 0.1 0.6 0.2 0.8 0.4 0.5 0.3 0.9 0.6 1.2 1.1 0 0 0.1 0.1 0.1 0.1C12 16.3 11.7 15.4 11.3 15.3z' fill='%236D3D00'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-c,
@@ -158,14 +170,7 @@
 }
 
 .cm-c:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpolygon points='15.9 2.9 15.5 12.3 8.6 14.5 7.2 13.8 7.8 4.5 13.8 2.5 ' fill='%23634228'/%3E%3Cpolygon points='8.6 14.5 1.8 12 1.9 2.6 8.9 4.8 ' fill='%23996A3C'/%3E%3Cpolygon points='8.9 4.8 1.9 2.6 8.9 0.9 15.9 2.9 ' fill='%23875C35'/%3E%3Cpolygon points='6.7 4.1 4.1 3.3 6.2 2.6 8.5 3.4 ' fill='%23848484'/%3E%3Cpolygon points='6.6 7.3 4 6.2 4.1 3.3 6.7 4.1 ' fill='%23C6C6C6'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-g,
@@ -174,14 +179,7 @@
 }
 
 .cm-g:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M6 15.1h11.6c0-3-1.8-5.4-4.3-6.2 1.1-0.8 1.9-2.1 1.9-3.6 0-2.4-1.8-4.3-4-4.3 -2.2 0-4 1.9-4 4.3 0 1.7 0.9 3.2 2.3 3.9C7.5 10.1 6 12.4 6 15.1z' fill='%2361ADDB'/%3E%3Cpath d='M0.7 15.1H12.3c0-3-1.8-5.4-4.3-6.2C9.2 8.1 9.9 6.8 9.9 5.2c0-2.4-1.8-4.3-4-4.3S2 2.9 2 5.2c0 1.7 0.9 3.2 2.3 3.9C2.2 10.1 0.7 12.4 0.7 15.1z' fill='%231D62DF'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-m,
@@ -190,14 +188,7 @@
 }
 
 .cm-m:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpolygon points='16 12.2 10.3 13.2 8.4 13.2 1.7 12.2 1.7 1.2 7.9 2.2 10 2.2 16 1.2 ' fill='%23545454'/%3E%3Cpath d='M15.2 11.4l-5.2 1h-1.5l-5.9-1V1.7l0.8-1c0 0 2.5 0.1 3.1 0.2 0.8 0.2 2.2 1.3 2.2 1.3s1.4-0.7 2.4-1.1c0.5-0.2 3.3-0.3 3.3-0.3l0.9 0.7V11.4z' fill='%23DDD'/%3E%3Cpath d='M8.6 8.7C8.5 5.9 8.8 5.4 8.7 2.9 8.5 2.7 7.8 2.3 7.2 2 7.8 4 7.8 5.5 7.9 7.8c0 1.5 0 2.9 0 4.4l0.7 0.1L9 12.2C8.8 11.3 8.6 9.6 8.6 8.7z' fill='%23B7B7B7'/%3E%3Cpath d='M2.6 11.4l1.3-0.8c0 0 1.9-0.1 2.7 0.2S9 12.1 9 12.1s1.3-0.9 1.9-1 3.3-0.5 3.3-0.5l1.1 0.8 -5.2 1H8.4l-5.7-0.9' fill='%23B7B7B7'/%3E%3Cpolygon points='14.4 1 14.2 10.6 15.2 11.4 15.2 1.7 ' fill='%23B7B7B7'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-s,
@@ -206,14 +197,7 @@
 }
 
 .cm-s:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpolygon points='1.5 8.5 12.6 8.2 15.7 14.3 3.9 14.5 ' fill='%23B7713D'/%3E%3Crect x='4' y='14.3' width='11.7' height='1.6' fill='%239B5E35'/%3E%3Cpolygon points='1.5 8.5 1.5 9.8 4 15.9 4 14.3 ' fill='%239B5E35'/%3E%3Cpolygon points='15.2 6.1 14.3 14 11.3 14 12.2 6.1 ' fill='%237E961B'/%3E%3Cpolygon points='12.2 6.1 11.3 14 9.4 8.9 10.3 1 ' fill='%236F8418'/%3E%3Cpolygon points='12.8 1.3 11.1 1.3 10.9 1 10.3 1 12.2 6.1 15.2 6.1 13.3 1 12.8 1 ' fill='%238FAF1E'/%3E%3Cpolyline points='12.6 5.6 14.7 5.6 13 1.3 11.1 1.3 ' fill='%23FFFBC5'/%3E%3Cpolygon points='11.6 4.5 10.8 13.1 8.3 13 9.1 4.5 ' fill='%23B3230B'/%3E%3Cpolygon points='9.1 4.5 8.3 13 6.7 8.7 7.5 0.1 ' fill='%23A7210B'/%3E%3Cpolygon points='9.5 0.4 8.1 0.4 8 0.2 7.5 0.1 9.1 4.5 11.6 4.5 10 0.2 9.6 0.2 ' fill='%23CF290D'/%3E%3Cpolyline points='9.4 4.1 11.1 4.1 9.7 0.4 8.1 0.4 ' fill='%23FFFBC5'/%3E%3Cpolygon points='8.6 5.6 7.8 13.1 5.3 13 6.1 5.5 ' fill='%232F5291'/%3E%3Cpolygon points='6.1 5.5 5.3 13 3.7 8.7 4.5 1.2 ' fill='%23315699'/%3E%3Cpolygon points='6.5 1.5 5.1 1.5 4.9 1.2 4.5 1.2 6.1 5.5 8.6 5.6 7 1.2 6.5 1.2 ' fill='%233860B2'/%3E%3Cpolyline points='6.4 5.2 8.1 5.2 6.7 1.5 5.1 1.5 ' fill='%23FFFBC5'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-t,
@@ -222,14 +206,7 @@
 }
 
 .cm-t:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'%3E%3Cstyle%3E.a%7Bfill:%23444;%7D.b%7Bfill:%23636363;%7D%3C/style%3E%3Cpolygon points='13.9 14.4 3.5 14.4 3.5 0.5 9 0.5 13.9 5.5 ' fill='%23FFF'/%3E%3Cpath d='M14.3 14.7H3.2V0.1h6l5.1 5.2V14.7zM3.9 14h9.6V5.6L8.8 0.8H3.9V14z' class='a'/%3E%3Cpolygon points='8.5 0.7 9 0.7 9 5.1 13.5 5.4 13.6 6.1 8.5 6 ' fill='%238F9998'/%3E%3Crect x='5.3' y='2.6' width='3.6' height='0.8' class='b'/%3E%3Crect x='5.3' y='3.9' width='3.6' height='0.5' class='b'/%3E%3Crect x='5.3' y='5' width='4.8' height='0.5' class='b'/%3E%3Crect x='5.3' y='6.7' width='6.7' height='0.5' class='b'/%3E%3Crect x='5.3' y='7.9' width='6.8' height='0.5' class='b'/%3E%3Crect x='5.4' y='11.3' width='4.1' height='0.5' class='b'/%3E%3Crect x='5.4' y='12.4' width='4.1' height='0.5' class='b'/%3E%3Cpolygon points='13.9 5.9 8.9 5.2 8.6 0.5 9.4 0.4 9.7 4.6 14 5.2 ' class='a'/%3E%3C/svg%3E");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .cm-policy {
@@ -253,14 +230,7 @@
 }
 
 .cm-comment:before {
-  content: "";
-  display: inline-block;
-  vertical-align: middle;
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAQAAAADQ4RFAAAACXBIWXMAAAsTAAALEwEAmpwYAAADGGlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjaY2BgnuDo4uTKJMDAUFBUUuQe5BgZERmlwH6egY2BmYGBgYGBITG5uMAxIMCHgYGBIS8/L5UBFTAyMHy7xsDIwMDAcFnX0cXJlYE0wJpcUFTCwMBwgIGBwSgltTiZgYHhCwMDQ3p5SUEJAwNjDAMDg0hSdkEJAwNjAQMDg0h2SJAzAwNjCwMDE09JakUJAwMDg3N+QWVRZnpGiYKhpaWlgmNKflKqQnBlcUlqbrGCZ15yflFBflFiSWoKAwMD1A4GBgYGXpf8EgX3xMw8BSMDVQYqg4jIKAUICxE+CDEESC4tKoMHJQODAIMCgwGDA0MAQyJDPcMChqMMbxjFGV0YSxlXMN5jEmMKYprAdIFZmDmSeSHzGxZLlg6WW6x6rK2s99gs2aaxfWMPZ9/NocTRxfGFM5HzApcj1xZuTe4FPFI8U3mFeCfxCfNN45fhXyygI7BD0FXwilCq0A/hXhEVkb2i4aJfxCaJG4lfkaiQlJM8JpUvLS19QqZMVl32llyfvIv8H4WtioVKekpvldeqFKiaqP5UO6jepRGqqaT5QeuA9iSdVF0rPUG9V/pHDBYY1hrFGNuayJsym740u2C+02KJ5QSrOutcmzjbQDtXe2sHY0cdJzVnJRcFV3k3BXdlD3VPXS8Tbxsfd99gvwT//ID6wIlBS4N3hVwMfRnOFCEXaRUVEV0RMzN2T9yDBLZE3aSw5IaUNak30zkyLDIzs+ZmX8xlz7PPryjYVPiuWLskq3RV2ZsK/cqSql01jLVedVPrHzbqNdU0n22VaytsP9op3VXUfbpXta+x/+5Em0mzJ/+dGj/t8AyNmf2zvs9JmHt6vvmCpYtEFrcu+bYsc/m9lSGrTq9xWbtvveWGbZtMNm/ZarJt+w6rnft3u+45uy9s/4ODOYd+Hmk/Jn58xUnrU+fOJJ/9dX7SRe1LR68kXv13fc5Nm1t379TfU75/4mHeY7En+59lvhB5efB1/lv5dxc+NH0y/fzq64Lv4T8Ffp360/rP8f9/AA0ADzT6lvFdAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1MAAA6mAAADqYAAAXb5JfxUYAAAMZSURBVHjalJRNaF1FFMd/d+7M/XgvLy9pno0kBBtbCiIIIqQbKdRPUBSysG6Kq+Iquy6quHTvwg+ELFwIblRc1A9EurJFaqsYqbUWTaqtic17bfPy3r333XfvnRkXmTwrIuIMzIE58z//8zXHs/z/JeFlDDEh4OGhpqMFcdCfkQ0r6Wcb9irfeGt9CiKGXGGARO6iLSXR4vgLk0/W4hoKD7AYBiQmvZC9q5eryvuLaQeiJxrvzC3upU5IgHC3UFGI5NDkoY2lzovmrLcLChlStqbOH5ifpk6AROI5JouhJKZB8774zNoz+SfVDmgTydyn++dnGCMkQCIQd4A0BQofweDj6weqVYWEdWaPzy/cTZ2ICOV4POeeRePjAYZ93F7+41EfAdPMvdKiTkjomCQ+Pr6TkpCIgJgpWo/o+1MEqIda+xooFMrZ3HHLYLCAh3DamCni5/ymAO/wOIGzaokIMWjCkYzwAImPYozoQfGAAHlQIVwUAatcQqH4lYtIFNf5HoFwjCF2JpkV4O3xXFUkiiWepYfiJI+xieJVHmaNOtYlg5psSNCBwWKxVJQ8zQIBmse5lxqaw4wzwXAU5dAmRkKvk1OhMRRYloCUlONARsoxjpGTYDBocvJucUtA9/xtcioqNJo+CRrok1A5mWPRVBR0SX7yLgvYPnWNHkNKB9OjTrBYNCUVFQVDUjbpnN66IkC219/7ndQpS0p3lpQUbufkDGizluWnJBJStk40j7aUwgd8BBY76nKDoaIko80PfHsyzRQSzsFm96nZD2vNEItEuEzhcmoYMqDNRc6+f+FN9zVqAKd/fmnu7QYGzz20ozLkbLPBj6y8dXMpoNgBHQU01eotMir69OhhkEgMGQk9biTrn/feSL4MULsgDRT4+z0yOvzGpZXy9fqk2dtrDGN/S9/srJTfcWOMmNzFKmEIFNz1REiHdb44t3rkSK7IaJOyhzoQIhDYO6dRHUN4T3MxYZ2rH515fqJqIJBEGAJ8JPafIywEJV6r+te+7i5vfwAxBv+/5h4gvF/Ky9lX+jP5Nzf+bf05AH8eZf0CaV0YAAAAAElFTkSuQmCC");
-  repeat: no-repeat;
-  width: 20px;
-  height: 20px;
-  background-size: 20px 20px;
 }
 
 .rule-error {

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -67,7 +67,6 @@ function getTypeOptions(selector, typeKey) {
     text: `${text} `,
     displayText,
     className: 'rule-hint-minor',
-    completeOnSingleClick: true,
     id: selector.id,
   };
 }
@@ -117,7 +116,6 @@ export function rulesHint(Codemirror, props) {
         text: newRuleText,
         displayText: formatMessage({ id: 'ui-circulation.settings.circulationRules.newRule' }),
         className: 'rule-hint-major',
-        completeOnSingleClick: true,
       });
     }
 
@@ -134,7 +132,6 @@ export function rulesHint(Codemirror, props) {
           text: `${key} `,
           displayText: `${key}: ${text}`,
           className: 'rule-hint-minor',
-          completeOnSingleClick: true,
         });
       });
     }
@@ -177,7 +174,6 @@ export function rulesHint(Codemirror, props) {
           text: `${key} `,
           displayText: formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` }),
           className: 'rule-hint-minor',
-          completeOnSingleClick: true,
         });
       });
     }
@@ -193,7 +189,6 @@ export function rulesHint(Codemirror, props) {
             text: `${selector} `,
             displayText: selector,
             className: 'rule-hint-minor',
-            completeOnSingleClick: true,
           });
         });
       }
@@ -241,7 +236,6 @@ export function initSubMenuDataFetching(Codemirror, props) {
         text,
         displayText: text,
         className: 'rule-hint-minor',
-        completeOnSingleClick: true,
         inactive: true,
       });
     }

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -71,6 +71,16 @@ const propTypes = {
   filter: PropTypes.string,
 };
 
+function handleBackspace(cm) {
+  const { widget } = cm.state.completionActive;
+
+  if (widget.currentSectionIndex < 1) {
+    return cm.deleteH(-1, 'char');
+  }
+
+  widget.moveToPreviousSectionInCurrentSectionsList();
+}
+
 // custom handlers for working with the ever-present code hinting
 const moveFocus = value => (cm, handle) => handle.moveFocus(value);
 
@@ -342,6 +352,7 @@ class RulesEditor extends React.Component {
         End: (codeMirror, handle) => { handle.setFocus(handle.length - 1); },
         Enter: handleEnter,
         Tab: handleTab,
+        Backspace: handleBackspace,
         Esc: noop,
       }
     };

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -374,7 +374,6 @@ class RulesEditor extends React.Component {
 
     const hintOptions = {
       completeSingle: false,
-      completeOnSingleClick: true,
       hideOnUnfocus: true,
       customKeys: {
         Up: moveFocusUp,

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -16,6 +16,9 @@ import {
   HINT_ELEMENT_CLASS,
 } from '../../../constants';
 
+const HINT_SECTIONS_CONTAINER = 'CodeMirror-hints-sections-container';
+const HINT_SECTION_CONTAINER = 'CodeMirror-hints-list';
+
 CodeMirror.registerHelper('hint', 'auto', { resolve: resolveAutoHints });
 
 const defaultOptions = {
@@ -253,16 +256,15 @@ class Widget {
     return keyMap;
   }
 
-  static getHintElement(hintsContainer, targetElement) {
-    let currentSearchElement = targetElement;
+  static getHintElement(targetElement) {
+    return targetElement.closest(`.${HINT_ELEMENT_CLASS}`);
+  }
 
-    while (currentSearchElement && currentSearchElement !== hintsContainer) {
-      if (currentSearchElement.nodeName.toUpperCase() === 'LI' && currentSearchElement.parentNode === hintsContainer) {
-        return currentSearchElement;
-      }
+  static getHintSectionIndex(targetElement) {
+    const hintSections = targetElement.closest(`.${HINT_SECTIONS_CONTAINER}`);
+    const hintSection = targetElement.closest(`.${HINT_SECTION_CONTAINER}`);
 
-      currentSearchElement = currentSearchElement.parentNode;
-    }
+    return Array.from(hintSections.children).indexOf(hintSection);
   }
 
   constructor(completion, data) {
@@ -322,12 +324,7 @@ class Widget {
     });
 
     CodeMirror.on(this.container, 'click', e => {
-      const hint = Widget.getHintElement(this.getCurrentSection().listContainer, e.target);
-
-      if (hint && hint.hintId != null) {
-        this.changeActive(hint.hintId);
-        this.pick();
-      }
+      this.handleSectionHintClick(e.target);
     });
 
     CodeMirror.on(this.container, 'mousedown', () => setTimeout(() => cm.focus(), 20));
@@ -335,17 +332,61 @@ class Widget {
     CodeMirror.signal(data, 'select', completions[0], this.getCurrentSection().getListNodeAt(0));
   }
 
+  handleSectionHintClick(targetElement) {
+    const hint = Widget.getHintElement(targetElement);
+    const hintExists = hint && hint.hintId != null;
+
+    if (!hintExists) return;
+
+    const currentSectionIndex = Widget.getHintSectionIndex(targetElement);
+    const nextSectionIndex = currentSectionIndex + 1;
+    const isNextSectionEmpty = isEmpty(get(this.getSectionAt(nextSectionIndex), 'itemsOptions'));
+    const isSameHint = hint.hintId === this.getSectionAt(currentSectionIndex).selectedHintIndex;
+
+    if (isSameHint && !isNextSectionEmpty) return;
+
+    const isLastSection = currentSectionIndex === this.sections.length - 1;
+    const isSectionChanged = currentSectionIndex !== this.currentSectionIndex;
+
+    if (isSectionChanged && !isLastSection) {
+      this.currentSectionIndex = currentSectionIndex;
+      this.resetSectionsInCurrentSectionsListFrom(nextSectionIndex);
+    }
+
+    this.changeActive(hint.hintId);
+    this.pick();
+  }
+
+  resetSectionsInCurrentSectionsListFrom(index) {
+    this.sections.slice(index).forEach(section => section.clearItemsList());
+    this.data.sections.slice(index).forEach(section => {
+      section.selectedHintIndex = 0;
+    });
+  }
+
+  moveToPreviousSectionInCurrentSectionsList() {
+    const currentSection = this.getCurrentSection();
+
+    this.getCurrentSection(this.data).selectedHintIndex = 0;
+    currentSection.clearItemsList();
+    this.currentSectionIndex -= 1;
+  }
+
   getSelectedHintInCurrentSection() {
     return this.getCurrentSection().selectedHintIndex;
   }
 
   getCurrentSection(context = this) {
-    return context.sections[this.currentSectionIndex];
+    return this.getSectionAt(this.currentSectionIndex, context);
+  }
+
+  getSectionAt(index = this.currentSectionIndex, context = this) {
+    return context.sections[index];
   }
 
   initContainers() {
     this.container = createContainer('CodeMirror-hints');
-    this.sectionsContainer = createContainer('CodeMirror-hints-sections-container');
+    this.sectionsContainer = createContainer(HINT_SECTIONS_CONTAINER);
 
     if (this.data.header) {
       this.container.appendChild(createHeader(this.data.header, 'CodeMirror-hints-header'));
@@ -476,8 +517,8 @@ class Widget {
     const {
       childSection,
       list,
-    } = this.data.sections[this.currentSectionIndex];
-    const nextSectionData = this.data.sections[this.currentSectionIndex + 1];
+    } = this.getCurrentSection(this.data);
+    const nextSectionData = this.getSectionAt(this.currentSectionIndex + 1, this.data);
     const parentId = list[this.getSelectedHintInCurrentSection()].id;
 
     nextSectionData.list = CodeMirror.hint.getSubMenuData(this.completion.cm, { childSection, parentId });
@@ -485,18 +526,19 @@ class Widget {
 
   changeActive = (nextActiveHintIndex, avoidWrap) => {
     const currentSection = this.getCurrentSection();
-    const {
-      selectedHintIndex,
-      itemsOptions,
-    } = currentSection;
+    const { itemsOptions } = currentSection;
+    const nextHintIndex = currentSection.calculateNextHintIndex(nextActiveHintIndex, avoidWrap);
 
-    currentSection.changeActive(nextActiveHintIndex, avoidWrap);
+    if (currentSection.isSelectedByIndex(nextHintIndex)) return;
+
+    this.getCurrentSection(this.data).selectedHintIndex = nextHintIndex;
+    currentSection.changeActive(nextHintIndex);
 
     CodeMirror.signal(
       this.data,
       'select',
-      itemsOptions[selectedHintIndex],
-      currentSection.getListNodeAt(selectedHintIndex)
+      itemsOptions[nextHintIndex],
+      currentSection.getListNodeAt(nextHintIndex)
     );
   };
 
@@ -508,7 +550,7 @@ class Widget {
 class HintSection {
   constructor(sectionOptions, cm) {
     this.cm = cm;
-    this.container = createContainer('CodeMirror-hints-list');
+    this.container = createContainer(HINT_SECTION_CONTAINER);
     this.setSelectedHintIndex(sectionOptions.selectedHintIndex || 0);
     this.defaultSelectedHintIndex = this.selectedHintIndex;
     this.itemsOptions = sectionOptions.list;
@@ -543,6 +585,7 @@ class HintSection {
   }
 
   clearItemsList() {
+    this.defaultSelectedHintIndex = 0;
     this.setSelectedHintIndex(this.defaultSelectedHintIndex);
     this.itemsOptions = [];
 
@@ -563,7 +606,7 @@ class HintSection {
     return this.listContainer.childNodes[index];
   }
 
-  changeActive(nextActiveHintIndex, avoidWrap) {
+  calculateNextHintIndex(nextActiveHintIndex, avoidWrap) {
     const itemsOptionsSize = this.itemsOptions.length;
     let nextIndex = nextActiveHintIndex;
 
@@ -573,8 +616,10 @@ class HintSection {
       nextIndex = avoidWrap ? 0 : itemsOptionsSize - 1;
     }
 
-    if (this.isSelectedByIndex(nextIndex)) return;
+    return nextIndex;
+  }
 
+  changeActive(nextIndex) {
     let hintNode = this.getListNodeAt(this.selectedHintIndex);
 
     if (hintNode) {

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -24,7 +24,6 @@ const defaultOptions = {
   alignWithWord: true,
   closeCharacters: /[\s()[]{};:>,]/,
   closeOnUnfocus: true,
-  completeOnSingleClick: true,
   container: null,
   customKeys: null,
   extraKeys: null
@@ -322,24 +321,12 @@ class Widget {
       this.container.style.left = `${this.position.left + startScroll.left - curScroll.left}px`;
     });
 
-    CodeMirror.on(this.container, 'dblclick', e => {
-      const hint = Widget.getHintElement(this.getCurrentSection().listContainer, e.target);
-
-      if (hint && hint.hintId != null) {
-        this.changeActive(hint.hintId);
-        this.pick();
-      }
-    });
-
     CodeMirror.on(this.container, 'click', e => {
       const hint = Widget.getHintElement(this.getCurrentSection().listContainer, e.target);
 
       if (hint && hint.hintId != null) {
         this.changeActive(hint.hintId);
-
-        if (completion.options.completeOnSingleClick) {
-          this.pick();
-        }
+        this.pick();
       }
     });
 

--- a/test/bigtest/interactors/circulation-rules.js
+++ b/test/bigtest/interactors/circulation-rules.js
@@ -105,6 +105,15 @@ const scrollingOffset = 3;
     }).run();
   });
 
+  setValueWithoutShowingHint = action(function (value) {
+    return this.find('.CodeMirror').do(({ CodeMirror }) => {
+      CodeMirror.doc.setValue(value);
+      CodeMirror.setCursor(CodeMirror.lineCount(), 0);
+
+      return CodeMirror;
+    }).run();
+  });
+
   pickHint = action(function (index = 0) {
     return this.find('.CodeMirror').do(({ CodeMirror }) => {
       const {
@@ -144,6 +153,7 @@ const scrollingOffset = 3;
   pressTab = this.pressKey(9);
   pressArrowDown = this.pressKey(40);
   pressArrowUp = this.pressKey(38);
+  pressBackspace = this.pressKey(8);
 
   textArea = new Interactor('textarea');
   hints = new Hints();

--- a/test/bigtest/interactors/circulation-rules.js
+++ b/test/bigtest/interactors/circulation-rules.js
@@ -89,26 +89,19 @@ const scrollingOffset = 3;
   };
 
   clickOnItem = this.triggerItemEvent('click');
-  doubleClickOnItem = this.triggerItemEvent('dblclick');
 }
 
 @interactor class Editor {
   static defaultScope = '.react-codemirror2';
 
-  setValue = action(function (value) {
+  setValue = action(function (value, showHint = true) {
     return this.find('.CodeMirror').do(({ CodeMirror }) => {
       CodeMirror.doc.setValue(value);
       CodeMirror.setCursor(CodeMirror.lineCount(), 0);
-      CodeMirror.showHint();
 
-      return CodeMirror;
-    }).run();
-  });
-
-  setValueWithoutShowingHint = action(function (value) {
-    return this.find('.CodeMirror').do(({ CodeMirror }) => {
-      CodeMirror.doc.setValue(value);
-      CodeMirror.setCursor(CodeMirror.lineCount(), 0);
+      if (showHint) {
+        CodeMirror.showHint();
+      }
 
       return CodeMirror;
     }).run();

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -127,8 +127,8 @@ describe('CirculationRules', () => {
           await circulationRules.editor.pressArrowUp();
         });
 
-        it('should not contain active items', () => {
-          expect(circulationRules.editor.hints.sections(0).isActiveItemPresent).to.be.false;
+        it('should contain active items', () => {
+          expect(circulationRules.editor.hints.sections(0).isActiveItemPresent).to.be.true;
         });
       });
 

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -494,6 +494,43 @@ describe('CirculationRules', () => {
     });
   });
 
+  describe('backspace button', () => {
+    beforeEach(async () => {
+      await circulationRules.editor.setValueWithoutShowingHint('b ');
+      await circulationRules.editor.textArea.focus();
+    });
+
+    describe('with reset to previous section behaviour', () => {
+      beforeEach(async () => {
+        // select first institute
+        await circulationRules.editor.hints.clickOnItem(0);
+
+        // reset selection
+        await circulationRules.editor.pressBackspace();
+
+        // select first institute
+        await circulationRules.editor.hints.clickOnItem(0);
+
+        // select first campus
+        await circulationRules.editor.hints.clickOnItem(1, 1);
+      });
+
+      it('should be treated properly', () => {
+        expect(circulationRules.editor.value).to.equal(`b ${replacer(campuses[campusesAmount - 1].code)} `);
+      });
+    });
+
+    describe('with normal behaviour', () => {
+      beforeEach(async () => {
+        await circulationRules.editor.pressBackspace();
+      });
+
+      it('should remove characters in editor', () => {
+        expect(circulationRules.editor.value).to.equal('b');
+      });
+    });
+  });
+
   describe('choosing type locating type - library', () => {
     beforeEach(async () => {
       await circulationRules.editor.setValue('c ');
@@ -670,7 +707,8 @@ describe('CirculationRules', () => {
 
   describe('choosing policy type', () => {
     beforeEach(async () => {
-      await circulationRules.editor.setValue('m book: ');
+      await circulationRules.editor.setValueWithoutShowingHint('m book: ');
+      await circulationRules.editor.textArea.focus();
     });
 
     describe('press enter on the selected item', () => {

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -715,16 +715,6 @@ describe('CirculationRules', () => {
         expect(circulationRules.editor.value).to.equal('m book: l ');
       });
     });
-
-    describe('click on the first item in policies list', () => {
-      beforeEach(async () => {
-        await circulationRules.editor.hints.doubleClickOnItem(0);
-      });
-
-      it('should choose loan policy type', () => {
-        expect(circulationRules.editor.value).to.equal('m book: l ');
-      });
-    });
   });
 
   describe('choosing loan policy', () => {


### PR DESCRIPTION
# Purpose
Implement moving to the previous section in current sections list upon click on Backspace button. Implement hint selecting functionality upon mouse click. Refs [UICIRC-285](https://issues.folio.org/browse/UICIRC-285).

# Screenshots

- clicking on Backspace button
![backspace](https://user-images.githubusercontent.com/40821852/63512167-cac86480-c4eb-11e9-8fbf-b4e941f1d705.gif)

- clicking on a mouse button
![mouse](https://user-images.githubusercontent.com/40821852/63512174-ce5beb80-c4eb-11e9-8738-5bb9183c2cd4.gif)