### PR TITLE
UICIRC-500: Lost item fee displays as Set cost of NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Refactor `bigtest/mirage` to `miragejs`.
 * Display loans section when `loanable` is set to `No`. Fixes UICIRC-392.
+* Fix of Lost item fee displays as `Set cost of NaN`. Refs UICIRC-500. 
 
 ## 3.0.0 (https://github.com/folio-org/ui-circulation/tree/v3.0.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v2.0.0...v3.0.0)

--- a/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeSection/LostItemFeeSection.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeSection/LostItemFeeSection.js
@@ -34,7 +34,7 @@ class LostItemFeeSection extends React.Component {
     this.generateOptions = optionsGenerator.bind(null, this.props.intl.formatMessage);
   }
 
-  formatNumber = (value) => {
+  formatNumber = (value = 0) => {
     return isNumber(Number(value)) ? parseFloat(value).toFixed(2) : value;
   };
 


### PR DESCRIPTION
# Description
In `Lost item fee policy`, when select `Set cost`  and then blank it out (delete the 0.00) -> 
`Lost item fee` displays as `Set cost of NaN`
# Issue
https://issues.folio.org/browse/UICIRC-500
# Screenshot
**Before**
![image](https://user-images.githubusercontent.com/55694637/94279186-71373280-ff54-11ea-900f-9386c4db8758.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/94279272-8e6c0100-ff54-11ea-8bbe-d00f707ecc82.png)
