### PR TITLE
UICIRC-396 - Add hold shelf exp and request exp date/time tokens to patron notice templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.13.0] (IN PROGRESS)
 
 * Provide two options for barcode tokens on staff slips. Refs UICIRC-393.
+* Add hold shelf exp and request exp date/time tokens to patron notice templates. UICIRC-396.
 
 ## [1.12.0](https://github.com/folio-org/ui-circulation/tree/v1.12.0) (2019-12-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.11.0...v1.12.0)

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -24,8 +24,10 @@ const formats = {
   },
   request: {
     'request.servicePointPickup': 'Circulation Desk - Main Library',
-    'request.requestExpirationDate': 'Jun 30, 2020 23:59',
-    'request.holdShelfExpirationDate': 'Mar 31, 2020 23:59',
+    'request.requestExpirationDate': 'Mar 31 30, 2020',
+    'request.requestExpirationDateTime': 'Mar 31, 2020 23:59',
+    'request.holdShelfExpirationDate': 'Jun 30, 2020',
+    'request.holdShelfExpirationDateTime': 'Jun 30, 2020 23:59',
     'request.reasonForCancellation': 'Item not available',
     'request.additionalInfo': 'Additional information regarding the request cancellation',
   },


### PR DESCRIPTION
# Purpose
Add requestExpirationDateTime and holdShelfExpirationDateTime tokens for patron notices.

# Link
https://issues.folio.org/browse/UICIRC-396

# Screenshots
<img width="1680" alt="Screen Shot 2019-12-09 at 12 03 53" src="https://user-images.githubusercontent.com/43472449/70426829-560a3d80-1a7c-11ea-9b65-1e1f69261dde.png">
<img width="1094" alt="Screen Shot 2019-12-09 at 12 04 17" src="https://user-images.githubusercontent.com/43472449/70426830-560a3d80-1a7c-11ea-884b-2195ef3a90ec.png">
