### PR TITLE
UICIRC-537 - Add fee/fine action tokens to template with fee/fine charge or adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Circ rules editor does not generate space as expected when adding criteria to multiple criteria rule. Refs UICIRC-488.
 * Add aged to lost triggers to notice policy. Refs UICIRC-515.
 * Add a staff slips token for patron comments. Refs UICIRC-523.
+* Add fee/fine action tokens to template with fee/fine charge or adjustment. Refs UICIRC-537.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -354,16 +354,16 @@ export const patronNoticeCategories = [
     label: 'ui-circulation.settings.patronNotices.categories.request',
   },
   {
+    id: patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+    label: 'ui-circulation.settings.patronNotices.categories.automatedFeeFineAction',
+  },
+  {
     id: patronNoticeCategoryIds.FEE_FINE_CHARGE,
     label: 'ui-circulation.settings.patronNotices.categories.feeFineCharge',
   },
   {
     id: patronNoticeCategoryIds.FEE_FINE_ACTION,
     label: 'ui-circulation.settings.patronNotices.categories.feeFineAction',
-  },
-  {
-    id: patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
-    label: 'ui-circulation.settings.patronNotices.categories.automatedFeeFineAction',
   },
 ];
 

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -4,7 +4,6 @@ import { Field } from 'react-final-form';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import {
   find,
-  sortBy,
   memoize,
 } from 'lodash';
 
@@ -153,8 +152,7 @@ class PatronNoticeForm extends React.Component {
     const isActive = initialValues && initialValues.active;
     const category = getFieldState('category')?.value;
 
-    const sortedCategories = sortBy(patronNoticeCategories, ['label']);
-    const categoryOptions = sortedCategories.map(({ label, id }) => ({
+    const categoryOptions = patronNoticeCategories.map(({ label, id }) => ({
       label: formatMessage({ id: label }),
       value: id,
     }));

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -79,7 +79,7 @@ class PatronNotices extends React.Component {
   };
 
   render() {
-    const [{ id: defaultCategory }] = sortBy(patronNoticeCategories, ['label']);
+    const [{ id: defaultCategory }] = patronNoticeCategories;
 
     return (
       <EntryManager

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -329,32 +329,50 @@ const formats = {
     {
       token: 'feeAction.type',
       previewValue: 'Waived partially',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
     {
       token: 'feeAction.actionDate',
       previewValue: 'Jul 10, 2020',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
     {
       token: 'feeAction.actionDateTime',
       previewValue: 'Jul 10, 2020 8:00',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
     {
       token: 'feeAction.amount',
       previewValue: '$5.00',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
     {
       token: 'feeAction.remainingAmount',
       previewValue: '$10.00',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
     {
       token: 'feeAction.additionalInfo',
       previewValue: 'Cost to repair less than expected.',
-      allowedFor: [patronNoticeCategoryIds.FEE_FINE_ACTION],
+      allowedFor: [
+        patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE,
+      ],
     },
   ],
 };

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -159,7 +159,7 @@
   "settings.checkout.filterRules": "filter rules",
   "settings.checkout.timeout.duration": "Timeout duration",
 
-  "settings.patronNotices.categories.feeFineAction": "Fee/fine action (pay, waive, refund, transfer or cancel in error)",
+  "settings.patronNotices.categories.feeFineAction": "Manual fee/fine action (pay, waive, refund, transfer or cancel/error)",
   "settings.patronNotices.categories.feeFineCharge": "Manual fee/fine charge",
   "settings.patronNotices.categories.automatedFeeFineAction": "Automated fee/fine charge or adjustment",
   "settings.patronNotices.categories.loan": "Loan",


### PR DESCRIPTION
# Purpose
- make `fee/fine action` tokens available for `automated fee/fine charge or adjustment` category
- rename `manual fee/fine action` category
- reorder values for `category` dropdown

# Link
https://issues.folio.org/browse/UICIRC-537

# Screenshots
<img width="1677" alt="Screen Shot 2020-12-15 at 11 21 12" src="https://user-images.githubusercontent.com/43472449/102195788-bae64800-3ec7-11eb-875a-6a236cdc70a8.png">
<img width="1680" alt="Screen Shot 2020-12-15 at 11 21 36" src="https://user-images.githubusercontent.com/43472449/102195806-bf126580-3ec7-11eb-9f72-f46e12e1a783.png">
