### PR TITLE
UICIRC-350 - Loan policy: Renewals section not displaying in view when Renewable = N

### DIFF
--- a/src/settings/LoanPolicy/LoanPolicyDetail.js
+++ b/src/settings/LoanPolicy/LoanPolicyDetail.js
@@ -159,7 +159,7 @@ class LoanPolicyDetail extends React.Component {
             getScheduleValue={this.getScheduleValue}
           />
           <RenewalsSection
-            isVisible={loanPolicy.renewable}
+            isVisible={loanPolicy.loanable}
             policy={loanPolicy}
             getValue={this.getValue}
             getDropdownValue={this.getDropdownValue}

--- a/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.js
+++ b/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.js
@@ -40,6 +40,16 @@ const RenewalsSection = (props) => {
       </Row>
       <Row>
         <Col xs={12}>
+          <div data-test-renewals-section-renewable>
+            <KeyValue
+              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewable" />}
+              value={getCheckboxValue('renewable')}
+            />
+          </div>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12}>
           <div data-test-renewals-section-unlimited-renewals>
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.loanPolicy.unlimitedRenewals" />}
@@ -48,14 +58,14 @@ const RenewalsSection = (props) => {
           </div>
         </Col>
       </Row>
-      { policy.isRenewable() && !policy.isUnlimitedRenewals() &&
+      { (!policy.isRenewable() || (policy.isRenewable() && !policy.isUnlimitedRenewals())) &&
         <div>
           <Row>
             <Col xs={12}>
               <div data-test-renewals-section-number-renewals-allowed>
                 <KeyValue
                   label={<FormattedMessage id="ui-circulation.settings.loanPolicy.numRenewalsAllowed" />}
-                  value={getValue('renewalsPolicy.numberAllowed')}
+                  value={getValue('renewalsPolicy.numberAllowed') || '-'}
                 />
               </div>
             </Col>


### PR DESCRIPTION
# Purpose
To show renewals section in case is policy is loanable

# Link
https://issues.folio.org/browse/UICIRC-350

# Screenshots
<img width="580" alt="Screen Shot 2019-11-05 at 11 45 23" src="https://user-images.githubusercontent.com/43472449/68196832-d3e0b200-ffc1-11e9-8aca-172d211f33e2.png">
<img width="579" alt="Screen Shot 2019-11-05 at 11 45 45" src="https://user-images.githubusercontent.com/43472449/68196833-d3e0b200-ffc1-11e9-8833-bdf8e6f14abf.png">
