### PR TITLE
UICIRC-436 - Styling of patron notices should support better line spacing

### DIFF
--- a/src/settings/components/TemplateEditor/TemplateEditor.js
+++ b/src/settings/components/TemplateEditor/TemplateEditor.js
@@ -30,10 +30,13 @@ import css from './TemplateEditor.css';
 
 const AlignStyle = Quill.import('attributors/style/align');
 const SizeStyle = Quill.import('attributors/style/size');
+const Block = Quill.import('blots/block');
+Block.tagName = 'DIV';
 
 Quill.register(IndentStyle, true);
 Quill.register(AlignStyle, true);
 Quill.register(SizeStyle, true);
+Quill.register(Block, true);
 
 class TemplateEditor extends React.Component {
   static propTypes = {


### PR DESCRIPTION
# Purpose
Update editor configuration in order to support another block tag. 

# Link
https://issues.folio.org/browse/UICIRC-436

# Screenshots
**Before**
<img width="977" alt="Screen Shot 2020-03-19 at 10 07 05" src="https://user-images.githubusercontent.com/43472449/77045288-8e99ab80-69c9-11ea-905a-4bf6d0b6c7ca.png">
**After**
<img width="896" alt="Screen Shot 2020-03-19 at 10 07 41" src="https://user-images.githubusercontent.com/43472449/77045308-978a7d00-69c9-11ea-961f-28248d67d44b.png">
