### PR TITLE
UICIRC-518 - Validation and other issues with patron notice template names

### DIFF
--- a/src/settings/NoticePolicy/NoticePolicySettings.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.js
@@ -37,7 +37,7 @@ class NoticePolicySettings extends React.Component {
       path: 'templates',
       params: {
         query: 'cql.allRecords=1 AND category=""',
-        limit: '100',
+        limit: '1000',
       },
     },
     circulationRules: {

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -44,8 +44,8 @@ class PatronNotices extends React.Component {
       params: {
         query: 'cql.allRecords=1 AND category=""',
       },
-      recordsRequired: 50,
-      perRequest: 50,
+      recordsRequired: 1000,
+      perRequest: 1000,
     },
     patronNoticePolicies: {
       type: 'okapi',


### PR DESCRIPTION
# Purpose
Increase limits for fetching templates (up to 1000)

# Link
https://issues.folio.org/browse/UICIRC-518

# Screenshot
<img width="1680" alt="Screen Shot 2020-11-04 at 11 55 40" src="https://user-images.githubusercontent.com/43472449/98096654-afe5d400-1e94-11eb-94a0-3319e6191ee4.png">
