### PR TITLE
UICIRC-476 - fixed incorrect validation for overdue fines

### DIFF
--- a/src/settings/Validation/engine/handlers.js
+++ b/src/settings/Validation/engine/handlers.js
@@ -39,7 +39,7 @@ export const isGreaterOrEqualThanPassedField = (fieldToCompare, value, model) =>
 
 export const isMaximumFineValueValid = (fieldToCompare, value, model) => {
   const valueToCompare = get(model, fieldToCompare);
-  return parseInt(value, 10) > 0 && parseInt(valueToCompare, 10) !== 0;
+  return parseInt(value, 10) > 0 && parseInt(valueToCompare, 10) > 0;
 };
 
 export const hasFine = (value, model) => {

--- a/src/settings/Validation/fine-policy/fines.js
+++ b/src/settings/Validation/fine-policy/fines.js
@@ -23,12 +23,12 @@ export default function (finePolicy) {
       shouldValidate: finePolicy.isOverdueRecallFine(),
     },
     'maxOverdueFine': {
-      rules: ['isStringGreaterThanOrEqualToZero', 'isMaximumOverdueFineValid', 'isGreaterThanOverdueFine'],
-      shouldValidate: finePolicy.hasValue('maxOverdueFine'),
+      rules: ['isStringGreaterThanOrEqualToZero', 'isGreaterThanOverdueFine', 'isMaximumOverdueFineValid'],
+      shouldValidate: finePolicy.isOverdueFine() || finePolicy.hasValue('maxOverdueFine'),
     },
     'maxOverdueRecallFine': {
-      rules: ['isStringGreaterThanOrEqualToZero', 'isMaximumOverdueRecallFineValid', 'isGreaterThanOverdueRecallFine'],
-      shouldValidate: finePolicy.hasValue('maxOverdueRecallFine'),
+      rules: ['isStringGreaterThanOrEqualToZero', 'isGreaterThanOverdueRecallFine', 'isMaximumOverdueRecallFineValid'],
+      shouldValidate: finePolicy.isOverdueRecallFine() || finePolicy.hasValue('maxOverdueRecallFine'),
     },
   };
 }

--- a/test/bigtest/tests/fine-policy/fine-policy-form-test.js
+++ b/test/bigtest/tests/fine-policy/fine-policy-form-test.js
@@ -61,6 +61,7 @@ describe('FinePolicyForm', () => {
           .aboutSection.policyName.fillAndBlur(newFinePolicyName)
           .overdueFineSection.overdue.quantity.fillAndBlur(1)
           .overdueFineSection.overdue.interval.selectAndBlur('minute')
+          .overdueFineSection.maxOverdue.fillAndBlur('11.99')
           .save();
       });
 


### PR DESCRIPTION
# Purpose
Fix incorrect validation behavior for Maximum overdue fine and Maximum recall overdue fine fields.

# Link
https://issues.folio.org/browse/UICIRC-476

# Screenshot
<img width="1264" alt="Screen Shot 2020-06-25 at 10 57 35" src="https://user-images.githubusercontent.com/43472449/85680199-be480600-b6d2-11ea-96f3-d94b752c14aa.png">
