### PR TITLE
UICIRC-355 follow-up: remove isomorphic-fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add full hierarchial path to location codes that are used in the input field of the circulation rules editor. Refs UICIRC-333.
 * Fix loan policy holds section. Refs UICIRC-349.
 * Clean up Loan history model. Refs UITEN-57.
+* Clean up unused dependencies.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
   },
   "dependencies": {
     "html-to-react": "^1.3.3",
-    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",
     "moment": "^2.19.1",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
`isomorphic-fetch` caused errors in some unit tests and was factored out
of the codebase in #448. This update simply removes the (now unused)
dependency from the `package.json` file.

Refs [UICIRC-355](https://issues.folio.org/browse/UICIRC-355)