### PR TITLE
UICIRC-525: Add 'Allow recalls to extend overdue loans' setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Unable to enter decimal places on Overdue Fines Policy on Honeysuckle and Snapshot Dev. Refs UICIRC-514.
 * Update version of `feesfines` okapi interface to `v16.0`.
 * Modifier ! (not) - preceding value entered for a criteria, means any value except. Refs UICIRC-507.
+* Add `Allow recalls to extend overdue loans` setting. Refs UICIRC-525.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
@@ -77,6 +77,29 @@ class RequestManagementSection extends React.Component {
               changeFormValue={change}
             />
           </div>
+          <div data-test-request-management-section-recalls-extend-overdue-loans>
+            <Field
+              label={<FormattedMessage id="ui-circulation.settings.requestManagement.allowRecallsToExtendOverdueLoans" />}
+              name="requestManagement.recalls.allowRecallsToExtendOverdueLoans"
+              id="requestManagement.recalls.allowRecallsToExtendOverdueLoans"
+              component={Checkbox}
+              type="checkbox"
+            />
+          </div>
+          <br />
+          {
+            policy.isProfileRolling() &&
+            policy.requestManagement?.recalls?.allowRecallsToExtendOverdueLoans &&
+            <div data-test-request-management-section-alternate-recall-return-interval>
+              <Period
+                fieldLabel="ui-circulation.settings.requestManagement.alternateRecallReturnInterval"
+                inputValuePath="requestManagement.recalls.alternateRecallReturnInterval.duration"
+                selectValuePath="requestManagement.recalls.alternateRecallReturnInterval.intervalId"
+                intervalPeriods={this.generateOptions(intervalPeriods, 'ui-circulation.settings.loanPolicy.selectInterval')}
+                changeFormValue={change}
+              />
+            </div>
+          }
         </Accordion>
         <Accordion
           id="holdsSection"

--- a/src/settings/LoanPolicy/components/ViewSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/ViewSections/RequestManagementSection/RequestManagementSection.js
@@ -54,6 +54,26 @@ const RequestManagementSection = (props) => {
             </div>
           </Col>
         </Row>
+        <Row>
+          <Col xs={12}>
+            <div data-test-request-management-section-recalls-extend-overdue-loans>
+              <KeyValue
+                label={<FormattedMessage id="ui-circulation.settings.requestManagement.allowRecallsToExtendOverdueLoans" />}
+                value={getCheckboxValue('requestManagement.recalls.allowRecallsToExtendOverdueLoans')}
+              />
+            </div>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <div data-test-request-management-section-alternate-recall-return-interval>
+              <KeyValue
+                label={<FormattedMessage id="ui-circulation.settings.requestManagement.alternateRecallReturnInterval" />}
+                value={getPeriodValue('requestManagement.recalls.alternateRecallReturnInterval')}
+              />
+            </div>
+          </Col>
+        </Row>
       </Accordion>
       <Accordion
         id="holds"

--- a/src/settings/LoanPolicy/utils/normalize.js
+++ b/src/settings/LoanPolicy/utils/normalize.js
@@ -20,6 +20,7 @@ const checkInvalidPeriods = (policy) => {
     'renewalsPolicy.period',
     'requestManagement.recalls.recallReturnInterval',
     'requestManagement.recalls.minimumGuaranteedLoanPeriod',
+    'requestManagement.recalls.alternateRecallReturnInterval',
     'requestManagement.holds.alternateCheckoutLoanPeriod',
     'requestManagement.holds.alternateRenewalLoanPeriod',
   ];

--- a/src/settings/Models/LoanPolicy/Recalls.js
+++ b/src/settings/Models/LoanPolicy/Recalls.js
@@ -3,7 +3,9 @@ import { Period } from '../common';
 class Recalls {
   constructor(recall = {}) {
     this.recallReturnInterval = new Period(recall.recallReturnInterval);
+    this.allowRecallsToExtendOverdueLoans = recall.allowRecallsToExtendOverdueLoans;
     this.minimumGuaranteedLoanPeriod = new Period(recall.minimumGuaranteedLoanPeriod);
+    this.alternateRecallReturnInterval = new Period(recall.alternateRecallReturnInterval);
   }
 }
 

--- a/src/settings/Validation/loan-policy/request-management.js
+++ b/src/settings/Validation/loan-policy/request-management.js
@@ -4,6 +4,7 @@ const recalls = (loanPolicy) => {
   return {
     ...buildPeriodValidationConfig(loanPolicy, 'requestManagement.recalls.recallReturnInterval'),
     ...buildPeriodValidationConfig(loanPolicy, 'requestManagement.recalls.minimumGuaranteedLoanPeriod'),
+    ...buildPeriodValidationConfig(loanPolicy, 'requestManagement.recalls.alternateRecallReturnInterval'),
   };
 };
 

--- a/test/bigtest/interactors/loan-policy/loan-policy-form/request-management-section.js
+++ b/test/bigtest/interactors/loan-policy/loan-policy-form/request-management-section.js
@@ -13,6 +13,8 @@ import Period from '../../Period';
   header = scoped('[data-test-renewals-request-management-section-header]');
   recallReturnInterval = new Period('[data-test-request-management-section-recall-return-interval]');
   minimumGuaranteedLoanPeriod = new Period('[data-test-request-management-section-minimum-guaranteed-loan-period]');
+  recallsExtendOverdueLoans = new CheckboxInteractor('[data-test-request-management-section-recalls-extend-overdue-loans]');
+  alternateRecallReturnInterval = new Period('[data-test-request-management-section-alternate-recall-return-interval]');
   alternateCheckoutLoanPeriod = new Period('[data-test-request-management-section-alternate-checkout-loan-period]');
   renewItemsWithRequest = new CheckboxInteractor('[data-test-request-management-section-renew-items-with-request]');
   alternateRenewalLoanPeriod = new Period('[data-test-request-management-section-alternate-renewal-loan-period]');

--- a/test/bigtest/tests/loan-policy/loan-policy-form-test.js
+++ b/test/bigtest/tests/loan-policy/loan-policy-form-test.js
@@ -758,6 +758,40 @@ describe('LoanPolicyForm', () => {
             });
           });
         });
