### PR TITLE
UICIRC-456: Change style

### DIFF
--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -10,7 +10,7 @@
   line-height: 23px;
 }
 
-.CodeMirror-scroll {
+.CodeMirror-sizer {
   padding-top: 8px;
 }
 


### PR DESCRIPTION
# Approach
Any indents should not be added to `CodeMirror-scroll` class.  A small padding gave effect that the line is just cut off, and the scrollbal is in the bottom, but in fact it can be scrolled more.
# Issue
https://issues.folio.org/browse/UICIRC-456
# Screenshot 
![picturemessage_uxedf5g0 j1o](https://user-images.githubusercontent.com/55694637/84797245-4444bc80-b002-11ea-9821-7ec7ba2d7b73.png)
