### PR TITLE
UICIRC-314: Add location items filtering into the circulation rules editor menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 1.12.0 (IN PROGRESS)
+
+* Add location items filtering into the circulation rules editor menu. Refs UICIRC-314
+
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)
 

--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -45,6 +45,36 @@
   font-weight: normal;
   border-bottom: #bebdbd solid 1px;
   border-top: #bebdbd solid 1px;
+  height: 20px;
+  padding-top: 4px;
+}
+
+.CodeMirror-hints-multiple-selection .CodeMirror-hints-subheader {
+  display: flex;
+  text-align: left;
+  padding-top: 3px;
+  height: 20px;
+  padding-right: 0px;
+  white-space: nowrap;
+  padding-left: 5px;
+}
+
+.CodeMirror-hints-multiple-selection .CodeMirror-hints-subheader input {
+  overflow: hidden;
+  float: left;
+  margin-left: 5px;
+  margin-top: -4px;
+  height: 20px;
+  min-width: 150px;
+  padding: 0 5px;
+  border-width: 2px;
+}
+
+.CodeMirror-hints-multiple-selection .CodeMirror-hints-subheader input:focus {
+  border: 1px solid #2b75bb;
+  padding: 0 6px;
+  box-shadow: inset 0 0 0 2px rgba(37, 118, 195, 0.3);
+  outline: none;
 }
 
 .CodeMirror-hints-sections-container {
@@ -56,6 +86,16 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+}
+
+.CodeMirror-checkbox-container {
+  width: 100%;
+  height: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .CodeMirror-checkbox-container input,
@@ -128,8 +168,18 @@
   overflow-y: auto;
 }
 
+.CodeMirror-hints-list ul li.hidden {
+  display: none;
+}
+
+.CodeMirror-hints-list ul li {
+  height: 12px;
+}
+
 .CodeMirror-hints-list.CodeMirror-hints-multiple-selection ul {
   max-height: 18em;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .CodeMirror-hint {

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -58,10 +58,9 @@ const getSectionsDescriptions = type => {
   }
 };
 
-function getTypeOptions(selector, typeKey) {
-  const isLocationTypeKey = isLocationType(typeKey);
-  const text = isLocationTypeKey ? selector.code : selector;
-  const displayText = isLocationTypeKey ? truncate(selector.displayCode, truncateOptions) : selector;
+function getItemOptions(selector, typeKey) {
+  const text = isLocationType(typeKey) ? selector.code : selector;
+  const displayText = getDisplayText(selector, typeKey);
 
   return {
     text: `${text} `,
@@ -69,6 +68,14 @@ function getTypeOptions(selector, typeKey) {
     className: 'rule-hint-minor',
     id: selector.id,
   };
+}
+
+function getDisplayText(selector, typeKey) {
+  if (isLocationType(typeKey)) {
+    return typeKey !== RULES_TYPE.LOCATION ? truncate(selector.displayCode, truncateOptions) : selector.displayCode;
+  }
+
+  return selector;
 }
 
 export function rulesHint(Codemirror, props) {
@@ -160,7 +167,7 @@ export function rulesHint(Codemirror, props) {
         const type = typeMapping[typeKeyProperty];
 
         completionLists[type].forEach(selector => {
-          result.push(getTypeOptions(selector, typeKeyProperty));
+          result.push(getItemOptions(selector, typeKeyProperty));
         });
       }
     }
@@ -204,6 +211,7 @@ export function rulesHint(Codemirror, props) {
 
         if (section.isMultipleSelection) {
           section.buttonText = formatMessage({ id: 'ui-circulation.settings.circulationRules.done' });
+          section.filterPlaceholder = formatMessage({ id: 'ui-circulation.settings.circulationRules.filterOptionsList' });
         }
       });
       // The first section should be always filled and other sections should be filed by request in getSubMenuData helper
@@ -247,7 +255,7 @@ export function initSubMenuDataFetching(Codemirror, props) {
 
     completionLists[type].forEach((selector) => {
       if (selector.parentId === options.parentId) {
-        subMenuData.push(getTypeOptions(selector, options.childSection));
+        subMenuData.push(getItemOptions(selector, options.childSection));
       }
     });
 

--- a/test/bigtest/interactors/circulation-rules.js
+++ b/test/bigtest/interactors/circulation-rules.js
@@ -11,6 +11,7 @@ import {
   scoped,
   triggerable,
   fillable,
+
 } from '@bigtest/interactor';
 
 import { ACTIVE_HINT_ELEMENT_CLASS } from '../../../src/constants';
@@ -48,9 +49,14 @@ const scrollingOffset = 3;
   isCompletionButtonHidden = hasClass('.CodeMirror-hint-section-button-container', 'hidden');
   isCompletionButtonDisabled = hasClass('.CodeMirror-hint-section-button', 'disabled');
   hasCheckBoxes = isPresent('input[type="checkbox"]');
+  filterInput = scoped('input[type="text"]');
 
   isCheckBoxChecked = function (itemIndex) {
     return this.$(`.CodeMirror-hint:nth-child(${itemIndex + 1}) input[type="checkbox"]`).checked;
+  }
+
+  getShownItemsCount = function () {
+    return this.itemsCount - this.$$('.CodeMirror-hint.hidden').length;
   }
 
   isScrollable = function () {
@@ -168,6 +174,7 @@ const scrollingOffset = 3;
   formPresent = isPresent('[data-test-circulation-rules-form]');
   editorPresent = isPresent('.react-codemirror2');
   clickSaveRulesBtn = clickable('#clickable-save-loan-rules');
+  filterInputField = new Interactor('[data-test-rules-filter]');
   isSaveButtonDisabled = property('#clickable-save-loan-rules', 'disabled');
   editor = new Editor();
   filter = fillable('[data-test-rules-filter]');

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -87,6 +87,7 @@
   "settings.circulationRules.selectLibrary": "Select library",
   "settings.circulationRules.selectLocation": "Select location",
   "settings.circulationRules.done": "Done",
+  "settings.circulationRules.filterOptionsList": "Filter options list",
   "settings.circulationRules.loanPolicies": "Loan policies",
   "settings.circulationRules.requestPolicies": "Request policies",
   "settings.circulationRules.noticePolicies": "Patron notice policies",


### PR DESCRIPTION
## Purpose

Add location items filtering into the circulation rules editor menu in the scope of the [story](https://issues.folio.org/browse/UICIRC-314).

## Screenshots

![filtering_1](https://user-images.githubusercontent.com/50317804/65022562-e16ea980-d939-11e9-86b9-81594d50cd42.png)
![filtering_2](https://user-images.githubusercontent.com/50317804/65022571-e3d10380-d939-11e9-9055-5fd222a554e7.png)
![filtering_3](https://user-images.githubusercontent.com/50317804/65022575-e59ac700-d939-11e9-83e3-5275a0948259.png)
![filtering_4](https://user-images.githubusercontent.com/50317804/65022582-e895b780-d939-11e9-8043-a48759bef996.png)
 