### PR TITLE
UICIRC-460 - Fixed Due Date Schedule - Dates on Edit/Create and View out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Extend fee/fine tokens available for notices. Refs UICIRC-458.
 * Grey out unavailable tokens on patron notice template token modal. Refs UICIRC-459.
 * Use `UNSAFE_` prefix for deprecated React methods. We know, we know. Refs UICIRC-431.
+* Fixed Due Date Schedule - Dates on Edit/Create and View out of sync. Refs UICIRC-460.
 
 ## [2.1.0] (IN PROGRESS)
 

--- a/src/settings/FixedDueDateScheduleDetail.js
+++ b/src/settings/FixedDueDateScheduleDetail.js
@@ -76,13 +76,13 @@ class FixedDueDateScheduleDetail extends React.Component {
           </Row>
           <Row key={index + 2}>
             <Col xs={4}>
-              <FormattedDate value={schedule.from} />
+              <FormattedDate value={schedule.from} timeZone="UTC" />
             </Col>
             <Col xs={4}>
-              <FormattedDate value={schedule.to} />
+              <FormattedDate value={schedule.to} timeZone="UTC" />
             </Col>
             <Col xs={4}>
-              <FormattedDate value={schedule.due} />
+              <FormattedDate value={schedule.due} timeZone="UTC" />
             </Col>
           </Row>
         </div>


### PR DESCRIPTION
# Purpose
To fix dates displaying on view fixed due date schedules page.

# Link
https://issues.folio.org/browse/UICIRC-460

# Screenshot
<img width="1680" alt="Screen Shot 2020-06-05 at 18 23 21" src="https://user-images.githubusercontent.com/43472449/83894224-af1c0b00-a759-11ea-82ec-ff787fcdde8c.png">
<img width="586" alt="Screen Shot 2020-06-05 at 18 23 33" src="https://user-images.githubusercontent.com/43472449/83894233-b216fb80-a759-11ea-9f5b-0e61d03588d2.png">

