### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Create/Edit loan policy | Move Save/Cancel buttons to the footer Refs UICIRC-372.
 * Lost item fee policies |  Create/Edit Request policies | Move Save/Cancel buttons to the footer UICIRC-370
 * Add the overdue fine policies menu to the circulation rules editor. Refs UICIRC-353.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## [1.11.0](https://github.com/folio-org/ui-circulation/tree/v1.13.0) (2019-09-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.10.0...v1.11.0)

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
   "dependencies": {
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
-    "moment": "^2.19.1",
+    "moment": "~2.24.0",
     "prop-types": "^15.5.10",
     "react-barcode": "^1.3.2",
     "react-codemirror2": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -285,5 +285,8 @@
   "peerDependencies": {
     "@folio/stripes": "^2.6.0",
     "react": "*"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)