### PR TITLE
UICIRC-314: Fix filtered items selection on mouse click

### DIFF
--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -383,7 +383,7 @@ class Widget {
       this.resetSectionsInCurrentSectionsListFrom(nextSectionIndex);
     }
 
-    this.changeActive(hint.hintId);
+    this.changeActive(this.getCurrentSection().listNodes.indexOf(hint));
 
     const isCheckBoxHint = targetElement.type === 'checkbox';
 


### PR DESCRIPTION
## Purpose

Fix a bug about the incorrect filtered item selection on mouse click. This is an additional change for the [ticket](https://issues.folio.org/browse/UICIRC-314).  