### PR TITLE
UICIRC-418: Show in template dropdown only active policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## [2.1.0] (IN PROGRESS)
+
+* New/Edit Patron notice policy: make inactive loan and request notice templates do not display in dropdown. Refs UICIRC-418.
+
 ## 2.0.0 (https://github.com/folio-org/ui-circulation/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.12.0...v2.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.1.0] (IN PROGRESS)
 
-* New/Edit Patron notice policy: make inactive loan and request notice templates do not display in dropdown. Refs UICIRC-418.
+* New/Edit Patron notice policy: do not display inactive loan and request notice templates in the dropdown. Refs UICIRC-418.
 
 ## 2.0.0 (https://github.com/folio-org/ui-circulation/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.12.0...v2.0.0)

--- a/src/settings/NoticePolicy/utils/get-templates.js
+++ b/src/settings/NoticePolicy/utils/get-templates.js
@@ -2,7 +2,7 @@ import { reduce } from 'lodash';
 
 export default (templates = [], categoryName = '') => {
   return reduce(templates, (items, { id, name, category, active }) => {
-    if (category === categoryName && active) {
+    if (active && category === categoryName) {
       items.push({ value: id, label: name });
     }
 

--- a/src/settings/NoticePolicy/utils/get-templates.js
+++ b/src/settings/NoticePolicy/utils/get-templates.js
@@ -1,8 +1,8 @@
 import { reduce } from 'lodash';
 
 export default (templates = [], categoryName = '') => {
-  return reduce(templates, (items, { id, name, category }) => {
-    if (category === categoryName) {
+  return reduce(templates, (items, { id, name, category, active }) => {
+    if (category === categoryName && active) {
       items.push({ value: id, label: name });
     }
 

--- a/test/bigtest/tests/notice-policy/notice-policy-detail-test.js
+++ b/test/bigtest/tests/notice-policy/notice-policy-detail-test.js
@@ -266,12 +266,50 @@ describe('NoticePolicyDetail', () => {
     });
 
     describe('notice card', () => {
+      describe('notice policy with inactive template', () => {
+        let patronNoticeTemplate;
+        let noticePolicy;
+
+        beforeEach(function () {
+          patronNoticeTemplate = this.server.create('templates', { category: 'Loan', active: false });
+          noticePolicy = this.server.create('patronNoticePolicy', {
+            active: true,
+            loanNotices: [{
+              name: 'mockName',
+              templateId: patronNoticeTemplate.id,
+              templateName: 'mockTemplateName',
+              format: 'Email',
+              frequency: 'Recurring',
+              realTime: true,
+              sendOptions: {
+                sendHow: 'After',
+                sendWhen: 'Due date',
+                sendBy: {
+                  duration: 2,
+                  intervalId: 'Hours'
+                },
+                sendEvery: {
+                  duration: 2,
+                  intervalId: 'Hours'
+                }
+              }
+            }],
+          });
+
+          this.visit(`/settings/circulation/notice-policies/${noticePolicy.id}`);
+        });
+
+        it('templateId should have no value', () => {
+          expect(NoticePolicyDetail.loanNoticesSection.loanNotices(0).templateId.value.text).to.equal('');
+        });
+      });
+
       describe('random notice policy', () => {
         let patronNoticeTemplate;
         let noticePolicy;
 
         beforeEach(function () {
-          patronNoticeTemplate = this.server.create('templates', { category: 'Loan' });
+          patronNoticeTemplate = this.server.create('templates', { category: 'Loan', active: true });
           noticePolicy = this.server.create('patronNoticePolicy', {
             active: true,
             loanNotices: [{


### PR DESCRIPTION
# Description
On New/Edit Patron notice policy page: make Inactive loan and request notice templates **NOT** display in dropdown
# Issue
https://issues.folio.org/browse/UICIRC-418
# Screenshot
**Loan demo (the same with request)**
![image](https://user-images.githubusercontent.com/55694637/77538750-e8f2aa80-6ea8-11ea-8225-89744626c512.png)

