### PR TITLE
UICIRC-488: Add space to rule editor to multiple criteria rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update version of `feesfines` okapi interface to `v16.0`.
 * Modifier ! (not) - preceding value entered for a criteria, means any value except. Refs UICIRC-507.
 * Add `Allow recalls to extend overdue loans` setting. Refs UICIRC-525.
+* Circ rules editor does not generate space as expected when adding criteria to multiple criteria rule. Refs UICIRC-488.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -14,7 +14,7 @@ import {
   RULES_TYPE,
   LOCATION_RULES_TYPES
 } from '../../../constants';
-import { addSpaceToCMRules } from './utils';
+import addIndentToCMRules from './utils';
 
 const locationHeadersMapping = {
   [RULES_TYPE.INSTITUTION]: 'institution',
@@ -64,7 +64,7 @@ function getItemOptions(selector, typeKey) {
   const displayText = getDisplayText(selector, typeKey);
 
   return {
-    text: addSpaceToCMRules(text, 'after'),
+    text: addIndentToCMRules(text, 'after'),
     displayText,
     className: 'rule-hint-minor',
     id: selector.id,
@@ -153,7 +153,7 @@ export function rulesHint(Codemirror, props) {
         const text = formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` });
 
         result.push({
-          text: addSpaceToCMRules(key, 'after'),
+          text: addIndentToCMRules(key, 'after'),
           displayText: `${key}: ${text}`,
           className: 'rule-hint-minor',
         });
@@ -195,7 +195,7 @@ export function rulesHint(Codemirror, props) {
 
       forOwn(policyMapping, (value, key) => {
         result.push({
-          text: addSpaceToCMRules(key, 'after'),
+          text: addIndentToCMRules(key, 'after'),
           displayText: formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` }),
           className: 'rule-hint-minor',
         });
