### PR TITLE
UICIRC-494 - Loan tokens should be unavailable (and greyed out) for manual fee/fine charge category

### DIFF
--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -154,7 +154,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -164,7 +163,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -174,7 +172,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -184,7 +181,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -194,7 +190,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -204,7 +199,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -214,7 +208,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -224,7 +217,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },
@@ -234,7 +226,6 @@ const formats = {
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-        patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
       ],
     },


### PR DESCRIPTION
# Purpose
Disable loan tokens for manual fee/fine charge category in patron notices

# Link
https://issues.folio.org/browse/UICIRC-494

# Screenshot
<img width="1680" alt="Screen Shot 2020-08-07 at 11 47 06" src="https://user-images.githubusercontent.com/43472449/89627807-0f3b4480-d8a4-11ea-8164-02ad7348c995.png">
