### PR TITLE
UICIRC-523: Add staff slips token for patron comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Duplicate patron notice template names allowed - case is not considered in validation. Refs UICIRC-528.
 * Circ rules editor does not generate space as expected when adding criteria to multiple criteria rule. Refs UICIRC-488.
 * Add aged to lost triggers to notice policy. Refs UICIRC-515.
+* Add a staff slips token for patron comments. Refs UICIRC-523.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/settings/StaffSlips/tokens.js
+++ b/src/settings/StaffSlips/tokens.js
@@ -146,6 +146,11 @@ const formats = {
       previewValue: '987321654',
       allowedFor: [...Object.values(staffSlipMap)]
     },
+    {
+      token: 'request.patronComments',
+      previewValue: 'Please deliver to the History building for Professor McCoy.',
+      allowedFor: [...Object.values(staffSlipMap)]
+    },
   ],
   requestDeliveryAddress: [
     {


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-523

This issue is just about exposing a 'patron comments' token in the UI so that it can be added to templates.

<img width="1415" alt="Screen Shot 2020-12-15 at 4 39 40 PM" src="https://user-images.githubusercontent.com/1322242/102276053-4aa1eb80-3ef4-11eb-8a4b-75cebb0acaf3.png">
<img width="711" alt="Screen Shot 2020-12-15 at 4 40 17 PM" src="https://user-images.githubusercontent.com/1322242/102276056-4bd31880-3ef4-11eb-9939-2b9c2da02569.png">