@@ -210,7 +210,7 @@ export function rulesHint(Codemirror, props) {
 
         completionLists[type].forEach((selector) => {
           result.push({
-            text: addSpaceToCMRules(selector, 'after'),
+            text: addIndentToCMRules(selector, 'after'),
             displayText: selector,
             className: 'rule-hint-minor',
           });

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -14,7 +14,7 @@ import {
   RULES_TYPE,
   LOCATION_RULES_TYPES
 } from '../../../constants';
-import addIndentToCMRules from './utils';
+import addIndentToEditorRules from './utils';
 
 const locationHeadersMapping = {
   [RULES_TYPE.INSTITUTION]: 'institution',
@@ -64,7 +64,7 @@ function getItemOptions(selector, typeKey) {
   const displayText = getDisplayText(selector, typeKey);
 
   return {
-    text: addIndentToCMRules(text, 'after'),
+    text: addIndentToEditorRules(text, 'after'),
     displayText,
     className: 'rule-hint-minor',
     id: selector.id,
@@ -153,7 +153,7 @@ export function rulesHint(Codemirror, props) {
         const text = formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` });
 
         result.push({
-          text: addIndentToCMRules(key, 'after'),
+          text: addIndentToEditorRules(key, 'after'),
           displayText: `${key}: ${text}`,
           className: 'rule-hint-minor',
         });
@@ -195,7 +195,7 @@ export function rulesHint(Codemirror, props) {
 
       forOwn(policyMapping, (value, key) => {
         result.push({
-          text: addIndentToCMRules(key, 'after'),
+          text: addIndentToEditorRules(key, 'after'),
           displayText: formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` }),
           className: 'rule-hint-minor',
         });
@@ -210,7 +210,7 @@ export function rulesHint(Codemirror, props) {
 
         completionLists[type].forEach((selector) => {
           result.push({
-            text: addIndentToCMRules(selector, 'after'),
+            text: addIndentToEditorRules(selector, 'after'),
             displayText: selector,
             className: 'rule-hint-minor',
           });

--- a/src/settings/lib/RuleEditor/Rules-hint.js
+++ b/src/settings/lib/RuleEditor/Rules-hint.js
@@ -14,6 +14,7 @@ import {
   RULES_TYPE,
   LOCATION_RULES_TYPES
 } from '../../../constants';
+import { addSpaceToCMRules } from './utils';
 
 const locationHeadersMapping = {
   [RULES_TYPE.INSTITUTION]: 'institution',
@@ -38,13 +39,13 @@ const getSectionsDescriptions = type => {
     case RULES_TYPE.CAMPUS:
       return [
         { header: 'ui-circulation.settings.circulationRules.institution', childSection: RULES_TYPE.CAMPUS },
-        { header: 'ui-circulation.settings.circulationRules.campus', selectedHintIndex: 0 },
+        { header: 'ui-circulation.settings.circulationRules.campus', selectedHintIndex: 0, isMultipleSelection: true },
       ];
     case RULES_TYPE.LIBRARY:
       return [
         { header: 'ui-circulation.settings.circulationRules.institution', childSection: RULES_TYPE.CAMPUS },
         { header: 'ui-circulation.settings.circulationRules.campus', childSection: RULES_TYPE.LIBRARY, selectedHintIndex: 0 },
-        { header: 'ui-circulation.settings.circulationRules.library', selectedHintIndex: 0 },
+        { header: 'ui-circulation.settings.circulationRules.library', selectedHintIndex: 0, isMultipleSelection: true },
       ];
     case RULES_TYPE.LOCATION:
       return [
@@ -63,7 +64,7 @@ function getItemOptions(selector, typeKey) {
   const displayText = getDisplayText(selector, typeKey);
 
   return {
-    text: `${text} `,
+    text: addSpaceToCMRules(text, 'after'),
     displayText,
     className: 'rule-hint-minor',
     id: selector.id,
@@ -152,7 +153,7 @@ export function rulesHint(Codemirror, props) {
         const text = formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` });
 
         result.push({
-          text: `${key} `,
+          text: addSpaceToCMRules(key, 'after'),
           displayText: `${key}: ${text}`,
           className: 'rule-hint-minor',
         });
@@ -194,7 +195,7 @@ export function rulesHint(Codemirror, props) {
 
       forOwn(policyMapping, (value, key) => {
         result.push({
-          text: `${key} `,
+          text: addSpaceToCMRules(key, 'after'),
           displayText: formatMessage({ id: `ui-circulation.settings.circulationRules.${value}` }),
           className: 'rule-hint-minor',
         });
@@ -209,7 +210,7 @@ export function rulesHint(Codemirror, props) {
 
         completionLists[type].forEach((selector) => {
           result.push({
-            text: `${selector} `,
+            text: addSpaceToCMRules(selector, 'after'),
             displayText: selector,
             className: 'rule-hint-minor',
           });

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -17,7 +17,7 @@ import {
   ACTIVE_HINT_ELEMENT_CLASS,
   HINT_ELEMENT_CLASS,
 } from '../../../constants';
-import { addSpaceToCMRules } from './utils';
+import addIndentToCMRules from './utils';
 
 const HINT_SECTIONS_CONTAINER = 'CodeMirror-hints-sections-container';
 const HINT_SECTION_CONTAINER = 'CodeMirror-hints-list';
@@ -146,7 +146,7 @@ class Completion {
     const codesText = pickedCompletions.map(getText).join('');
 
     pickedCompletions.forEach(completion => { CodeMirror.signal(data, 'pick', completion); });
-    this.cm.replaceRange(addSpaceToCMRules(codesText, 'before'), from, to, 'complete');
+    this.cm.replaceRange(addIndentToCMRules(codesText, 'before'), from, to, 'complete');
     this.close();
   }
 
@@ -671,7 +671,7 @@ class HintSection {
 
   createListItem(itemOptions, index) {
     const listItemElement = document.createElement('li');
-    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? addSpaceToCMRules(ACTIVE_HINT_ELEMENT_CLASS, 'before') : '');
+    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? addIndentToCMRules(ACTIVE_HINT_ELEMENT_CLASS, 'before') : '');
 
     listItemElement.className = itemOptions.className ? `${itemOptions.className} ${className}` : className;
 

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -17,7 +17,7 @@ import {
   ACTIVE_HINT_ELEMENT_CLASS,
   HINT_ELEMENT_CLASS,
 } from '../../../constants';
-import addIndentToCMRules from './utils';
+import addIndentToEditorRules from './utils';
 
 const HINT_SECTIONS_CONTAINER = 'CodeMirror-hints-sections-container';
 const HINT_SECTION_CONTAINER = 'CodeMirror-hints-list';
@@ -146,7 +146,7 @@ class Completion {
     const codesText = pickedCompletions.map(getText).join('');
 
     pickedCompletions.forEach(completion => { CodeMirror.signal(data, 'pick', completion); });
-    this.cm.replaceRange(addIndentToCMRules(codesText, 'before'), from, to, 'complete');
+    this.cm.replaceRange(addIndentToEditorRules(codesText, 'before'), from, to, 'complete');
     this.close();
   }
 
@@ -671,7 +671,7 @@ class HintSection {
 
   createListItem(itemOptions, index) {
     const listItemElement = document.createElement('li');
-    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? addIndentToCMRules(ACTIVE_HINT_ELEMENT_CLASS, 'before') : '');
+    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? addIndentToEditorRules(ACTIVE_HINT_ELEMENT_CLASS, 'before') : '');
 
     listItemElement.className = itemOptions.className ? `${itemOptions.className} ${className}` : className;
 

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -17,6 +17,7 @@ import {
   ACTIVE_HINT_ELEMENT_CLASS,
   HINT_ELEMENT_CLASS,
 } from '../../../constants';
+import { addSpaceToCMRules } from './utils';
 
 const HINT_SECTIONS_CONTAINER = 'CodeMirror-hints-sections-container';
 const HINT_SECTION_CONTAINER = 'CodeMirror-hints-list';
@@ -145,7 +146,7 @@ class Completion {
     const codesText = pickedCompletions.map(getText).join('');
 
     pickedCompletions.forEach(completion => { CodeMirror.signal(data, 'pick', completion); });
-    this.cm.replaceRange(codesText, from, to, 'complete');
+    this.cm.replaceRange(addSpaceToCMRules(codesText, 'before'), from, to, 'complete');
     this.close();
   }
 
@@ -670,7 +671,7 @@ class HintSection {
 
   createListItem(itemOptions, index) {
     const listItemElement = document.createElement('li');
-    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? ` ${ACTIVE_HINT_ELEMENT_CLASS}` : '');
+    const className = HINT_ELEMENT_CLASS + (this.isSelectedByIndex(index) ? addSpaceToCMRules(ACTIVE_HINT_ELEMENT_CLASS, 'before') : '');
 
     listItemElement.className = itemOptions.className ? `${itemOptions.className} ${className}` : className;
 

--- a/src/settings/lib/RuleEditor/utils.js
+++ b/src/settings/lib/RuleEditor/utils.js
@@ -1,4 +1,4 @@
-const addIndentToCMRules = (rule, position) => {
+const addIndentToEditorRules = (rule, position) => {
   switch (position) {
     case 'before':
       return ` ${rule}`;
@@ -9,4 +9,4 @@ const addIndentToCMRules = (rule, position) => {
   }
 };
 
-export default addIndentToCMRules;
+export default addIndentToEditorRules;

--- a/src/settings/lib/RuleEditor/utils.js
+++ b/src/settings/lib/RuleEditor/utils.js
@@ -1,0 +1,10 @@
+export const addSpaceToCMRules = (rule, position) => {
+  switch (position) {
+    case 'before':
+      return ` ${rule}`;
+    case 'after':
+      return `${rule} `;
+    default:
+      return rule;
+  }
+};

--- a/src/settings/lib/RuleEditor/utils.js
+++ b/src/settings/lib/RuleEditor/utils.js
@@ -1,4 +1,4 @@
-export const addSpaceToCMRules = (rule, position) => {
+const addIndentToCMRules = (rule, position) => {
   switch (position) {
     case 'before':
       return ` ${rule}`;
@@ -8,3 +8,5 @@ export const addSpaceToCMRules = (rule, position) => {
       return rule;
   }
 };
+
+export default addIndentToCMRules;

--- a/test/bigtest/tests/circulation-rules-editor/hints-menu/backward-navigation-test.js
+++ b/test/bigtest/tests/circulation-rules-editor/hints-menu/backward-navigation-test.js
@@ -14,6 +14,8 @@ import {
   removeDisplayedHints,
 } from '../utils';
 
+const getEditorHintSection = sectionIndex => circulationRules.editor.hints.sections(sectionIndex);
+
 describe('Circulation rules editor -> hints menu: backward navigation between multiple sections ', () => {
   setupApplication();
 
@@ -54,6 +56,7 @@ describe('Circulation rules editor -> hints menu: backward navigation between mu
 
           // select first campus
           await circulationRules.editor.hints.clickOnItem(0, 1);
+          await getEditorHintSection(1).completionButton.click();
         });
 
         it('should insert the right campus code', () => {
@@ -85,6 +88,7 @@ describe('Circulation rules editor -> hints menu: backward navigation between mu
 
           // select first campus in second institution
           await circulationRules.editor.hints.clickOnItem(0, 1);
+          await getEditorHintSection(1).completionButton.click();
         });
 
         it('should insert the right campus code', () => {
@@ -104,6 +108,7 @@ describe('Circulation rules editor -> hints menu: backward navigation between mu
 
           // select first campus in second institution
           await circulationRules.editor.hints.clickOnItem(0, 1);
+          await getEditorHintSection(1).completionButton.click();
         });
 
         it('should insert the right campus code', () => {

--- a/test/bigtest/tests/circulation-rules-editor/hints-menu/backward-navigation-test.js
+++ b/test/bigtest/tests/circulation-rules-editor/hints-menu/backward-navigation-test.js
@@ -39,7 +39,7 @@ describe('Circulation rules editor -> hints menu: backward navigation between mu
 
   describe('navigating between sections', () => {
     beforeEach(async () => {
-      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'b ');
+      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'b');
     });
 
     describe('pressing Backspace button', () => {
@@ -72,7 +72,7 @@ describe('Circulation rules editor -> hints menu: backward navigation between mu
         });
 
         it('should remove characters in editor', () => {
-          expect(circulationRules.editor.value).to.equal('b');
+          expect(circulationRules.editor.value).to.equal('');
         });
       });
     });

--- a/test/bigtest/tests/circulation-rules-editor/hints-menu/criteria-hints-menu-test.js
+++ b/test/bigtest/tests/circulation-rules-editor/hints-menu/criteria-hints-menu-test.js
@@ -143,7 +143,6 @@ describe('Circulation rules editor: criteria hints', () => {
       beforeEach(async () => {
         await circulationRules.editor.changeActiveItem(0);
         await circulationRules.editor.hints.sections(0).subheader.click();
-
       });
 
       it('should not change hints state', () => {

--- a/test/bigtest/tests/circulation-rules-editor/hints-menu/criteria-hints-menu-test.js
+++ b/test/bigtest/tests/circulation-rules-editor/hints-menu/criteria-hints-menu-test.js
@@ -143,6 +143,7 @@ describe('Circulation rules editor: criteria hints', () => {
       beforeEach(async () => {
         await circulationRules.editor.changeActiveItem(0);
         await circulationRules.editor.hints.sections(0).subheader.click();
+
       });
 
       it('should not change hints state', () => {
@@ -154,7 +155,7 @@ describe('Circulation rules editor: criteria hints', () => {
 
   describe('choosing locating criteria type - campus', () => {
     beforeEach(async () => {
-      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'b ');
+      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'b');
     });
 
     it('should display campus codes hints list', () => {
@@ -205,7 +206,7 @@ describe('Circulation rules editor: criteria hints', () => {
       });
 
       it('should not change the editor value', () => {
-        expect(circulationRules.editor.value).to.equal('b ');
+        expect(circulationRules.editor.value).to.equal('b');
       });
 
       it('should display sections without the special value ANY', () => {
@@ -243,7 +244,8 @@ describe('Circulation rules editor: criteria hints', () => {
 
         describe('selecting active item in the second section', () => {
           beforeEach(async () => {
-            await circulationRules.editor.pickHint(campusesAmount - 1);
+            await circulationRules.editor.hints.clickOnItem(campusesAmount - 1, 1);
+            await getEditorHintSection(1).completionButton.click();
           });
 
           it('should add full hierarchical path with campus code to the editor', () => {
@@ -258,7 +260,7 @@ describe('Circulation rules editor: criteria hints', () => {
 
   describe('choosing locating criteria type - library', () => {
     beforeEach(async () => {
-      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'c ');
+      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 'c');
     });
 
     it('should display library codes hints list', () => {
@@ -340,7 +342,8 @@ describe('Circulation rules editor: criteria hints', () => {
 
         describe('clicking on the first library', () => {
           beforeEach(async () => {
-            await circulationRules.editor.hints.clickOnItem(1, 2);
+            await circulationRules.editor.hints.clickOnItem(0, 2);
+            await getEditorHintSection(2).completionButton.click();
           });
 
           it('should add full hierarchial path with library code to the editor value', () => {
@@ -357,7 +360,7 @@ describe('Circulation rules editor: criteria hints', () => {
     const editorHints = circulationRules.editor.hints;
 
     beforeEach(async () => {
-      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 's ');
+      await showHintsWithAttachedCustomKeysHandlers(circulationRules.editor, 's');
     });
 
     it('should display location codes hints list ', () => {
@@ -619,7 +622,7 @@ describe('Circulation rules editor: criteria hints', () => {
             });
 
             it('should not add any codes to input field on click on location items', () => {
-              expect(circulationRules.editor.value).to.equal('s ');
+              expect(circulationRules.editor.value).to.equal('s');
             });
 
             describe('clicking on the completion button', () => {


### PR DESCRIPTION
# Description
In Circ Rule editor when selecting multiple criteria was a problem with after `Enter` - `rule` with `criteria` were concatenated into regular text. In this PR were added formatted function for adding of `indent` to editor values. Since there were many places where template strings with space used, so I replace them with function too for consistency.
Also add `library` and `campuses` rule multiple selection behavior, because they are - multiple.    
# Task
https://issues.folio.org/browse/UICIRC-488
# Screenshots
**Before:** https://recordit.co/5lroDBsjUm
**After:** https://recordit.co/0xXdNbmq4v
