### PR TITLE
UICIRC-392: Adjust validation for no loanable policies

### DIFF
--- a/src/settings/Validation/loan-policy/loans.js
+++ b/src/settings/Validation/loan-policy/loans.js
@@ -8,7 +8,7 @@ export default function (loanPolicy) {
     },
     'loansPolicy.closedLibraryDueDateManagementId': {
       rules: ['isNotEmpty'],
-      shouldValidate: true,
+      shouldValidate: loanPolicy.isLoanable(),
     },
     'loansPolicy.period.duration': {
       rules: ['isNotEmpty', 'isIntegerGreaterThanZero'],


### PR DESCRIPTION
The work for https://issues.folio.org/browse/UICIRC-392 was done in: https://github.com/folio-org/ui-circulation/pull/622
but the validation was still not working correctly for no loanable items. This PR should fix it.

