### PR TITLE
STRIPES-678 avoid moment < 2.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * New/Edit Patron notice policy: do not display inactive loan and request notice templates in the dropdown. Refs UICIRC-418.
 * Overdue fee/fine notices. Refs UICIRC-451.
+* Update `moment` to `^2.25.3` to avoid `2.25.x` bugs. Refs STRIPES-678.
 
 ## 2.0.0 (https://github.com/folio-org/ui-circulation/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v1.12.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
   "dependencies": {
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
-    "moment": "^2.19.1",
+    "moment": "^2.25.3",
     "prop-types": "^15.5.10",
     "react-barcode": "^1.3.2",
     "react-codemirror2": "^1.0.0",


### PR DESCRIPTION
`moment` `v2.25` less than `v2.25.3` caused many webpack-related bugs
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs STRIPES-678

Replaces #553