### PR TITLE
UICIRC-279 -Patron notice policy events updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "fixed-due-date-schedules-storage": "2.0",
       "loan-policy-storage": "1.0 2.0",
       "template-engine": "2.0",
-      "patron-notice-policy-storage": "0.7",
+      "patron-notice-policy-storage": "0.11",
       "location-units": "1.1",
       "locations": "3.0",
       "feesfines": "15.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -201,6 +201,7 @@ export const loanUserInitiatedEventsIds = {
   CHECK_OUT: 'Check out',
   RENEWED: 'Renewed',
   MANUAL_DUE_DATE_CHANGE: 'Manual due date change',
+  ITEM_RECALLED: 'Item recalled',
 };
 
 export const loanTimeBasedEventsIds = {
@@ -228,18 +229,21 @@ export const loanNoticesTriggeringEvents = [
     value: loanUserInitiatedEventsIds.MANUAL_DUE_DATE_CHANGE,
     label: 'ui-circulation.settings.noticePolicy.loanNotices.manualDueDateChange',
   },
+  {
+    value: loanUserInitiatedEventsIds.ITEM_RECALLED,
+    label: 'ui-circulation.settings.noticePolicy.loanNotices.itemRecalled',
+  },
 ];
 
 export const requestUserInitiatedEventsIds = {
   RECALL_REQUEST: 'Recall request',
-  RECALL_LOANEE: 'Recall loanee',
   HOLD: 'Hold request',
   PAGE: 'Paging request',
   CANCEL: 'Request cancellation'
 };
 
 export const requestTimeBasedEventsIds = {
-  HOLD_EXPIRATION: 'Hold Expiration',
+  HOLD_EXPIRATION: 'Hold expiration',
   REQUEST_EXPIRATION: 'Request expiration',
 };
 
@@ -275,10 +279,6 @@ export const requestNoticesTriggeringEvents = [
   {
     value: requestTimeBasedEventsIds.REQUEST_EXPIRATION,
     label: 'ui-circulation.settings.noticePolicy.requestNotices.requestExpiration',
-  },
-  {
-    value: requestUserInitiatedEventsIds.RECALL_LOANEE,
-    label: 'ui-circulation.settings.noticePolicy.requestNotices.recallLoanee',
   },
 ];
 

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -291,7 +291,6 @@
   "settings.noticePolicy.notices.upon": "Upon/At",
 
   "settings.noticePolicy.requestNotices.recallRequest": "Recall request",
-  "settings.noticePolicy.requestNotices.recallLoanee": "Due date change",
   "settings.noticePolicy.requestNotices.holdRequest": "Hold request",
   "settings.noticePolicy.requestNotices.pagingRequest": "Page request",
   "settings.noticePolicy.requestNotices.available": "Awaiting pickup",
@@ -301,6 +300,7 @@
   "settings.noticePolicy.notices.triggeringEvent": "Triggering event",
   "settings.noticePolicy.loanNotices.dueDate": "Loan due date/time",
   "settings.noticePolicy.loanNotices.manualDueDateChange": "Loan due date change",
+  "settings.noticePolicy.loanNotices.itemRecalled": "Item recalled",
   "settings.noticePolicy.loanNotices.renewed": "Item renewed",
   "settings.noticePolicy.loanNotices.checkIn": "Check in",
   "settings.noticePolicy.loanNotices.checkOut": "Check out",


### PR DESCRIPTION
# Purpose
- add "Item recalled" event to Loans section
- remove "Due date change" event from Requests section
- update patron-notice-policy-storage version
- update event name for "Hold expiration event"

# Link
https://issues.folio.org/browse/UICIRC-279

# Screenshot
![Screenshot_14](https://user-images.githubusercontent.com/43472449/65022069-f860cc00-d938-11e9-9a64-5858182b2d23.png)
