### PR TITLE
UICIRC-333: Add full hierarchical path to location codes in the circulation rules editor field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Validate for closed loans and fines/fees in loan history settings. Refs UITEN-42.
 * Fix incorrect save button behavior in Circulation Rules Editor. Refs UICIRC-296.
 * Add handling of the special item Any for intermediate menus. Refs UICIRC-334.
+* Add full hierarchial path to location codes that are used in the input field of the circulation rules editor. Refs UICIRC-333.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -895,7 +895,7 @@ class MultipleSelectionHintSection extends HintSection {
       this.handleFilterInputChange();
     }
 
-    this.setCompletionButtonVisibility(list.length > 1);
+    this.setCompletionButtonVisibility(list.length > 0);
     this.setCompletionButtonEnabling(this.hasSelectedItems());
   }
 

--- a/src/settings/utils/location-code-formatters.js
+++ b/src/settings/utils/location-code-formatters.js
@@ -1,0 +1,37 @@
+import { find } from 'lodash';
+import replacer from './with-dash-replacer';
+
+export function formatCampusCode(campus, institutions) {
+  const targetInstitution = find(institutions.records, { id: campus.institutionId });
+
+  return `${replacer(targetInstitution.code)}>${replacer(campus.code)}`;
+}
+
+export function formatCampusDisplayCode(campus, institutions) {
+  const targetInstitution = find(institutions.records, { id: campus.institutionId });
+
+  return `${replacer(campus.code)} (${replacer(targetInstitution.code)})`;
+}
+
+export function formatLibraryCode(library, institutions, campuses) {
+  const targetCampus = find(campuses.records, { id: library.campusId });
+
+  return `${this.formatCampusCode(targetCampus, institutions)}>${replacer(library.code)}`;
+}
+
+export function formatLibraryDisplayCode(library, institutions, campuses) {
+  const targetCampus = find(campuses.records, { id: library.campusId });
+  const targetInstitution = find(institutions.records, { id: targetCampus.institutionId });
+
+  return `${replacer(library.code)} (${replacer(targetInstitution.code)}-${replacer(targetCampus.code)})`;
+}
+
+export function formatLocationCode(location, institutions, campuses, libraries) {
+  const targetLibrary = find(libraries.records, { id: location.libraryId });
+
+  return `${this.formatLibraryCode(targetLibrary, institutions, campuses)}>${replacer(location.code)}`;
+}
+
+export function formatLocationDisplayCode(location) {
+  return `${replacer(location.code)} (${location.name})`;
+}

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -491,8 +491,10 @@ describe('CirculationRules', () => {
             await circulationRules.editor.pickHint(campusesAmount - 1);
           });
 
-          it('should add the campus code to the editor', () => {
-            expect(circulationRules.editor.value).to.equal(`b ${replacer(campuses1[campusesAmount - 1].code)} `);
+          it('should add full hierarchical path with campus code to the editor', () => {
+            const code = `${replacer(institutions[0].code)}>${replacer(campuses1[campusesAmount - 1].code)}`;
+
+            expect(circulationRules.editor.value).to.equal(`b ${code} `);
           });
         });
       });
@@ -521,7 +523,9 @@ describe('CirculationRules', () => {
         });
 
         it('should work', () => {
-          expect(circulationRules.editor.value).to.equal(`b ${replacer(campuses1[campusesAmount - 1].code)} `);
+          const code = `${replacer(institutions[0].code)}>${replacer(campuses1[campusesAmount - 1].code)}`;
+
+          expect(circulationRules.editor.value).to.equal(`b ${code} `);
         });
       });
 
@@ -550,7 +554,9 @@ describe('CirculationRules', () => {
         });
 
         it('should work', () => {
-          expect(circulationRules.editor.value).to.equal(`b ${replacer(campuses2[0].code)} `);
+          const code = `${replacer(institutions[1].code)}>${replacer(campuses2[0].code)}`;
+
+          expect(circulationRules.editor.value).to.equal(`b ${code} `);
         });
       });
 
@@ -567,7 +573,9 @@ describe('CirculationRules', () => {
         });
 
         it('should work', () => {
-          expect(circulationRules.editor.value).to.equal(`b ${replacer(campuses2[0].code)} `);
+          const code = `${replacer(institutions[1].code)}>${replacer(campuses2[0].code)}`;
+
+          expect(circulationRules.editor.value).to.equal(`b ${code} `);
         });
       });
     });
@@ -660,8 +668,10 @@ describe('CirculationRules', () => {
             await circulationRules.editor.hints.clickOnItem(1, 2);
           });
 
-          it('should add library code to the editor value', () => {
-            expect(circulationRules.editor.value).to.equal(`c ${replacer(libraries1[0].code)} `);
+          it('should add full hierarchial path with library code to the editor value', () => {
+            const code = `${replacer(institutions[0].code)}>${replacer(campuses1[0].code)}>${replacer(libraries1[0].code)}`;
+
+            expect(circulationRules.editor.value).to.equal(`c ${code} `);
           });
         });
       });
@@ -915,9 +925,11 @@ describe('CirculationRules', () => {
               });
 
               it('should add the location codes of selected items to the editor', () => {
-                const locationCodesString = `${replacer(locations[locationsAmount - 2].code)} ${replacer(locations[locationsAmount - 1].code)}`;
+                const hierarchicalPath = `${replacer(institutions[0].code)}>${replacer(campuses1[0].code)}>${replacer(libraries1[0].code)}`;
+                const locationCode1 = `${hierarchicalPath}>${replacer(locations[locationsAmount - 2].code)}`;
+                const locationCode2 = `${hierarchicalPath}>${replacer(locations[locationsAmount - 1].code)}`;
 
-                expect(circulationRules.editor.value).to.equal(`s ${locationCodesString} `);
+                expect(circulationRules.editor.value).to.equal(`s ${locationCode1} ${locationCode2} `);
               });
             });
 


### PR DESCRIPTION
## Purpose

Add full hierarchical path to location codes in the circulation rules editor field in the scope of the [story](https://issues.folio.org/browse/UICIRC-333).

## Screenshots

![full_path_1](https://user-images.githubusercontent.com/50317804/65871071-50aabb80-e386-11e9-9512-cc2e92d0baa2.png)
![full_path_2](https://user-images.githubusercontent.com/50317804/65871072-50aabb80-e386-11e9-9dac-f3752ae87ea1.png)
![full_path_3](https://user-images.githubusercontent.com/50317804/65871073-50aabb80-e386-11e9-9c68-9c02d32c8d0b.png)


