### PR TITLE
UICIRC-341: Add lost item fee policies menu to the circulation rules …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add the overdue fine policies menu to the circulation rules editor. Refs UICIRC-353.
 * Add minutes and hours support to the loan history form. Refs UICIRC-388.
 * Update structure of the circulation rules editor tests. Refs UICIRC-382.
+* Add the lost item fee policies menu to the circulation rules editor. Refs UICIRC-341.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -393,6 +393,7 @@ export const POLICY = {
   REQUEST: 'r',
   NOTICE: 'n',
   OVERDUE_FINE: 'o',
+  LOST_ITEM_FEE: 'i',
 };
 
 export const EDITOR_KEYWORD = {

--- a/src/settings/CirculationRules.js
+++ b/src/settings/CirculationRules.js
@@ -50,6 +50,7 @@ const editorDefaultProps = {
     [POLICY.REQUEST]: 'requestPolicies',
     [POLICY.NOTICE]: 'noticePolicies',
     [POLICY.OVERDUE_FINE]: 'overdueFinePolicies',
+    [POLICY.LOST_ITEM_FEE]: 'lostItemFeePolicies',
   },
 };
 
@@ -124,6 +125,15 @@ class CirculationRules extends React.Component {
       },
       resourceShouldRefresh: true,
     },