+
+        describe('recalls extend overdue loans checkbox', () => {
+          it('should be displayed', () => {
+            expect(LoanPolicyForm.requestManagementSection.recallsExtendOverdueLoans.isPresent).to.be.true;
+          });
+
+          it('should be unchecked', () => {
+            expect(LoanPolicyForm.requestManagementSection.recallsExtendOverdueLoans.isChecked).to.be.false;
+          });
+
+          it('should has proper label', () => {
+            expect(LoanPolicyForm.requestManagementSection.recallsExtendOverdueLoans.text).to.equal(
+              translation['settings.requestManagement.allowRecallsToExtendOverdueLoans']
+            );
+          });
+
+          describe('alternate recall return interval', () => {
+            beforeEach(async () => {
+              await LoanPolicyForm
+                .requestManagementSection.recallsExtendOverdueLoans.clickAndBlur()
+                .loansSection.loanProfile.selectAndBlur(translation['settings.loanPolicy.profileType.rolling']);
+            });
+
+            it('should be displayed', () => {
+              expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.isPresent).to.be.true;
+            });
+
+            it('should have proper label', () => {
+              expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.label).to.equal(
+                translation['settings.requestManagement.alternateRecallReturnInterval']
+              );
+            });
+          });
+        });
       });
 
       describe('holds', () => {

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -224,6 +224,8 @@
   "settings.requestManagement.recalls": "Recalls",
   "settings.requestManagement.recallReturnInterval": "Recall return interval",
   "settings.requestManagement.minimumGuaranteedLoanPeriod": "Minimum guaranteed loan period for recalled items",
+  "settings.requestManagement.allowRecallsToExtendOverdueLoans": "Allow recalls to extend due dates for overdue loans",
+  "settings.requestManagement.alternateRecallReturnInterval": "Alternate recall return interval for overdue loans",
   "settings.requestManagement.alternateGracePeriod": "Alternate grace period for recalled items",
   "settings.requestManagement.alternateCheckoutLoanPeriod": "Alternate loan period at checkout for items with an active, pending hold request",
   "settings.requestManagement.renewItemsWithRequest": "Allow renewal of items with an active, pending hold request",


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-525

### Purpose
It was added a new setting on the loan policy (in `Request management` -> `Recalls` section) that allows recalls to extend overdue loans.