### PR TITLE
UICIRC-392: Display loans section when loanable is set to no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix of accessibility errors. Refs UICIRC-464.
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Refactor `bigtest/mirage` to `miragejs`.
+* Display loans section when `loanable` is set to `No`. Fixes UICIRC-392.
 
 ## 3.0.0 (https://github.com/folio-org/ui-circulation/tree/v3.0.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v2.0.0...v3.0.0)

--- a/src/settings/LoanPolicy/LoanPolicyDetail.js
+++ b/src/settings/LoanPolicy/LoanPolicyDetail.js
@@ -156,11 +156,11 @@ class LoanPolicyDetail extends React.Component {
             />
             <AboutSection getValue={this.getValue} />
             <LoansSection
-              isVisible={loanPolicy.loanable}
               policy={loanPolicy}
               getDropdownValue={this.getDropdownValue}
               getPeriodValue={this.getPeriodValue}
               getScheduleValue={this.getScheduleValue}
+              getCheckboxValue={this.getCheckboxValue}
               getValue={this.getValue}
             />
             <RenewalsSection

--- a/src/settings/LoanPolicy/components/ViewSections/LoansSection/LoansSection.js
+++ b/src/settings/LoanPolicy/components/ViewSections/LoansSection/LoansSection.js
@@ -16,16 +16,36 @@ import {
 
 const LoansSection = (props) => {
   const {
-    isVisible,
     policy,
     getPeriodValue,
     getDropdownValue,
     getScheduleValue,
+    getCheckboxValue,
     getValue,
   } = props;
 
-  if (!isVisible) {
-    return null;
+  if (!policy.loanable) {
+    return (
+      <div data-test-loan-policy-detail-loans-section>
+        <Row>
+          <Col xs={12}>
+            <h2 data-test-loans-section-header>
+              <FormattedMessage id="ui-circulation.settings.loanPolicy.loans" />
+            </h2>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <div data-test-renewals-section-loanable>
+              <KeyValue
+                label={<FormattedMessage id="ui-circulation.settings.loanPolicy.loanable" />}
+                value={getCheckboxValue('loanable')}
+              />
+            </div>
+          </Col>
+        </Row>
+      </div>
+    );
   }
 
   const dueDateScheduleFieldLabel = policy.isProfileRolling()
@@ -126,11 +146,11 @@ const LoansSection = (props) => {
 };
 
 LoansSection.propTypes = {
-  isVisible: PropTypes.bool.isRequired,
   policy: PropTypes.object.isRequired,
   getDropdownValue: PropTypes.func.isRequired,
   getPeriodValue: PropTypes.func.isRequired,
   getScheduleValue: PropTypes.func.isRequired,
+  getCheckboxValue: PropTypes.func.isRequired,
   getValue: PropTypes.func.isRequired,
 };
 

--- a/test/bigtest/tests/loan-policy/loan-policy-detail-test.js
+++ b/test/bigtest/tests/loan-policy/loan-policy-detail-test.js
@@ -120,8 +120,8 @@ describe('LoanPolicyDetail', () => {
         });
 
         describe('loans section', () => {
-          it('should not be displayed', () => {
-            expect(LoanPolicyDetail.loansSection.isPresent).to.be.false;
+          it('should be displayed', () => {
+            expect(LoanPolicyDetail.loansSection.isPresent).to.be.true;
           });
         });
       });


### PR DESCRIPTION
Display loans section when `loanable` is set to `No`.

https://issues.folio.org/browse/UICIRC-392

![loan](https://user-images.githubusercontent.com/63545/92760460-a9d4ea80-f35e-11ea-923b-85ad7101cffe.png)
