### PR TITLE
props cleanup

### DIFF
--- a/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.js
+++ b/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.js
@@ -80,11 +80,16 @@ const GeneralSection = (props) => {
 GeneralSection.propTypes = {
   metadata: PropTypes.object.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  isPolicyActive: PropTypes.bool.isRequired,
+  isPolicyActive: PropTypes.bool,
   policyName: PropTypes.string.isRequired,
-  policyDescription: PropTypes.string.isRequired,
+  policyDescription: PropTypes.string,
   connect: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired,
+};
+
+GeneralSection.defaultProps = {
+  policyDescription: '',
+  isPolicyActive: false,
 };
 
 export default GeneralSection;


### PR DESCRIPTION
I noticed some console errors flying by while running integration tests.
Here, optional fields were listed as required; now they are optional and
have sensible defaults. Presto! No more console errors.