### PR TITLE
UITEN-57: Clean up Loan history model before sending to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add handling of the special item Any for intermediate menus. Refs UICIRC-334.
 * Add full hierarchial path to location codes that are used in the input field of the circulation rules editor. Refs UICIRC-333.
 * Fix loan policy holds section. Refs UICIRC-349.
+* Clean up Loan history model. Refs UITEN-57.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/settings/LoanHistory/ExceptionsList.js
+++ b/src/settings/LoanHistory/ExceptionsList.js
@@ -5,8 +5,12 @@ import {
   uniqBy,
   get,
 } from 'lodash';
+import { arrayRemove } from 'redux-form';
 
-import { stripesConnect } from '@folio/stripes/core';
+import {
+  stripesConnect,
+  stripesShape,
+} from '@folio/stripes/core';
 import { Button } from '@folio/stripes/components';
 
 import ExceptionCard from './ExceptionCard';
@@ -28,6 +32,7 @@ class ExceptionsList extends Component {
     resources: PropTypes.shape({
       paymentMethods: PropTypes.object,
     }).isRequired,
+    stripes: stripesShape.isRequired,
   }
 
   handleAddField = () => {
@@ -35,7 +40,13 @@ class ExceptionsList extends Component {
   };
 
   handleRemoveField = index => {
-    this.props.fields.remove(index);
+    const {
+      fields,
+      stripes,
+    } = this.props;
+
+    stripes.store.dispatch(arrayRemove('loanHistoryForm', 'closingType.loanExceptions', index));
+    fields.remove(index);
   };
 
   render() {

--- a/src/settings/LoanHistory/LoanHistory.js
+++ b/src/settings/LoanHistory/LoanHistory.js
@@ -42,11 +42,11 @@ class LoanHistorySettings extends React.Component {
     const value = settings.length === 0 ? '' : settings[0].value;
     const defaultConfig = {
       closingType: {
-        loans: null,
+        loan: null,
         feeFine: null,
       },
       treatEnabled: false,
-      selectedPeriodsValues
+      selectedPeriodsValues,
     };
     let config;
 

--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -8,6 +8,8 @@ import {
   Field,
   FieldArray,
   getFormValues,
+  arrayRemoveAll,
+  change,
 } from 'redux-form';
 
 import stripesForm from '@folio/stripes/form';
@@ -27,11 +29,13 @@ import {
   closingTypes,
   closedLoansRules,
 } from '../../constants';
+import { normalize } from './utils/normalize';
 
 import css from './LoanHistoryForm.css';
 
 class LoanHistoryForm extends Component {
   static propTypes = {
+    dispatch: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
@@ -47,7 +51,16 @@ class LoanHistoryForm extends Component {
     this.state = { checked: false };
   }
 
-  onSave = data => this.props.onSubmit({ loan_history: JSON.stringify(data) });
+  onSave = data => {
+    const {
+      dispatch,
+      onSubmit,
+    } = this.props;
+
+    const normalizedData = normalize({ data, dispatch });
+
+    onSubmit({ loan_history: JSON.stringify(normalizedData) });
+  };
 
   getLastMenu = () => {
     const {
@@ -67,7 +80,16 @@ class LoanHistoryForm extends Component {
     );
   }
 
+  // Due to the issue https://github.com/erikras/redux-form/issues/4101
+  // the multiple actions should be dispatched instead of single one ('clearFields')
   toggleCheckbox = () => {
+    const { dispatch } = this.props;
+
+    dispatch(change('loanHistoryForm', 'closingType.feeFine', null));
+    dispatch(change('loanHistoryForm', 'closingType.loanExceptions', []));
+    dispatch(change('loanHistoryForm', 'feeFine', {}));
+    dispatch(arrayRemoveAll('loanHistoryForm', 'loanExceptions'));
+
     this.setState(({ checked }) => ({
       // eslint-disable-next-line react/no-unused-state
       checked: !checked

--- a/src/settings/LoanHistory/utils/normalize.js
+++ b/src/settings/LoanHistory/utils/normalize.js
@@ -1,0 +1,43 @@
+import {
+  cloneDeep,
+  forEach,
+  set,
+  isArray,
+  isString,
+} from 'lodash';
+import { change } from 'redux-form';
+
+import { closingTypesMap } from '../../../constants';
+
+const cleanInterval = ({ data, dispatch }) => {
+  const newData = cloneDeep(data);
+
+  forEach(data.closingType, (value, key) => {
+    if (isString(value) && value !== closingTypesMap.INTERVAL) {
+      set(newData, key, {});
+      dispatch(change('loanHistoryForm', key, {}));
+    } else if (isArray(value)) {
+      forEach(value, (loanExceptionsValue, index) => {
+        if (loanExceptionsValue !== closingTypesMap.INTERVAL) {
+          set(newData, [key, index], {});
+          dispatch(change('loanHistoryForm', [key, index], {}));
+        }
+      });
+    }
+  });
+
+  return newData;
+};
+
+export const normalize = entity => {
+  let cleanedEntity = cloneDeep(entity);
+  const cleaners = [cleanInterval];
+
+  forEach(cleaners, cleaner => {
+    cleanedEntity = cleaner(cleanedEntity);
+  });
+
+  return cleanedEntity;
+};
+
+export default normalize;

--- a/test/bigtest/interactors/loan-history/loan-history-form.js
+++ b/test/bigtest/interactors/loan-history/loan-history-form.js
@@ -10,6 +10,7 @@ import {
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+import RadioButtonInteractor from '@folio/stripes-components/lib/RadioButton/tests/interactor';
 import SelectInteractor from '@folio/stripes-components/lib/Select/tests/interactor';
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor';
 
@@ -20,6 +21,7 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
 
   duration = scoped('[data-test-period-duration]', TextFieldInteractor);
   interval = scoped('[data-test-period-interval]', SelectInteractor);
+  closingTypes = collection('label', RadioButtonInteractor);
 }
 
 @interactor class ExceptionSection {

--- a/test/bigtest/tests/loan-history/loan-history-form-test.js
+++ b/test/bigtest/tests/loan-history/loan-history-form-test.js
@@ -121,18 +121,48 @@ describe('Loan History Form', () => {
       });
     });
 
-    describe('selecting any radio button and clicking save button', () => {
+    describe('selecting any radio button', () => {
       beforeEach(async () => {
         await LoanHistoryForm
           .feeFine.selectRadio(closingTypesMap.IMMEDIATELY)
           .feeFine.selectRadio(closingTypesMap.INTERVAL)
           .feeFine.selectRadio(closingTypesMap.NEVER);
-
-        await LoanHistoryForm.saveButton.click();
       });
 
-      it('should save form successfully', () => {
-        expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+      describe('unchecking the checkbox', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.clickTreatEnabledCheckbox();
+        });
+
+        it('should disappear section for closed loans with associated fees/fines', () => {
+          expect(LoanHistoryForm.feefineSection.isPresent).to.be.false;
+        });
+
+        describe('when checkbox is checked', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.clickTreatEnabledCheckbox();
+          });
+
+          it('should display section for closed loans with associated fees/fines', () => {
+            expect(LoanHistoryForm.feefineSection.isPresent).to.be.true;
+          });
+
+          it('no radio button should be selected', () => {
+            const isChecked = LoanHistoryForm.feeFine.closingTypes().some(item => item.isChecked);
+
+            expect(isChecked).to.be.false;
+          });
+        });
+      });
+
+      describe('clicking save button', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.saveButton.click();
+        });
+
+        it('should save form successfully', () => {
+          expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+        });
       });
     });
 
@@ -217,18 +247,38 @@ describe('Loan History Form', () => {
         });
       });
 
-      describe('selecting any closing type radio button and clicking save button', () => {
+      describe('selecting any closing type radio button', () => {
         beforeEach(async () => {
+          await LoanHistoryForm.loan.selectRadio(closingTypesMap.IMMEDIATELY);
+
           await LoanHistoryForm
             .loanException.selectRadio(closingTypesMap.IMMEDIATELY)
             .loanException.selectRadio(closingTypesMap.INTERVAL)
             .loanException.selectRadio(closingTypesMap.NEVER);
-
-          await LoanHistoryForm.saveButton.click();
         });
 
-        it('should save form successfully', () => {
-          expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+        describe('clicking save button', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.saveButton.click();
+          });
+
+          it('should save form successfully', () => {
+            expect(LoanHistoryForm.callout.successCalloutIsPresent).to.be.true;
+          });
+        });
+
+        describe('unchecking the checkbox', () => {
+          beforeEach(async () => {
+            await LoanHistoryForm.clickTreatEnabledCheckbox();
+          });
+
+          it('should disappear section for closed loans with associated fees/fines', () => {
+            expect(LoanHistoryForm.feefineSection.isPresent).to.be.false;
+          });
+
+          it('save button should be active', () => {
+            expect(LoanHistoryForm.disabledSaveButton).to.be.false;
+          });
         });
       });
 


### PR DESCRIPTION
### Purpose
Clean up Loan history model before sending to the backend according to the [story](https://issues.folio.org/browse/UITEN-57).

**Demo**

![Scenario 3](https://user-images.githubusercontent.com/49517355/66127311-00d12c00-e5f4-11e9-931f-f447a8daace6.gif)

![Scenario 4](https://user-images.githubusercontent.com/49517355/66127528-95d42500-e5f4-11e9-8697-85c87dd8924d.gif)
