### PR TITLE
UICIRC-375: Add buttonStyle missing prop

### DIFF
--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -75,6 +75,7 @@ class LoanHistoryForm extends Component {
           <Button
             data-test-loan-history-save-button
             type="submit"
+            buttonStyle="primary paneHeaderNewButton"
             disabled={pristine || submitting}
             marginBottom0
           >


### PR DESCRIPTION
### Description
Add to PaneFooter's `save` button missing prop `buttonStyle`, to make button blue color, when it is enabled 

---

### Story
https://issues.folio.org/browse/UICIRC-375

---

### Screenshot
![image](https://user-images.githubusercontent.com/55694637/70977150-03e99d80-20b6-11ea-9220-20338f129461.png)
