### PR TITLE
UICIRC-525: Set same behavior when selecting Rolling or Fixed loan p…

### DIFF
--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.js
@@ -88,7 +88,6 @@ class RequestManagementSection extends React.Component {
           </div>
           <br />
           {
-            policy.isProfileRolling() &&
             policy.requestManagement?.recalls?.allowRecallsToExtendOverdueLoans &&
             <div data-test-request-management-section-alternate-recall-return-interval>
               <Period

--- a/test/bigtest/tests/loan-policy/loan-policy-form-test.js
+++ b/test/bigtest/tests/loan-policy/loan-policy-form-test.js
@@ -775,20 +775,40 @@ describe('LoanPolicyForm', () => {
           });
 
           describe('alternate recall return interval', () => {
-            beforeEach(async () => {
-              await LoanPolicyForm
-                .requestManagementSection.recallsExtendOverdueLoans.clickAndBlur()
-                .loansSection.loanProfile.selectAndBlur(translation['settings.loanPolicy.profileType.rolling']);
+            describe('when select Fixed option for loan profile', () => {
+              beforeEach(async () => {
+                await LoanPolicyForm
+                  .requestManagementSection.recallsExtendOverdueLoans.clickAndBlur()
+                  .loansSection.loanProfile.selectAndBlur(translation['settings.loanPolicy.profileType.fixed']);
+              });
+
+              it('should be displayed', () => {
+                expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.isPresent).to.be.true;
+              });
+
+              it('should have proper label', () => {
+                expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.label).to.equal(
+                  translation['settings.requestManagement.alternateRecallReturnInterval']
+                );
+              });
             });
 
-            it('should be displayed', () => {
-              expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.isPresent).to.be.true;
-            });
+            describe('when select Rolling option for loan profile', () => {
+              beforeEach(async () => {
+                await LoanPolicyForm
+                  .requestManagementSection.recallsExtendOverdueLoans.clickAndBlur()
+                  .loansSection.loanProfile.selectAndBlur(translation['settings.loanPolicy.profileType.rolling']);
+              });
 
-            it('should have proper label', () => {
-              expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.label).to.equal(
-                translation['settings.requestManagement.alternateRecallReturnInterval']
-              );
+              it('should be displayed', () => {
+                expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.isPresent).to.be.true;
+              });
+
+              it('should have proper label', () => {
+                expect(LoanPolicyForm.requestManagementSection.alternateRecallReturnInterval.label).to.equal(
+                  translation['settings.requestManagement.alternateRecallReturnInterval']
+                );
+              });
             });
           });
         });


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-525

### Purpose
This PR is a continuation of the two previous - #659 and #662.

Some requirements have been clarified and added to the description. In particular, the behavior of the "Allow recalls to extend overdue loans" setting shouldn't be dependent on which type of loan profile is selected.