### PR TITLE
UICIRC-499 - Incorrect error validation for 'Patron billed after aged to lost'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Display loans section when `loanable` is set to `No`. Fixes UICIRC-392.
 * Localized permission names. Refs UICIRC-504.
 * Fix of Lost item fee displays as `Set cost of NaN`. Refs UICIRC-500.
+* Incorrect error validation for 'Patron billed after aged to lost' on Lost Item Fee Policy. Refs UICIRC-499.
 
 ## 3.0.0 (https://github.com/folio-org/ui-circulation/tree/v3.0.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v2.0.0...v3.0.0)

--- a/src/settings/Validation/engine/validators.js
+++ b/src/settings/Validation/engine/validators.js
@@ -96,10 +96,6 @@ export default {
     validate: hasPatronBilledAfterAgedToLostValue,
     message: <FormattedMessage id="ui-circulation.settings.lostItemFee.validate.hasPatronBilledAfterAgedToLostValue" />
   },
-  hasItemsAgedToLostAfterOverdueValue: {
-    validate: isNotEmpty,
-    message: <FormattedMessage id="ui-circulation.settings.lostItemFee.validate.hasItemsAgedToLostAfterOverdueValue" />
-  },
   hasPositiveLostItemProcessingFeeValue: {
     validate: isStringGreaterThanZero,
     message: <FormattedMessage id="ui-circulation.settings.lostItemFee.validate.hasPositiveLostItemProcessingFeeValue" />

--- a/src/settings/Validation/lost-item-fee-policy/lost-item-fee.js
+++ b/src/settings/Validation/lost-item-fee-policy/lost-item-fee.js
@@ -13,8 +13,8 @@ export default function (l) {
       shouldValidate: l.hasValue('itemAgedLostOverdue.duration'),
     },
     'patronBilledAfterAgedLost.duration': {
-      rules: ['hasItemsAgedToLostAfterOverdueValue', 'isIntegerGreaterThanOrEqualToZero'],
-      shouldValidate: l.hasValue('itemAgedLostOverdue.duration') || l.hasValue('patronBilledAfterAgedLost.duration'),
+      rules: ['isIntegerGreaterThanOrEqualToZero'],
+      shouldValidate: l.hasValue('patronBilledAfterAgedLost.duration'),
     },
     'patronBilledAfterAgedLost.intervalId': {
       rules: ['isNotEmptySelect'],

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -417,7 +417,6 @@
   "settings.lostItemFee.late": "late",
   "settings.lostItemFee.deleteFeePolicy": "Delete lost item fee policy",
   "settings.lostItemFee.validate.hasPatronBilledAfterAgedToLostValue": "Entry required if patron billed after aged to lost interval is selected",
-  "settings.lostItemFee.validate.hasItemsAgedToLostAfterOverdueValue": "Entry required if items aged to lost after overdue interval is selected",
   "settings.lostItemFee.validate.hasPositiveLostItemProcessingFeeValue": "Entry required if charging lost item processing fee for declared lost or aged to lost selected",
   "settings.lostItemFee.validate.hasNoChargeLostItemProcessingFee": "Lost item processing fee cannot be > 0 unless charging lost item processing fee for declared lost or aged to lost selected",
   "settings.lostItemFee.validate.hasLostItemProcessingFeeValue": "Lost item processing fee must be > 0 for this selection",


### PR DESCRIPTION
# Purpose
Remove unnecessary validation for lost item fee policy.

# Link
https://issues.folio.org/browse/UICIRC-499