### PR TITLE
UICIRC-295 - Allow user to resize text area for notice and staff slip templates

### DIFF
--- a/src/settings/components/TemplateEditor/PreviewModal/PreviewModal.js
+++ b/src/settings/components/TemplateEditor/PreviewModal/PreviewModal.js
@@ -114,10 +114,7 @@ class PreviewModal extends React.Component {
         size="medium"
         footer={this.renderFooter()}
       >
-        <div
-          className="ql-editor"
-          ref={this.editorRef}
-        >
+        <div ref={this.editorRef}>
           {contentComponent}
         </div>
       </Modal>

--- a/src/settings/components/TemplateEditor/TemplateEditor.css
+++ b/src/settings/components/TemplateEditor/TemplateEditor.css
@@ -3,3 +3,8 @@
   border-color: #900;
   background-color: rgba(153, 0, 0, 0.050000000000000044);
 }
+
+.editor {
+  resize: vertical;
+  overflow: auto;
+}

--- a/src/settings/components/TemplateEditor/TemplateEditor.js
+++ b/src/settings/components/TemplateEditor/TemplateEditor.js
@@ -197,6 +197,7 @@ class TemplateEditor extends React.Component {
                   <EditorToolbar />
                   <ReactQuill
                     id="template-editor"
+                    className={css.editor}
                     value={value}
                     ref={this.quill}
                     modules={this.modules}

--- a/src/settings/components/TemplateEditor/quillCustom.css
+++ b/src/settings/components/TemplateEditor/quillCustom.css
@@ -1,5 +1,6 @@
 .ql-editor {
   min-height: 100px !important;
+  resize: vertical; 
 }
 
 .ql-token {


### PR DESCRIPTION
# Purpose
- add ability to resize template editor

# Link
https://issues.folio.org/browse/UICIRC-295

# Screenshot
![Screenshot_5](https://user-images.githubusercontent.com/43472449/65526952-9422a700-defa-11e9-92a0-771758561f4f.png)
