### PR TITLE
UICIRC-405: Remove periods values from default config in `<LoanHistory>`, handle CSS issue when the loan history form is being submitted and add tests for anonymizing intervals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Add Item Limit to Loan Policy. Refs UICIRC-390.
 * Overdue fine policy: Validation field incorrect for overdue recall fine. Refs UIU-1232.
 * Lost item fee policy: Words "late" and "Set cost" missing on entry of new policy. Refs UIU-1315.
+* Remove periods values from default config in `<LoanHistory>`, handle CSS issue when the loan history form is being submitted and add tests for anonymizing intervals. Refs UICIRC-405.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.11.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/src/settings/LoanHistory/LoanHistory.js
+++ b/src/settings/LoanHistory/LoanHistory.js
@@ -13,7 +13,6 @@ import { ConfigManager } from '@folio/stripes/smart-components';
 
 import LoanHistoryForm from './LoanHistoryForm';
 import { LoanHistory as validateLoanHistory } from '../Validation';
-import { anonymizingIntervals } from '../../constants';
 
 class LoanHistorySettings extends React.Component {
   static propTypes = {
@@ -45,7 +44,6 @@ class LoanHistorySettings extends React.Component {
       feeFine: {},
       loanExceptions: [],
       treatEnabled: false,
-      selectedPeriodsValues: anonymizingIntervals,
     };
     let config;
 

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
@@ -94,7 +94,7 @@ class AnonymizingTypeSelectContainer extends Component {
         <Field
           name={`${path}Selected`}
           component={({ meta }) => {
-            return meta.touched && <span className={css.error}>{meta.error}</span>;
+            return meta.touched && meta.error ? <span className={css.error}>{meta.error}</span> : null;
           }}
         />
       </Fragment>

--- a/test/bigtest/interactors/loan-history/loan-history-form.js
+++ b/test/bigtest/interactors/loan-history/loan-history-form.js
@@ -21,6 +21,7 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
 
   duration = scoped('[data-test-period-duration]', TextFieldInteractor);
   interval = scoped('[data-test-period-interval]', SelectInteractor);
+  intervalSelector = scoped('[data-test-period-interval] select');
   closingTypes = collection('label', RadioButtonInteractor);
 }
 

--- a/test/bigtest/interactors/staff-slip/staff-slip-detail.js
+++ b/test/bigtest/interactors/staff-slip/staff-slip-detail.js
@@ -10,7 +10,7 @@ import KeyValue from '../KeyValue';
 @interactor class PreviewModal {
   isLoaded = isPresent('[data-test-close-tokens-modal]');
   whenLoaded() {
-    return this.when(() => this.isLoaded);
+    return this.when(() => this.isLoaded).timeout(5000);
   }
 
   barcodeIsPresent = isPresent('barcode');

--- a/test/bigtest/tests/loan-history/loan-history-form-test.js
+++ b/test/bigtest/tests/loan-history/loan-history-form-test.js
@@ -4,11 +4,23 @@ import {
   it,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
+import { forEach } from 'lodash';
 
 import setupApplication from '../../helpers/setup-application';
 import LoanHistoryForm from '../../interactors/loan-history/loan-history-form';
 
-import { closingTypesMap } from '../../../../src/constants';
+import {
+  closingTypesMap,
+  intervalIdsMap,
+} from '../../../../src/constants';
+
+const intervals = {
+  MINUTES: 'Minute(s)',
+  HOURS: 'Hour(s)',
+  DAYS: 'Day(s)',
+  WEEKS: 'Week(s)',
+  MONTHS: 'Month(s)',
+};
 
 describe('Loan History Form', () => {
   setupApplication({ scenarios: ['testLoanHistory'] });
@@ -64,6 +76,18 @@ describe('Loan History Form', () => {
 
     it('save button should be active', () => {
       expect(LoanHistoryForm.disabledSaveButton).to.be.false;
+    });
+
+    forEach(intervals, (value, key) => {
+      describe('selecting interval', () => {
+        beforeEach(async () => {
+          await LoanHistoryForm.loan.interval.selectAndBlur(value);
+        });
+
+        it(`interval ${value} should be present`, () => {
+          expect(LoanHistoryForm.loan.intervalSelector.value).to.be.equal(intervalIdsMap[key]);
+        });
+      });
     });
 
     describe('filling completely the interval closing type fields', () => {


### PR DESCRIPTION
## Purpose
Remove periods values from default config in `<LoanHistory>`, handle CSS issue when the loan history form is being submitted and add tests for anonymizing intervals. [Story](https://issues.folio.org/browse/UICIRC-405).