### PR TITLE
UICIRC-479 - Adjust UI for fee/fine notice token options on templates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Accessibility work with color contrast. Refs UICIRC-463.
 * Able to set Overdue Fine Max to value less than Overdue Fine. Refs UICIRC-475.
 * Fee/Fine Overdue Fine Policies: Additional validation not in original user story. Refs UICIRC-476.
+* Adjust UI for fee/fine notice token options on templates. Refs UICIRC-479.
 
 ## 3.0.0 (https://github.com/folio-org/ui-circulation/tree/v3.0.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v2.0.0...v3.0.0)

--- a/src/settings/PatronNotices/TokensList/TokensList.js
+++ b/src/settings/PatronNotices/TokensList/TokensList.js
@@ -26,12 +26,6 @@ class TokensList extends React.Component {
       label: <FormattedMessage id="ui-circulation.settings.patronNotices.multipleLoans" />,
       tag: 'loans',
     };
-
-    this.feeFineActionLoopConfig = {
-      enabled: true,
-      label: <FormattedMessage id="ui-circulation.settings.patronNotices.multipleFeeFineActions" />,
-      tag: 'feeActions',
-    };
   }
 
   render() {
@@ -119,7 +113,6 @@ class TokensList extends React.Component {
                 selectedCategory={selectedCategory}
                 header={<FormattedMessage id="ui-circulation.settings.patronNotices.feeFineChargeTokenHeader" />}
                 tokens={tokens.feeFineCharge}
-                onLoopSelect={onLoopSelect}
                 onSectionInit={onSectionInit}
                 onTokenSelect={onTokenSelect}
               />
@@ -132,8 +125,6 @@ class TokensList extends React.Component {
                 selectedCategory={selectedCategory}
                 header={<FormattedMessage id="ui-circulation.settings.patronNotices.feeFineActionTokenHeader" />}
                 tokens={tokens.feeFineAction}
-                loopConfig={this.feeFineActionLoopConfig}
-                onLoopSelect={onLoopSelect}
                 onSectionInit={onSectionInit}
                 onTokenSelect={onTokenSelect}
               />

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -290,7 +290,7 @@ const formats = {
       ],
     },
     {
-      token: 'feeCharge.date',
+      token: 'feeCharge.chargeDate',
       previewValue: 'Jun 30, 2020',
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
@@ -299,7 +299,7 @@ const formats = {
       ],
     },
     {
-      token: 'feeCharge.dateTime',
+      token: 'feeCharge.chargeDateTime',
       previewValue: 'Jun 30, 2020 11:00',
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
@@ -330,7 +330,6 @@ const formats = {
       previewValue: 'This is a text field intended to provide additional information for the patron regarding the fee/fine.',
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
-        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -342,12 +341,12 @@ const formats = {
       allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
     },
     {
-      token: 'feeAction.date',
+      token: 'feeAction.actionDate',
       previewValue: 'Jul 10, 2020',
       allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
     },
     {
-      token: 'feeAction.dateTime',
+      token: 'feeAction.actionDateTime',
       previewValue: 'Jul 10, 2020 8:00',
       allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
     },


### PR DESCRIPTION
# Purpose
- change date related tokens for fee/fine charge and fee/fine actions categories
- disable ability to use loop for fee/fine action tokens
- disable feeCharge.additionalInfo for Automated fee/fine charge or adjustment category

# Link
https://issues.folio.org/browse/UICIRC-479

# Screenshot
<img width="1680" alt="Screen Shot 2020-06-25 at 12 48 26" src="https://user-images.githubusercontent.com/43472449/85697120-2e11bd00-b6e2-11ea-9e18-369b7b3ef0fb.png">
