### PR TITLE
UICIRC-469 - Incorrect footer displaying for circulation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Grey out unavailable tokens on patron notice template token modal. Refs UICIRC-459.
 * Use `UNSAFE_` prefix for deprecated React methods. We know, we know. Refs UICIRC-431.
 * Fixed Due Date Schedule - Dates on Edit/Create and View out of sync. Refs UICIRC-460.
+* Incorrect footer displaying for circulation settings. Refs UICIRC-469.
 
 ## [2.1.0] (IN PROGRESS)
 

--- a/src/settings/FinePolicy/FinePolicyForm.js
+++ b/src/settings/FinePolicy/FinePolicyForm.js
@@ -31,6 +31,8 @@ import {
 
 import formShape from '../utils/form-shape';
 
+import css from './FineSection.css';
+
 class FinePolicyForm extends React.Component {
   static propTypes = formShape;
 
@@ -101,6 +103,7 @@ class FinePolicyForm extends React.Component {
     return (
       <form
         noValidate
+        className={css.finePolicyForm}
         data-test-fine-policy-form
         onSubmit={handleSubmit(this.saveForm)}
       >

--- a/src/settings/FinePolicy/FineSection.css
+++ b/src/settings/FinePolicy/FineSection.css
@@ -3,4 +3,8 @@
     margin-left:40px;
   }
 
+  .finePolicyForm {
+    height: inherit;
+  }
+
   

--- a/src/settings/FixedDueDateSchedule.css
+++ b/src/settings/FixedDueDateSchedule.css
@@ -53,3 +53,7 @@
   justify-content: space-between;
   width: 100%;
 }
+
+.fixedDueDateScheduleForm {
+  height: inherit;
+}

--- a/src/settings/FixedDueDateScheduleForm.js
+++ b/src/settings/FixedDueDateScheduleForm.js
@@ -143,6 +143,7 @@ class FixedDueDateScheduleForm extends React.Component {
           <Button
             id="clickable-cancel-fixedDueDateSchedule"
             onClick={onCancel}
+            buttonStyle="default mega"
             marginBottom0
           >
             <FormattedMessage id="ui-circulation.settings.fDDSform.cancel" />
@@ -151,7 +152,7 @@ class FixedDueDateScheduleForm extends React.Component {
           <IfPermission perm="ui-circulation.settings.circulation-rules">
             <Button
               id="clickable-delete-item"
-              buttonStyle="danger"
+              buttonStyle="danger mega"
               marginBottom0
               onClick={this.beginDelete}
               disabled={confirmDelete}
@@ -163,10 +164,10 @@ class FixedDueDateScheduleForm extends React.Component {
             id="clickable-save-fixedDueDateSchedule"
             type="submit"
             marginBottom0
-            buttonStyle="primary"
+            buttonStyle="primary mega"
             disabled={(pristine || submitting)}
           >
-            <FormattedMessage id="ui-circulation.settings.fDDSform.saveSchedule" />
+            <FormattedMessage id="ui-circulation.settings.common.saveAndClose" />
           </Button>
         </div>
       </PaneFooter>
@@ -323,6 +324,7 @@ class FixedDueDateScheduleForm extends React.Component {
     return (
       <form
         id="form-fixedDueDateSchedule"
+        className={css.fixedDueDateScheduleForm}
         onSubmit={handleSubmit(this.saveSet)}
         data-test-fdds-form
       >

--- a/src/settings/LoanPolicy/LoanPolicyForm.css
+++ b/src/settings/LoanPolicy/LoanPolicyForm.css
@@ -1,0 +1,3 @@
+.loanPolicyForm {
+  height: inherit;
+}

--- a/src/settings/LoanPolicy/LoanPolicyForm.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.js
@@ -39,6 +39,8 @@ import {
   Metadata,
 } from '../components';
 
+import css from './LoanPolicyForm.css';
+
 class LoanPolicyForm extends React.Component {
   static propTypes = {
     intl: PropTypes.object,
@@ -143,6 +145,7 @@ class LoanPolicyForm extends React.Component {
     return (
       <form
         noValidate
+        className={css.loanPolicyForm}
         data-test-loan-policy-form
         onSubmit={handleSubmit(this.saveForm)}
       >

--- a/src/settings/LostItemFeePolicy/LostItemFee.css
+++ b/src/settings/LostItemFeePolicy/LostItemFee.css
@@ -1,5 +1,8 @@
 .accordionSection{
-  
   margin-left:300px;
   margin-right: 300px;
-  }
+}
+
+.lostItemFeePolicyForm {
+  height: inherit;
+}

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
@@ -33,6 +33,8 @@ import {
 
 import formShape from '../utils/form-shape';
 
+import css from './LostItemFee.css';
+
 class LostItemFeePolicyForm extends React.Component {
   static propTypes = formShape;
 
@@ -94,6 +96,7 @@ class LostItemFeePolicyForm extends React.Component {
     return (
       <form
         noValidate
+        className={css.lostItemFeePolicyForm}
         data-test-lost-item-fee-policy-form
         onSubmit={handleSubmit(this.saveForm)}
       >

--- a/src/settings/NoticePolicy/NoticePolicyForm.css
+++ b/src/settings/NoticePolicy/NoticePolicyForm.css
@@ -1,0 +1,3 @@
+.noticePolicyForm {
+  height: inherit;
+}

--- a/src/settings/NoticePolicy/NoticePolicyForm.js
+++ b/src/settings/NoticePolicy/NoticePolicyForm.js
@@ -31,6 +31,8 @@ import {
 
 import { patronNoticeCategoryIds } from '../../constants';
 
+import css from './NoticePolicyForm.css';
+
 class NoticePolicyForm extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -105,6 +107,7 @@ class NoticePolicyForm extends React.Component {
     return (
       <form
         data-test-notice-policy-form
+        className={css.noticePolicyForm}
         noValidate
         onSubmit={handleSubmit(this.saveForm)}
       >

--- a/src/settings/PatronNotices/PatronNoticeForm.css
+++ b/src/settings/PatronNotices/PatronNoticeForm.css
@@ -1,0 +1,3 @@
+.patronNoticeForm {
+  height: inherit;
+}

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -30,6 +30,8 @@ import {
   TemplateEditor,
 } from '../components';
 
+import css from './PatronNoticeForm.css';
+
 /**
  * on-blur validation checks that the name of the patron notice
  * is unique.
@@ -153,6 +155,7 @@ class PatronNoticeForm extends React.Component {
     return (
       <form
         id="form-patron-notice"
+        className={css.patronNoticeForm}
         noValidate
         data-test-patron-notice-form
         onSubmit={handleSubmit(this.onSave)}

--- a/src/settings/RequestPolicy/RequestPolicyForm.css
+++ b/src/settings/RequestPolicy/RequestPolicyForm.css
@@ -1,0 +1,3 @@
+.requestPolicyForm {
+  height: inherit;
+}

--- a/src/settings/RequestPolicy/RequestPolicyForm.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.js
@@ -23,6 +23,8 @@ import {
   FooterPane,
 } from '../components';
 
+import css from './RequestPolicyForm.css';
+
 class RequestPolicyForm extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -94,6 +96,7 @@ class RequestPolicyForm extends React.Component {
     return (
       <form
         noValidate
+        className={css.requestPolicyForm}
         data-test-request-policy-form
         onSubmit={handleSubmit(this.saveForm)}
       >

--- a/src/settings/StaffSlips/StaffSlipForm.css
+++ b/src/settings/StaffSlips/StaffSlipForm.css
@@ -1,0 +1,3 @@
+.staffSlipForm {
+  height: inherit;
+}

--- a/src/settings/StaffSlips/StaffSlipForm.js
+++ b/src/settings/StaffSlips/StaffSlipForm.js
@@ -23,6 +23,8 @@ import {
   TemplateEditor,
 } from '../components';
 
+import css from './StaffSlipForm.css';
+
 class StaffSlipForm extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
@@ -68,6 +70,7 @@ class StaffSlipForm extends React.Component {
     return (
       <form
         id="form-staff-slip"
+        className={css.staffSlipForm}
         noValidate
         onSubmit={handleSubmit(this.onSave)}
       >

--- a/src/settings/components/FooterPane/FooterPane.js
+++ b/src/settings/components/FooterPane/FooterPane.js
@@ -22,6 +22,7 @@ const FooterPane = (props) => {
         <Button
           id="footer-cancel-entity"
           marginBottom0
+          buttonStyle="default mega"
           onClick={onCancel}
         >
           <FormattedMessage id="ui-circulation.settings.common.cancel" />
@@ -30,7 +31,7 @@ const FooterPane = (props) => {
           id="footer-save-entity"
           type="submit"
           marginBottom0
-          buttonStyle="primary"
+          buttonStyle="primary mega"
           disabled={(pristine || submitting)}
         >
           <FormattedMessage id="ui-circulation.settings.common.saveAndClose" />

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -135,7 +135,6 @@
   "settings.fDDSform.close": "Close",
   "settings.fDDSform.cancel": "Cancel",
   "settings.fDDSform.closeLabel": "Close fixed due date schedule dialog",
-  "settings.fDDSform.saveSchedule": "Save",
   "settings.cancelReasons.label": "Request cancellation reasons",
   "settings.cancelReasons.labelSingular": "Request cancellation reason",
   "settings.cancelReasons.labelShort": "Cancel reason",


### PR DESCRIPTION
# Purpose
Fix page footer for circulation settings pages.

# Link
https://issues.folio.org/browse/UICIRC-469

# Screenshot
**Before**
<img width="1680" alt="Screen Shot 2020-06-05 at 18 47 46" src="https://user-images.githubusercontent.com/43472449/83900467-80eef900-a762-11ea-8612-e5a90e040676.png">
**After**
<img width="1680" alt="Screen Shot 2020-06-05 at 18 52 03" src="https://user-images.githubusercontent.com/43472449/83900503-83e9e980-a762-11ea-8fef-e7dbfd10a26e.png">

