### PR TITLE
UICIRC-334: Add handling of the special item Any for intermediate menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 1.12.0 (IN PROGRESS)
 
-* Add location items filtering into the circulation rules editor menu. Refs UICIRC-314
+* Add location items filtering into the circulation rules editor menu. Refs UICIRC-314.
 * Validate for closed loans and fines/fees in loan history settings. Refs UITEN-42.
 * Fix incorrect save button behavior in Circulation Rules Editor. Refs UICIRC-296.
+* Add handling of the special item Any for intermediate menus. Refs UICIRC-334.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -241,20 +241,21 @@ export function initSubMenuDataFetching(Codemirror, props) {
 
     const type = typeMapping[options.childSection];
 
-    if (options.childSection && isLocationType(options.childSection)) {
+    const hasAnyItem = options.childSection && isLocationType(options.childSection) && !options.isLastSection;
+
+    if (hasAnyItem) {
       const text = `<${formatMessage({ id: 'ui-circulation.settings.circulationRules.any' })}>`;
 
       subMenuData.push({
         text,
         displayText: text,
         className: 'rule-hint-minor',
-        inactive: true,
         id: `any${options.childSection}`,
       });
     }
 
     completionLists[type].forEach((selector) => {
-      if (selector.parentId === options.parentId) {
+      if (options.parentIds.includes(selector.parentId)) {
         subMenuData.push(getItemOptions(selector, options.childSection));
       }
     });

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -94,9 +94,12 @@ function handleEnter(cm, handle) {
 
 function selectHint(cm, handle) {
   const { currentSectionIndex } = cm.state.completionActive.widget;
-  const currentSection = handle.data.sections[currentSectionIndex];
+  const {
+    selectedHintIndex,
+    list,
+  } = handle.data.sections[currentSectionIndex];
 
-  if (currentSection.selectedHintIndex !== -1) {
+  if (selectedHintIndex !== -1 && selectedHintIndex < list.length) {
     handle.pick();
 
     return true;


### PR DESCRIPTION
## Purpose:

 Add handling of the special item Any for intermediate menus and remove the Any item for the last menus in scope of the [story](https://issues.folio.org/browse/UICIRC-334).

## Screenshots:

![any_item_1](https://user-images.githubusercontent.com/50317804/65589044-19589b00-df91-11e9-8a34-c237e98cf93c.png)
![any_item_2](https://user-images.githubusercontent.com/50317804/65589045-19589b00-df91-11e9-9df7-604cb453de13.png)
