### PR TITLE
UICIRC-435 - Should use Integer not String for checkout timeout value

### DIFF
--- a/src/settings/CheckoutSettingsForm.js
+++ b/src/settings/CheckoutSettingsForm.js
@@ -39,6 +39,7 @@ class CheckoutSettingsForm extends Component {
       checkoutTimeout,
       checkoutTimeoutDuration,
     } = data;
+
     const values = idents.reduce((vals, ident, index) => {
       if (ident) vals.push(patronIdentifierTypes[index].key);
       return vals;
@@ -48,7 +49,7 @@ class CheckoutSettingsForm extends Component {
       audioAlertsEnabled: audioAlertsEnabled === 'true',
       prefPatronIdentifier: values.join(','),
       checkoutTimeout,
-      checkoutTimeoutDuration,
+      checkoutTimeoutDuration: parseInt(checkoutTimeoutDuration, 10),
     });
 
     this.props.onSubmit({ other_settings: otherSettings });


### PR DESCRIPTION
# Purpose
To send checkoutTimeoutDuration as an integer value for checkout settings.

# LInk
https://issues.folio.org/browse/UICIRC-435

# Screenshot
<img width="1004" alt="Screenshot 2020-03-11 at 19 46 59" src="https://user-images.githubusercontent.com/43472449/76447298-23504800-63d1-11ea-9b4b-a7061771def6.png">
