### PR TITLE
remove extra/incorrect accordion styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Update circulation okapiInterface to version `9.0`. Part of UICIRC-411.
 * Add translations for aria-label values in EditorToolbar(WYSIWYG). Refs UICIRC-421.
 * Migrate to `stripes` `v3.0.0` and move `react-intl` to peerDependencies.
+* Remove extraneous accordion styling from lost-item fee-fine form.
 
 ## [1.12.0](https://github.com/folio-org/ui-circulation/tree/v1.12.0) (2019-12-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.11.0...v1.12.0)

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
@@ -108,7 +108,7 @@ class LostItemFeePolicyForm extends React.Component {
             firstMenu={<CancelButton onCancel={onCancel} />}
             footer={<FooterPane {...footerPaneProps} />}
           >
-            <div className={css.accordionSection}>
+            <>
               <Row end="xs">
                 <Col
                   data-test-expand-all
@@ -139,7 +139,7 @@ class LostItemFeePolicyForm extends React.Component {
                   accordionOnToggle={this.handleSectionToggle}
                 />
               </Accordion>
-            </div>
+            </>
           </Pane>
         </Paneset>
       </form>


### PR DESCRIPTION
The wrapper in the lost-item fee-policy form incorrectly contained
accordion-section styling, resulting in the form not expanding to make
use of the full width of the window. This was especially apparent on
narrow windows.