### PR TITLE
UICIRC-388: Add minutes and hours support to the loan history form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Create/Edit loan policy | Move Save/Cancel buttons to the footer Refs UICIRC-372.
 * Lost item fee policies |  Create/Edit Request policies | Move Save/Cancel buttons to the footer UICIRC-370
 * Add the overdue fine policies menu to the circulation rules editor. Refs UICIRC-353.
+* Add minutes and hours support to the loan history form. Refs UICIRC-388.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,14 @@ export const intervalPeriodsLower = [
   },
 ];
 
+export const anonymizingIntervals = [
+  intervalIdsMap.MINUTES,
+  intervalIdsMap.HOURS,
+  intervalIdsMap.DAYS,
+  intervalIdsMap.WEEKS,
+  intervalIdsMap.MONTHS,
+];
+
 export const loanProfileMap = {
   FIXED: 'Fixed',
   ROLLING: 'Rolling',

--- a/src/settings/LoanHistory/LoanHistory.js
+++ b/src/settings/LoanHistory/LoanHistory.js
@@ -13,12 +13,7 @@ import { ConfigManager } from '@folio/stripes/smart-components';
 
 import LoanHistoryForm from './LoanHistoryForm';
 import { LoanHistory as validateLoanHistory } from '../Validation';
-
-const selectedPeriodsValues = [
-  'Days',
-  'Weeks',
-  'Months',
-];
+import { anonymizingIntervals } from '../../constants';
 
 class LoanHistorySettings extends React.Component {
   static propTypes = {
@@ -50,7 +45,7 @@ class LoanHistorySettings extends React.Component {
       feeFine: {},
       loanExceptions: [],
       treatEnabled: false,
-      selectedPeriodsValues,
+      selectedPeriodsValues: anonymizingIntervals,
     };
     let config;
 

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
@@ -16,15 +16,10 @@ import optionsGenerator from '../../utils/options-generator';
 import {
   closingTypesMap,
   intervalPeriods,
+  anonymizingIntervals,
 } from '../../../constants';
 
 import css from './AnonymizingTypeSelectContainer.css';
-
-const selectedPeriodsValues = [
-  'Days',
-  'Weeks',
-  'Months',
-];
 
 class AnonymizingTypeSelectContainer extends Component {
   static propTypes = {
@@ -38,7 +33,7 @@ class AnonymizingTypeSelectContainer extends Component {
     super(props);
 
     this.generateOptions = optionsGenerator.bind(null, props.intl.formatMessage);
-    this.selectedPeriods = intervalPeriods.filter(period => selectedPeriodsValues.includes(period.value));
+    this.selectedPeriods = intervalPeriods.filter(period => anonymizingIntervals.includes(period.value));
   }
 
   renderPeriod(name, path) {


### PR DESCRIPTION
## Purposes

Add minutes and hours support to the loan history form in the scope of the [issue](https://issues.folio.org/browse/UICIRC-388).

## Screenshots

![minutes_and_hours_1](https://user-images.githubusercontent.com/50317804/68382417-52715700-015c-11ea-8b1b-76d8895efe11.png)

![minutes_and_hours_3](https://user-images.githubusercontent.com/50317804/68382420-5309ed80-015c-11ea-871b-2c4cc1d248bf.png)

![minutes_and_hours_2](https://user-images.githubusercontent.com/50317804/68382422-5309ed80-015c-11ea-88f1-505ef918957a.png)
