### PR TITLE
UICIRC-353: Add overdue fine policies menu to the circulation rules editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix validation error message display in the circulation rules editor. Refs UICIRC-377.
 * Validate the creation of the settings in the Anonymize closed loans section. Refs UITEN-58.
 * Create/Edit loan policy | Move Save/Cancel buttons to the footer Refs UICIRC-372.
+* Add the overdue fine policies menu to the circulation rules editor. Refs UICIRC-353.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -384,6 +384,7 @@ export const POLICY = {
   LOAN: 'l',
   REQUEST: 'r',
   NOTICE: 'n',
+  OVERDUE_FINE: 'o',
 };
 
 export const EDITOR_KEYWORD = {

--- a/src/settings/CirculationRules.js
+++ b/src/settings/CirculationRules.js
@@ -46,6 +46,7 @@ const editorDefaultProps = {
     [POLICY.LOAN]: 'loanPolicies',
     [POLICY.REQUEST]: 'requestPolicies',
     [POLICY.NOTICE]: 'noticePolicies',
+    [POLICY.OVERDUE_FINE]: 'overdueFinePolicies',
   },
 };
 
@@ -108,6 +109,15 @@ class CirculationRules extends React.Component {
       path: 'patron-notice-policy-storage/patron-notice-policies',
       params: {
         limit: '100',
+      },
+      resourceShouldRefresh: true,
+    },
+    overdueFinePolicies: {
+      type: 'okapi',
+      records: 'overdueFinePolicies',
+      path: 'overdue-fines-policies',
+      params: {
+        limit: '1000',
       },
       resourceShouldRefresh: true,
     },
@@ -176,6 +186,7 @@ class CirculationRules extends React.Component {
       loanPolicies,
       requestPolicies,
       noticePolicies,
+      overdueFinePolicies,
       locations,
       institutions,
       campuses,
@@ -188,6 +199,7 @@ class CirculationRules extends React.Component {
       !loanPolicies.isPending &&
       !requestPolicies.isPending &&
       !noticePolicies.isPending &&
+      !overdueFinePolicies.isPending &&
       !locations.isPending &&
       !institutions.isPending &&
       !campuses.isPending &&
@@ -216,6 +228,7 @@ class CirculationRules extends React.Component {
       loanPolicies,
       noticePolicies,
       requestPolicies,
+      overdueFinePolicies,
       institutions,
       campuses,
       libraries,
@@ -256,6 +269,7 @@ class CirculationRules extends React.Component {
         loanPolicies: loanPolicies.records.map(l => kebabCase(l.name)),
         requestPolicies: requestPolicies.records.map(r => kebabCase(r.name)),
         noticePolicies: noticePolicies.records.map(n => kebabCase(n.name)),
+        overdueFinePolicies: overdueFinePolicies.records.map(o => kebabCase(o.name)),
       },
     });
   }
