### PR TITLE
UICIRC-528 - Duplicate patron notice template names allowed - case is not considered in validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update version of `feesfines` okapi interface to `v16.0`.
 * Modifier ! (not) - preceding value entered for a criteria, means any value except. Refs UICIRC-507.
 * Add `Allow recalls to extend overdue loans` setting. Refs UICIRC-525.
+* Duplicate patron notice template names allowed - case is not considered in validation. Refs UICIRC-528.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -81,9 +81,11 @@ class PatronNoticeForm extends React.Component {
 
     if (name) {
       try {
-        const response = await this.getTemplatesByName(name);
+        const response = await this.getTemplatesByName(name.toLowerCase());
         const { templates = [] } = await response.json();
-        const matchedTemplate = find(templates, ['name', name]);
+        const matchedTemplate = find(templates, template => {
+          return template.name.toLowerCase() === name.toLowerCase();
+        });
         if (matchedTemplate && matchedTemplate.id !== initialValues.id) {
           error = <FormattedMessage id="ui-circulation.settings.patronNotices.errors.nameExists" />;
         }

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -81,7 +81,7 @@ class PatronNoticeForm extends React.Component {
 
     if (name) {
       try {
-        const response = await this.getTemplatesByName(name.toLowerCase());
+        const response = await this.getTemplatesByName(name);
         const { templates = [] } = await response.json();
         const matchedTemplate = find(templates, template => {
           return template.name.toLowerCase() === name.toLowerCase();


### PR DESCRIPTION
# Purpose
Make patron notice template name validation case insensitive.

# Link
https://issues.folio.org/browse/UICIRC-528

# Screenshot
<img width="1153" alt="Screen Shot 2020-11-27 at 12 34 23" src="https://user-images.githubusercontent.com/43472449/100439986-e639fc00-30ac-11eb-9cf9-920e7a886ec1.png">
