### PR TITLE
UICIRC-458 - Extend fee/fine tokens available for notices

### DIFF
--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -318,7 +318,7 @@ const formats = {
     },
     {
       token: 'feeCharge.remainingAmount',
-      previewValue: '$5.00',
+      previewValue: '$10.00',
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,


### PR DESCRIPTION
# Purpose
Changed preview value for feeCharge.remainingAmount

# Link
https://issues.folio.org/browse/UICIRC-458

# Screenshot
<img width="1389" alt="Screen Shot 2020-05-29 at 10 21 52" src="https://user-images.githubusercontent.com/43472449/83232698-3d125780-a196-11ea-9c39-6f953597bc99.png">