@@ -268,6 +282,7 @@ class CirculationRules extends React.Component {
       loanPolicies,
       requestPolicies,
       noticePolicies,
+      overdueFinePolicies,
       institutions,
       campuses,
       libraries,
@@ -278,6 +293,10 @@ class CirculationRules extends React.Component {
       memo[code] = id;
 
       return memo;
+    };
+
+    const reducePolicyHandler = (memo, policy) => {
+      return reduceHandler(memo, kebabCase(policy.name), policy.id);
     };
 
     return {
@@ -302,15 +321,10 @@ class CirculationRules extends React.Component {
       [RULES_TYPE.LOCATION]: locations.records.reduce((memo, location) => {
         return reduceHandler(memo, formatter.formatLocationCode(location, institutions, campuses, libraries), location.id);
       }, {}),
-      [POLICY.LOAN]: loanPolicies.records.reduce((memo, loanPolicy) => {
-        return reduceHandler(memo, kebabCase(loanPolicy.name), loanPolicy.id);
-      }, {}),
-      [POLICY.REQUEST]: requestPolicies.records.reduce((memo, requestPolicy) => {
-        return reduceHandler(memo, kebabCase(requestPolicy.name), requestPolicy.id);
-      }, {}),
-      [POLICY.NOTICE]: noticePolicies.records.reduce((memo, noticePolicy) => {
-        return reduceHandler(memo, kebabCase(noticePolicy.name), noticePolicy.id);
-      }, {}),
+      [POLICY.LOAN]: loanPolicies.records.reduce(reducePolicyHandler, {}),
+      [POLICY.REQUEST]: requestPolicies.records.reduce(reducePolicyHandler, {}),
+      [POLICY.NOTICE]: noticePolicies.records.reduce(reducePolicyHandler, {}),
+      [POLICY.OVERDUE_FINE]: overdueFinePolicies.records.reduce(reducePolicyHandler, {}),
     };
   }
 

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -28,17 +28,7 @@ import css from './RulesEditor.css';
 const propTypes = {
   onChange: PropTypes.func.isRequired,
 
-  /*
-    big collection of 'code hint' data...
-    all the possible named values/selectors from all of the system categories (typeGroups)...
-    'Patron Groups',
-    'Campus',
-    'Branch',
-    'Collection',
-    'Material Type',
-    'Shelf',
-    'Loan Type'
-  */
+  // collection of 'code hint' data: all the possible named values/selectors from all of the system categories (typeGroups)
   completionLists: PropTypes.object,
 
   /*

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -2,7 +2,7 @@
 export default function config() {
   this.get('/circulation/rules', {
     'id' : '4c70f818-2edc-4cf8-aa27-16c14c5c7b58',
-    'rulesAsText': 'priority: t, s, c, b, a, m, g\nfallback-policy: m 1a54b431-2e4f-452d-9cae-9cee66c9a892 :l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 1a29c562-d725-4a28-a071-24fdfd23a990 n 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd87'
+    'rulesAsText': 'priority: t, s, c, b, a, m, g\nfallback-policy: m 1a54b431-2e4f-452d-9cae-9cee66c9a892 :l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 1a29c562-d725-4a28-a071-24fdfd23a990 n 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd87 o 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd89'
   });
 
   this.get('/groups', {
@@ -196,6 +196,10 @@ export default function config() {
 
   this.get('/loan-policy-storage/loan-policies', function ({ loanPolicies }) {
     return this.serializerOrRegistry.serialize(loanPolicies.all());
+  });
+
+  this.get('/overdue-fines-policies', function ({ overdueFinePolicies }) {
+    return this.serializerOrRegistry.serialize(overdueFinePolicies.all());
   });
 
   this.get('/patron-notice-policy-storage/patron-notice-policies', ({ patronNoticePolicies }) => {

--- a/test/bigtest/network/factories/overdue-fine-policy.js
+++ b/test/bigtest/network/factories/overdue-fine-policy.js
@@ -5,7 +5,7 @@ import {
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
-  name: () => faker.hacker.noun(),
+  name: () => faker.hacker.noun() + faker.random.uuid(),
   description: () => faker.company.catchPhrase(),
   countClosed: () => faker.random.boolean(),
   forgiveOverdueFine: () => faker.random.boolean(),

--- a/test/bigtest/tests/circulation-rules-test.js
+++ b/test/bigtest/tests/circulation-rules-test.js
@@ -43,6 +43,7 @@ describe('CirculationRules', () => {
   let libraries1;
   let libraries2;
   let locations;
+  let overdueFinePolicy;
 
   const shortInstitutionCode = 'INST';
   const longInstitutionCode = '/TESTCODE TESTCODE TESTCODE TESTCODE';
@@ -64,6 +65,7 @@ describe('CirculationRules', () => {
     loanPolicies = await this.server.createList('loanPolicy', 3);
     requestPolicies = await this.server.createList('requestPolicy', 3);
     patronNoticePolicies = await this.server.createList('patronNoticePolicy', 3);
+    overdueFinePolicy = await this.server.createList('overdueFinePolicy', 1);
     const institutionsWithShortCode1 = this.server.createList('institution', 1, { code: `${shortInstitutionCode}1` });
     const institutionsWithShortCode2 = this.server.createList('institution', 1, { code: `${shortInstitutionCode}2` });
     institutions = await this.server.createList('institution', institutionsAmount - 2, { code: longInstitutionCode });
@@ -1101,18 +1103,22 @@ describe('CirculationRules', () => {
     let lPolicy;
     let rPolicy;
     let nPolicy;
+    let oPolicy;
     let lName;
     let rName;
     let nName;
+    let oName;
 
     beforeEach(async function () {
       lPolicy = loanPolicies[0];
       rPolicy = requestPolicies[0];
       nPolicy = patronNoticePolicies[0];
+      oPolicy = overdueFinePolicy[0];
 
       lName = kebabCase(lPolicy.name);
       rName = kebabCase(rPolicy.name);
       nName = kebabCase(nPolicy.name);
+      oName = kebabCase(oPolicy.name);
 
       this.server.put('/circulation/rules', (_, request) => {
         const params = JSON.parse(request.requestBody);
@@ -1120,12 +1126,12 @@ describe('CirculationRules', () => {
         return params;
       });
 
-      await circulationRules.editor.setValue(`m book dvd: l ${lName} r ${rName} n ${nName}`);
+      await circulationRules.editor.setValue(`m book dvd: l ${lName} r ${rName} n ${nName} o ${oName}`);
       await circulationRules.clickSaveRulesBtn();
     });
 
     it('should choose loan policy as a fallback', () => {
-      expect(savedRules).to.equal(`m 1a54b431-2e4f-452d-9cae-9cee66c9a892 5ee11d91-f7e8-481d-b079-65d708582ccc: l ${lPolicy.id} r ${rPolicy.id} n ${nPolicy.id}`);
+      expect(savedRules).to.equal(`m 1a54b431-2e4f-452d-9cae-9cee66c9a892 5ee11d91-f7e8-481d-b079-65d708582ccc: l ${lPolicy.id} r ${rPolicy.id} n ${nPolicy.id} o ${oPolicy.id}`);
     });
 
     describe('changing circulation rules', () => {

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -92,6 +92,7 @@
   "settings.circulationRules.requestPolicies": "Request policies",
   "settings.circulationRules.noticePolicies": "Patron notice policies",
   "settings.circulationRules.circulationPolicies": "Circulation policies",
+  "settings.circulationRules.overdueFinePolicies": "Overdue fine policies",
 
   "settings.validate.fillIn": "Please fill this in to continue",
   "settings.validate.select": "Please make a selection",


### PR DESCRIPTION
## Purposes

Add overdue fine policies handling (menu and parsing) to the circulation rules editor in the scope of [UICIRC-353](https://issues.folio.org/browse/UICIRC-353).

## Screenshots

![ovedue_fine_policy](https://user-images.githubusercontent.com/50317804/67754070-7fc45380-fa3e-11e9-9e1f-479529206526.png)
![ovedue_fine_policy_1](https://user-images.githubusercontent.com/50317804/67754072-7fc45380-fa3e-11e9-868c-72a47b4adfbd.png)
