### PR TITLE
UICIRC-305: Fix data replacement issues in the circulation rules editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix loan policy holds section. Refs UICIRC-349.
 * Clean up Loan history model. Refs UITEN-57.
 * Clean up unused dependencies.
+* Fix data replacement issues in the circulation rules editor. Refs UICIRC-305.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -363,6 +363,20 @@ export const POLICY = {
   NOTICE: 'n',
 };
 
+export const EDITOR_KEYWORD = {
+  FALLBACK_POLICY: 'fallback-policy',
+  PRIORITY: 'priority'
+};
+
+export const EDITOR_SPECIAL_SYMBOL = {
+  HASH: '#',
+  SLASH: '/',
+  COMMA: ',',
+  PLUS: '+',
+  COLON: ':',
+  NEGATION: '!',
+};
+
 export const LOCATION_RULES_TYPES = [
   RULES_TYPE.INSTITUTION,
   RULES_TYPE.CAMPUS,

--- a/src/settings/lib/RuleEditor/initRulesCMM.js
+++ b/src/settings/lib/RuleEditor/initRulesCMM.js
@@ -3,35 +3,39 @@
 *  the circulation rules code hinting functionality.
 */
 
-import { LOCATION_RULES_TYPES } from '../../../constants';
+import {
+  LOCATION_RULES_TYPES,
+  EDITOR_KEYWORD,
+  EDITOR_SPECIAL_SYMBOL,
+} from '../../../constants';
 
 const hooks = {
-  '#': (stream, state) => { // # starts a rule, followed by name of rule.
+  [EDITOR_SPECIAL_SYMBOL.HASH]: (stream, state) => { // # starts a rule, followed by name of rule.
     stream.eatWhile(/[^/]/);
     state.ruleLine = true;
 
     return 'ruleName';
   },
-  '/': (stream) => { // comment for rest of line after '/'
+  [EDITOR_SPECIAL_SYMBOL.SLASH]: (stream) => { // comment for rest of line after '/'
     stream.skipToEnd();
 
     return 'comment';
   },
-  ',': (stream) => { // comma separators.
+  [EDITOR_SPECIAL_SYMBOL.COMMA]: (stream) => { // comma separators.
     stream.eatWhile(/\s/);
 
     return 'comma';
   },
-  '+': (stream) => { // plus 'and'
+  [EDITOR_SPECIAL_SYMBOL.PLUS]: (stream) => { // plus 'and'
     stream.eatWhile(/\s/);
     return 'and';
   },
-  ':': (stream, state) => { // separate l-value from r-value
+  [EDITOR_SPECIAL_SYMBOL.COLON]: (stream, state) => { // separate l-value from r-value
     stream.eatWhile(/\s/);
     state.rValue = true;
     state.keyProperty = null;
   },
-  '!': (stream) => {
+  [EDITOR_SPECIAL_SYMBOL.NEGATION]: (stream) => {
     stream.eatWhile(/\s/);
 
     return 'not';
@@ -47,7 +51,7 @@ function processToken(stream, state, parserConfig) {
   } = parserConfig;
   const typeKeys = Object.keys(typeMapping);
   const policyKeys = Object.keys(policyMapping);
-  const keywords = ['fallback-policy', 'priority'];
+  const keywords = [...Object.values(EDITOR_KEYWORD)];
 
   if (stream.sol()) {
     state.rValue = false;

--- a/src/settings/utils/rules-string-convertors.js
+++ b/src/settings/utils/rules-string-convertors.js
@@ -1,0 +1,120 @@
+import {
+  get,
+  has,
+  forEach,
+} from 'lodash';
+
+import {
+  POLICY,
+  RULES_TYPE,
+  EDITOR_KEYWORD,
+  EDITOR_SPECIAL_SYMBOL,
+} from '../../constants';
+
+function isPriorityLine(lineContent) {
+  return lineContent.includes(EDITOR_KEYWORD.PRIORITY);
+}
+
+function isCommentSymbol(symbol) {
+  const {
+    HASH,
+    SLASH,
+  } = EDITOR_SPECIAL_SYMBOL;
+
+  return symbol === HASH || symbol === SLASH;
+}
+
+function isWordsSeparatingSymbol(symbol) {
+  const {
+    PLUS,
+    COLON,
+  } = EDITOR_SPECIAL_SYMBOL;
+
+  return symbol === ' ' || symbol === PLUS || symbol === COLON;
+}
+
+function convertNamesToIdsInLine(line, records, itemsTypes) {
+  if (isPriorityLine(line)) return line;
+
+  let replacedString = '';
+  let currentType = '';
+  let currentWord = '';
+
+
+  for (let i = 0; i < line.length; i++) {
+    const currentCharacter = line[i];
+
+    if (isCommentSymbol(currentCharacter)) {
+      replacedString += line.substring(i);
+
+      return replacedString;
+    }
+
+    const isWordsSeparator = isWordsSeparatingSymbol(currentCharacter);
+    const isLastSymbol = i === line.length - 1;
+
+    if (isLastSymbol && !isWordsSeparator && currentWord) {
+      currentWord += currentCharacter;
+    }
+
+    if (isWordsSeparator || isLastSymbol) {
+      if (currentWord) {
+        if (currentType) {
+          const itemPath = `${currentType}.${currentWord}`;
+
+          if (has(records, itemPath)) {
+            replacedString += get(records, itemPath);
+            currentWord = '';
+          }
+        }
+
+        if (itemsTypes.includes(currentWord)) {
+          currentType = currentWord;
+        }
+
+        replacedString += currentWord;
+        currentWord = '';
+      }
+
+      if (isWordsSeparator) {
+        replacedString += currentCharacter;
+      }
+    } else if (!currentWord && currentCharacter === EDITOR_SPECIAL_SYMBOL.NEGATION) {
+      replacedString += currentCharacter;
+    } else {
+      currentWord += currentCharacter;
+    }
+  }
+
+  return replacedString;
+}
+
+export function convertNamesToIds(rulesStr, records) {
+  const lines = rulesStr.split('\n');
+  const itemsTypes = [...Object.values(POLICY), ...Object.values(RULES_TYPE)];
+  let replacedString = '';
+
+  for (let i = 0; i < lines.length; i++) {
+    replacedString += convertNamesToIdsInLine(lines[i], records, itemsTypes);
+
+    if (i !== lines.length - 1) {
+      replacedString += '\n';
+    }
+  }
+
+  return replacedString;
+}
+
+export function convertIdsToNames(rulesStr, records) {
+  let convertedString = rulesStr;
+
+  forEach(records, (currentTypeRecords) => {
+    forEach(currentTypeRecords, (id, code) => {
+      const re = new RegExp(id, 'g');
+
+      convertedString = convertedString.replace(re, code);
+    });
+  });
+
+  return convertedString;
+}

--- a/test/bigtest/helpers/messageConverters.js
+++ b/test/bigtest/helpers/messageConverters.js
@@ -22,7 +22,3 @@ export const getPeriodRepresentation = (period) => {
 };
 
 export const getRequiredLabel = (text) => `${text} *`;
-
-export const toLowercaseReplaceAllSpaces = (text, newSubstr = '-') => text.toLowerCase()
-  .split(' ')
-  .join(newSubstr);

--- a/test/bigtest/network/factories/loan-policy.js
+++ b/test/bigtest/network/factories/loan-policy.js
@@ -18,7 +18,7 @@ export const getPeriod = {
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
-  name: () => faker.hacker.noun(),
+  name: () => faker.hacker.noun() + faker.random.uuid(),
   description: () => faker.company.catchPhrase(),
   loanable: () => faker.random.boolean(),
   loansPolicy: {

--- a/test/bigtest/network/factories/patron-notice-policy.js
+++ b/test/bigtest/network/factories/patron-notice-policy.js
@@ -5,7 +5,7 @@ import {
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
-  name: () => faker.hacker.noun(),
+  name: () => faker.hacker.noun() + faker.random.uuid(),
   description: () => faker.company.catchPhrase(),
   action: () => faker.random.boolean(),
   metadata: {

--- a/test/bigtest/network/factories/request-policy.js
+++ b/test/bigtest/network/factories/request-policy.js
@@ -1,7 +1,7 @@
 import { Factory, faker } from '@bigtest/mirage';
 
 export default Factory.extend({
-  name: () => faker.hacker.noun(),
+  name: () => faker.hacker.noun() + faker.random.uuid(),
   description: () => faker.company.catchPhrase(),
   requestTypes: () => ['Hold'],
 });

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -5,11 +5,13 @@ import {
   afterEach,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { truncate } from 'lodash';
+import {
+  truncate,
+  kebabCase,
+} from 'lodash';
 
 import setupApplication from '../helpers/setup-application';
 import circulationRules from '../interactors/circulation-rules';
-import { toLowercaseReplaceAllSpaces } from '../helpers/messageConverters';
 import replacer from '../../../src/settings/utils/with-dash-replacer';
 
 const removeDisplayedHints = () => {
@@ -1039,7 +1041,7 @@ describe('CirculationRules', () => {
 
     it('should choose loan policy', () => {
       expect(circulationRules.editor.value).to.equal(
-        `m book: l ${toLowercaseReplaceAllSpaces(loanPolicies[0].name)} `
+        `m book: l ${kebabCase(loanPolicies[0].name)} `
       );
     });
   });
@@ -1059,7 +1061,7 @@ describe('CirculationRules', () => {
 
     it('should choose loan policy as a fallback', () => {
       expect(circulationRules.editor.value).to.equal(
-        `fallback-policy: l ${toLowercaseReplaceAllSpaces(loanPolicies[0].name)} `
+        `fallback-policy: l ${kebabCase(loanPolicies[0].name)} `
       );
     });
   });
@@ -1078,9 +1080,9 @@ describe('CirculationRules', () => {
       rPolicy = requestPolicies[0];
       nPolicy = patronNoticePolicies[0];
 
-      lName = toLowercaseReplaceAllSpaces(lPolicy.name);
-      rName = toLowercaseReplaceAllSpaces(rPolicy.name);
-      nName = toLowercaseReplaceAllSpaces(nPolicy.name);
+      lName = kebabCase(lPolicy.name);
+      rName = kebabCase(rPolicy.name);
+      nName = kebabCase(nPolicy.name);
 
       this.server.put('/circulation/rules', (_, request) => {
         const params = JSON.parse(request.requestBody);

--- a/test/bigtest/tests/rules-string-convertors-test.js
+++ b/test/bigtest/tests/rules-string-convertors-test.js
@@ -1,0 +1,144 @@
+import {
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { faker } from '@bigtest/mirage';
+import { expect } from 'chai';
+
+import {
+  convertIdsToNames,
+  convertNamesToIds,
+} from '../../../src/settings/utils/rules-string-convertors';
+import {
+  RULES_TYPE,
+  POLICY,
+} from '../../../src/constants';
+
+describe('Rules string convertors', () => {
+  const generateCode = (type, number) => {
+    return type + number;
+  };
+
+  const generateRecords = (recordsAmount) => {
+    const typeSymbols = [...Object.values(RULES_TYPE), ...Object.values(POLICY)];
+    const records = {};
+
+    typeSymbols.forEach((currentSymbol) => {
+      records[currentSymbol] = {};
+
+      for (let i = 0; i < recordsAmount; i++) {
+        records[currentSymbol][generateCode(currentSymbol, i)] = faker.random.uuid();
+      }
+    });
+
+    return records;
+  };
+
+  const generateCriteriaString = (type, recordNumber, records, isCodeUsed) => {
+    const criteriaValue = isCodeUsed ? generateCode(type, recordNumber) : records[type][generateCode(type, recordNumber)];
+
+    return `${type} ${criteriaValue}`;
+  };
+
+  const generatePoliciesString = (recordNumber, records, isCodeUsed) => {
+    let policiesString = '';
+
+    Object.values(POLICY).forEach((policy) => {
+      policiesString += `${generateCriteriaString(policy, recordNumber, records, isCodeUsed)} `;
+    });
+
+    return policiesString;
+  };
+
+  const generateRule = (type, records, isCodeUsed = false, recordNumber = 0) => {
+    const criteria = generateCriteriaString(type, recordNumber, records, isCodeUsed);
+    const policiesString = generatePoliciesString(recordNumber, records, isCodeUsed);
+
+    return `${criteria} : ${policiesString}`;
+  };
+
+  const recordsAmount = 2;
+  const records = generateRecords(recordsAmount);
+
+  it('should convert ids to names correctly for all policy and criteria types', () => {
+    const criteriaTypeSymbols = Object.values(RULES_TYPE);
+    let idsString = '';
+    let namesString = '';
+
+    criteriaTypeSymbols.forEach((criteriaTypeSymbol) => {
+      idsString += `${generateRule(criteriaTypeSymbol, records)}\n`;
+      namesString += `${generateRule(criteriaTypeSymbol, records, true)}\n`;
+    });
+
+    expect(convertIdsToNames(idsString, records)).to.equal(namesString);
+  });
+
+  it('should left priority line as it is', () => {
+    const namesString = 'priority: t, s, c, b, a, m, g';
+
+    expect(convertNamesToIds(namesString, records)).to.equal(namesString);
+  });
+
+  it('should convert names to ids correctly for all policy and criteria types', () => {
+    const criteriaTypeSymbols = Object.values(RULES_TYPE);
+    let idsString = '';
+    let namesString = '';
+
+    criteriaTypeSymbols.forEach((criteriaTypeSymbol) => {
+      idsString += `${generateRule(criteriaTypeSymbol, records)}\n`;
+      namesString += `${generateRule(criteriaTypeSymbol, records, true)}\n`;
+    });
+
+    expect(convertNamesToIds(namesString, records)).to.equal(idsString);
+  });
+
+  it('should handle comment lines correctly', () => {
+    const { MATERIAL } = RULES_TYPE;
+    const rule = generateRule(MATERIAL, records);
+    const slashCommentLine = `/${rule}`;
+    const dashCommentLine = '#Rule header';
+    const namesString = `${slashCommentLine} \n ${rule} \n ${dashCommentLine}`;
+    const idsString = `${slashCommentLine} \n ${generateRule(MATERIAL, records)} \n ${dashCommentLine}`;
+
+    expect(convertNamesToIds(namesString, records)).to.equal(idsString);
+  });
+
+  it('should handle negotiation correctly', () => {
+    const { MATERIAL } = RULES_TYPE;
+    const recordNumber = 0;
+    const recordCode = generateCode(MATERIAL, recordNumber);
+    const namesString = `${MATERIAL} !${recordCode}: ${generatePoliciesString(recordNumber, records, true)}`;
+    const idsString = `${MATERIAL} !${records[MATERIAL][recordCode]}: ${generatePoliciesString(recordNumber, records)}`;
+
+    expect(convertNamesToIds(namesString, records)).to.equal(idsString);
+  });
+
+  it('should handle plus sign correctly', () => {
+    const {
+      MATERIAL,
+      INSTITUTION,
+    } = RULES_TYPE;
+    const recordNumber = 0;
+    const materialTypeCode = generateCode(MATERIAL, recordNumber);
+    const materialTypeId = records[MATERIAL][materialTypeCode];
+    const institutionCode = generateCode(INSTITUTION, recordNumber);
+    const institutionId = records[INSTITUTION][institutionCode];
+    const policiesNamesString = generatePoliciesString(recordNumber, records, true);
+    const policiesIdsString = generatePoliciesString(recordNumber, records);
+    const namesString = `${MATERIAL} ${materialTypeCode} + ${INSTITUTION} ${institutionCode}: ${policiesNamesString}`;
+    const idsString = `${MATERIAL} ${materialTypeId} + ${INSTITUTION} ${institutionId}: ${policiesIdsString}`;
+
+    expect(convertNamesToIds(namesString, records)).to.equal(idsString);
+  });
+
+  it('should handle multiple criteria names separated by space', () => {
+    const { MATERIAL } = RULES_TYPE;
+    const recordCode = generateCode(MATERIAL, 0);
+    const record2Code = generateCode(MATERIAL, 1);
+    const materialTypes = records[MATERIAL];
+    const namesString = `${MATERIAL} ${recordCode} ${record2Code}: ${generatePoliciesString(0, records, true)}`;
+    const idsString = `${MATERIAL} ${materialTypes[recordCode]} ${materialTypes[record2Code]}: ${generatePoliciesString(0, records)}`;
+
+    expect(convertNamesToIds(namesString, records)).to.equal(idsString);
+  });
+});


### PR DESCRIPTION
## Purposes:

Fix data replacement issues in the circulation rules editor, that are listed in the description and comments in the [issue](https://issues.folio.org/browse/UICIRC-305) (The issue with reserved keywords (all, m, g, t, a, b, c, s and other) was moved out of the scope).