### PR TITLE
Fix loan policy holds section. Refs UICIRC-349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix incorrect save button behavior in Circulation Rules Editor. Refs UICIRC-296.
 * Add handling of the special item Any for intermediate menus. Refs UICIRC-334.
 * Add full hierarchial path to location codes that are used in the input field of the circulation rules editor. Refs UICIRC-333.
+* Fix loan policy holds section. Refs UICIRC-349.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/settings/LoanPolicy/LoanPolicyForm.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.js
@@ -69,7 +69,7 @@ class LoanPolicyForm extends React.Component {
     sections: {
       generalSection: true,
       recallsSection: true,
-      holdsSection: false,
+      holdsSection: true,
     },
   };
 

--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import get from 'lodash/get';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import {

--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import {
@@ -14,7 +15,7 @@ import {
 
 import optionsGenerator from '../../../../utils/options-generator';
 import { Period } from '../../../../components';
-import { intervalPeriods } from '../../../../../constants';
+import { intervalPeriods, loanProfileMap } from '../../../../../constants';
 
 class RequestManagementSection extends React.Component {
   static propTypes = {
@@ -101,15 +102,18 @@ class RequestManagementSection extends React.Component {
             />
           </div>
           <br />
-          <div data-test-request-management-section-alternate-renewal-loan-period>
-            <Period
-              fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
-              inputValuePath="requestManagement.holds.alternateRenewalLoanPeriod.duration"
-              selectValuePath="requestManagement.holds.alternateRenewalLoanPeriod.intervalId"
-              intervalPeriods={this.generateOptions(intervalPeriods, 'ui-circulation.settings.loanPolicy.selectInterval')}
-              changeFormValue={change}
-            />
-          </div>
+          {
+            get(policy, 'loansPolicy.profileId') === loanProfileMap.ROLLING && get(policy, 'requestManagement.holds.renewItemsWithRequest') &&
+            <div data-test-request-management-section-alternate-renewal-loan-period>
+              <Period
+                fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"
+                inputValuePath="requestManagement.holds.alternateRenewalLoanPeriod.duration"
+                selectValuePath="requestManagement.holds.alternateRenewalLoanPeriod.intervalId"
+                intervalPeriods={this.generateOptions(intervalPeriods, 'ui-circulation.settings.loanPolicy.selectInterval')}
+                changeFormValue={change}
+              />
+            </div>
+          }
         </Accordion>
       </div>
     );

--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
@@ -15,7 +15,10 @@ import {
 
 import optionsGenerator from '../../../../utils/options-generator';
 import { Period } from '../../../../components';
-import { intervalPeriods, loanProfileMap } from '../../../../../constants';
+import {
+  intervalPeriods,
+  loanProfileMap,
+} from '../../../../../constants';
 
 class RequestManagementSection extends React.Component {
   static propTypes = {
@@ -103,7 +106,8 @@ class RequestManagementSection extends React.Component {
           </div>
           <br />
           {
-            get(policy, 'loansPolicy.profileId') === loanProfileMap.ROLLING && get(policy, 'requestManagement.holds.renewItemsWithRequest') &&
+            get(policy, 'loansPolicy.profileId') === loanProfileMap.ROLLING &&
+            get(policy, 'requestManagement.holds.renewItemsWithRequest') &&
             <div data-test-request-management-section-alternate-renewal-loan-period>
               <Period
                 fieldLabel="ui-circulation.settings.requestManagement.alternateRenewalLoanPeriod"

--- a/test/bigtest/tests/loan-policy/loan-policy-form-test.js
+++ b/test/bigtest/tests/loan-policy/loan-policy-form-test.js
@@ -807,6 +807,12 @@ describe('LoanPolicyForm', () => {
 
         describe('alternate renewal loan period', () => {
           describe('loan policy:\n\t\t-loanable\n', () => {
+            beforeEach(async () => {
+              await LoanPolicyForm
+                .requestManagementSection.renewItemsWithRequest.clickInput()
+                .loansSection.loanProfile.selectAndBlur(translation['settings.loanPolicy.profileType.rolling']);
+            });
+
             it('should be displayed', () => {
               expect(LoanPolicyForm.requestManagementSection.alternateRenewalLoanPeriod.isPresent).to.be.true;
             });


### PR DESCRIPTION
## Purpose
The PR makes the loan policy holds section be open by default. It also fixes some minor issues related to `Alternate loan period at renewal for items with an active, pending hold request` field visibility.

## Link
https://issues.folio.org/browse/UICIRC-349