+    lostItemFeePolicies: {
+      type: 'okapi',
+      records: 'lostItemFeePolicies',
+      path: 'lost-item-fees-policies',
+      params: {
+        limit: '1000',
+      },
+      resourceShouldRefresh: true,
+    },
     locations: {
       type: 'okapi',
       records: 'locations',
@@ -190,6 +200,7 @@ class CirculationRules extends React.Component {
       requestPolicies,
       noticePolicies,
       overdueFinePolicies,
+      lostItemFeePolicies,
       locations,
       institutions,
       campuses,
@@ -203,6 +214,7 @@ class CirculationRules extends React.Component {
       !requestPolicies.isPending &&
       !noticePolicies.isPending &&
       !overdueFinePolicies.isPending &&
+      !lostItemFeePolicies.isPending &&
       !locations.isPending &&
       !institutions.isPending &&
       !campuses.isPending &&
@@ -232,6 +244,7 @@ class CirculationRules extends React.Component {
       noticePolicies,
       requestPolicies,
       overdueFinePolicies,
+      lostItemFeePolicies,
       institutions,
       campuses,
       libraries,
@@ -273,6 +286,7 @@ class CirculationRules extends React.Component {
         requestPolicies: requestPolicies.records.map(r => kebabCase(r.name)),
         noticePolicies: noticePolicies.records.map(n => kebabCase(n.name)),
         overdueFinePolicies: overdueFinePolicies.records.map(o => kebabCase(o.name)),
+        lostItemFeePolicies: lostItemFeePolicies.records.map(i => kebabCase(i.name)),
       },
     });
   }
@@ -286,6 +300,7 @@ class CirculationRules extends React.Component {
       requestPolicies,
       noticePolicies,
       overdueFinePolicies,
+      lostItemFeePolicies,
       institutions,
       campuses,
       libraries,
@@ -328,6 +343,7 @@ class CirculationRules extends React.Component {
       [POLICY.REQUEST]: requestPolicies.records.reduce(reducePolicyHandler, {}),
       [POLICY.NOTICE]: noticePolicies.records.reduce(reducePolicyHandler, {}),
       [POLICY.OVERDUE_FINE]: overdueFinePolicies.records.reduce(reducePolicyHandler, {}),
+      [POLICY.LOST_ITEM_FEE]: lostItemFeePolicies.records.reduce(reducePolicyHandler, {}),
     };
   }
 

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -2,7 +2,7 @@
 export default function config() {
   this.get('/circulation/rules', {
     'id' : '4c70f818-2edc-4cf8-aa27-16c14c5c7b58',
-    'rulesAsText': 'priority: t, s, c, b, a, m, g\nfallback-policy: m 1a54b431-2e4f-452d-9cae-9cee66c9a892 :l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 1a29c562-d725-4a28-a071-24fdfd23a990 n 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd87 o 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd89'
+    'rulesAsText': 'priority: t, s, c, b, a, m, g\nfallback-policy: m 1a54b431-2e4f-452d-9cae-9cee66c9a892 :l d9cd0bed-1b49-4b5e-a7bd-064b8d177231 r 1a29c562-d725-4a28-a071-24fdfd23a990 n 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd87 o 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd89 i 1e5cb907-2dfd-4529-a8d8-0ba1cd86dd91'
   });
 
   this.get('/groups', {
@@ -200,6 +200,10 @@ export default function config() {
 
   this.get('/overdue-fines-policies', function ({ overdueFinePolicies }) {
     return this.serializerOrRegistry.serialize(overdueFinePolicies.all());
+  });
+
+  this.get('/lost-item-fees-policies', function ({ lostItemFeePolicies }) {
+    return this.serializerOrRegistry.serialize(lostItemFeePolicies.all());
   });
 
   this.get('/patron-notice-policy-storage/patron-notice-policies', ({ patronNoticePolicies }) => {

--- a/test/bigtest/network/factories/lost-item-fee-policy.js
+++ b/test/bigtest/network/factories/lost-item-fee-policy.js
@@ -14,7 +14,7 @@ export const getPeriod = {
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
-  name: () => faker.hacker.noun(),
+  name: () => faker.hacker.noun() + faker.random.uuid(),
   description: () => faker.company.catchPhrase(),
   itemAgedLostOverdue: getPeriod,
   patronBilledAfterAgedLost: getPeriod,

--- a/test/bigtest/tests/citrculation-rules-editor/hints-menu/policies-hints-menu-test.js
+++ b/test/bigtest/tests/citrculation-rules-editor/hints-menu/policies-hints-menu-test.js
@@ -51,6 +51,7 @@ describe('Circulation rules editor: policies hints', () => {
       expect(circulationRules.editor.hints.sections(0).items(1).text).to.equal('Request policies');
       expect(circulationRules.editor.hints.sections(0).items(2).text).to.equal('Patron notice policies');
       expect(circulationRules.editor.hints.sections(0).items(3).text).to.equal('Overdue fine policies');
+      expect(circulationRules.editor.hints.sections(0).items(4).text).to.equal('Lost item fee policies');
     });
 
     it('should display the correct header for the policy types hint menu', () => {

--- a/test/bigtest/tests/citrculation-rules-editor/pane-ui-test.js
+++ b/test/bigtest/tests/citrculation-rules-editor/pane-ui-test.js
@@ -22,6 +22,7 @@ describe('Circulation rules editor: pane UI', () => {
   let requestPolicies;
   let patronNoticePolicies;
   let overdueFinePolicy;
+  let lostItemFeePolicy;
 
   beforeEach(async function () {
     this.server.get('/circulation/rules', {
@@ -33,6 +34,7 @@ describe('Circulation rules editor: pane UI', () => {
     requestPolicies = await this.server.createList('requestPolicy', 3);
     patronNoticePolicies = await this.server.createList('patronNoticePolicy', 3);
     overdueFinePolicy = await this.server.createList('overdueFinePolicy', 3);
+    lostItemFeePolicy = await this.server.createList('lostItemFeePolicy', 3);
 
     return this.visit('/settings/circulation/rules', () => {
       expect(circulationRules.$root).to.exist;
@@ -108,21 +110,25 @@ describe('Circulation rules editor: pane UI', () => {
     let rPolicy;
     let nPolicy;
     let oPolicy;
+    let iPolicy;
     let lName;
     let rName;
     let nName;
     let oName;
+    let iName;
 
     beforeEach(async function () {
       lPolicy = loanPolicies[0];
       rPolicy = requestPolicies[0];
       nPolicy = patronNoticePolicies[0];
       oPolicy = overdueFinePolicy[0];
+      iPolicy = lostItemFeePolicy[0];
 
       lName = kebabCase(lPolicy.name);
       rName = kebabCase(rPolicy.name);
       nName = kebabCase(nPolicy.name);
       oName = kebabCase(oPolicy.name);
+      iName = kebabCase(iPolicy.name);
 
       this.server.put('/circulation/rules', (_, request) => {
         const params = JSON.parse(request.requestBody);
@@ -131,12 +137,12 @@ describe('Circulation rules editor: pane UI', () => {
         return params;
       });
 
-      await circulationRules.editor.setValue(`m book dvd: l ${lName} r ${rName} n ${nName} o ${oName}`);
+      await circulationRules.editor.setValue(`m book dvd: l ${lName} r ${rName} n ${nName} o ${oName} i ${iName}`);
       await circulationRules.clickSaveRulesBtn();
     });
 
     it('should choose loan policy as a fallback', () => {
-      expect(savedRules).to.equal(`m 1a54b431-2e4f-452d-9cae-9cee66c9a892 5ee11d91-f7e8-481d-b079-65d708582ccc: l ${lPolicy.id} r ${rPolicy.id} n ${nPolicy.id} o ${oPolicy.id}`);
+      expect(savedRules).to.equal(`m 1a54b431-2e4f-452d-9cae-9cee66c9a892 5ee11d91-f7e8-481d-b079-65d708582ccc: l ${lPolicy.id} r ${rPolicy.id} n ${nPolicy.id} o ${oPolicy.id} i ${iPolicy.id}`);
     });
 
     describe('changing circulation rules', () => {

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -94,6 +94,7 @@
   "settings.circulationRules.noticePolicies": "Patron notice policies",
   "settings.circulationRules.circulationPolicies": "Circulation policies",
   "settings.circulationRules.overdueFinePolicies": "Overdue fine policies",
+  "settings.circulationRules.lostItemFeePolicies": "Lost item fee policies",
 
   "settings.validate.fillIn": "Please fill this in to continue",
   "settings.validate.select": "Please make a selection",


### PR DESCRIPTION
## Purposes

Add lost item fee policies handling (menu and parsing) to the circulation rules editor in the scope of [UICIRC-341](https://issues.folio.org/browse/UICIRC-341).

## Screenshots

![lost_item_policy_1](https://user-images.githubusercontent.com/49517355/69822966-4d11a480-1210-11ea-8b8b-caa92765744d.png)
![lost_item_policy_2](https://user-images.githubusercontent.com/49517355/69822973-4edb6800-1210-11ea-9e52-75311c3b55d8.png)

