### PR TITLE
UICIRC-541 - First field should be in focus for all forms in circulation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add a staff slips token for patron comments. Refs UICIRC-523.
 * Add fee/fine action tokens to template with fee/fine charge or adjustment. Refs UICIRC-537.
 * Add separate aged to lost settings for recalled items in lost item fee policies. Refs UICIRC-529.
+* First field should be in focus for all forms in circulation settings. Refs UICIRc-541.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Add a staff slips token for patron comments. Refs UICIRC-523.
 * Add fee/fine action tokens to template with fee/fine charge or adjustment. Refs UICIRC-537.
 * Add separate aged to lost settings for recalled items in lost item fee policies. Refs UICIRC-529.
-* First field should be in focus for all forms in circulation settings. Refs UICIRc-541.
+* First field should be in focus for all forms in circulation settings. Refs UICIRC-541.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
+++ b/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
@@ -17,6 +17,7 @@ const OverdueAboutSection = () => (
           label={<FormattedMessage id="ui-circulation.settings.finePolicy.overdueFinePolicyName" />}
           id="input-policy-name"
           name="name"
+          autoFocus
           component={TextField}
           required
         />

--- a/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
@@ -20,6 +20,7 @@ const LostItemFeeAboutSection = () => (
           label={<FormattedMessage id="ui-circulation.settings.lostItemFee.lostItemFeePolicyName" />}
           component={TextField}
           required
+          autoFocus
           name="name"
           id="input-policy-name"
           fullWidth

--- a/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -45,6 +45,7 @@ class GeneralSection extends React.Component {
               name="name"
               label={<FormattedMessage id="ui-circulation.settings.noticePolicy.policyName" />}
               required
+              autoFocus
               component={TextField}
             />
           </div>

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -182,6 +182,7 @@ class PatronNoticeForm extends React.Component {
                   name="name"
                   required
                   id="input-patron-notice-name"
+                  autoFocus
                   component={TextField}
                   validate={this.validateName}
                 />

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -67,15 +67,17 @@ class GeneralSection extends React.Component {
           connect={connect}
           metadata={metadata}
         />
-        <Field
-          id="request_policy_name"
-          name="name"
-          required
-          autoFocus
-          label={<FormattedMessage id="ui-circulation.settings.requestPolicy.policyName" />}
-          component={TextField}
-          validate={validateName}
-        />
+        <div data-test-request-policy-name>
+          <Field
+            id="request_policy_name"
+            name="name"
+            required
+            autoFocus
+            label={<FormattedMessage id="ui-circulation.settings.requestPolicy.policyName" />}
+            component={TextField}
+            validate={validateName}
+          />
+        </div>
         <Field
           id="request_policy_description"
           name="description"

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -71,6 +71,7 @@ class GeneralSection extends React.Component {
           id="request_policy_name"
           name="name"
           required
+          autoFocus
           label={<FormattedMessage id="ui-circulation.settings.requestPolicy.policyName" />}
           component={TextField}
           validate={validateName}

--- a/src/settings/StaffSlips/StaffSlipForm.js
+++ b/src/settings/StaffSlips/StaffSlipForm.js
@@ -90,6 +90,7 @@ class StaffSlipForm extends React.Component {
                   label={<FormattedMessage id="ui-circulation.settings.staffSlips.description" />}
                   name="description"
                   id="input-staff-slip-description"
+                  autoFocus
                   component={TextArea}
                   fullWidth
                   disabled={disabled}

--- a/src/settings/StaffSlips/StaffSlipForm.js
+++ b/src/settings/StaffSlips/StaffSlipForm.js
@@ -85,7 +85,10 @@ class StaffSlipForm extends React.Component {
               </Col>
             </Row>
             <Row>
-              <Col xs={8}>
+              <Col
+                data-test-staff-slip-description
+                xs={8}
+              >
                 <Field
                   label={<FormattedMessage id="ui-circulation.settings.staffSlips.description" />}
                   name="description"

--- a/test/bigtest/interactors/request-policy/request-policy-form.js
+++ b/test/bigtest/interactors/request-policy/request-policy-form.js
@@ -10,6 +10,8 @@ import {
   focusable,
 } from '@bigtest/interactor';
 
+import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 @interactor class RequestPolicyForm {
@@ -18,6 +20,7 @@ import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tes
     return this.when(() => this.isLoaded);
   }
 
+  name = new TextFieldInteractor('[data-test-request-policy-name]');
   hasName = isPresent('#request_policy_name');
   nameValue = value('#request_policy_name');
   hasDescription = isPresent('#request_policy_description');

--- a/test/bigtest/interactors/staff-slip/staff-slip-form.js
+++ b/test/bigtest/interactors/staff-slip/staff-slip-form.js
@@ -6,12 +6,15 @@ import {
   value
 } from '@bigtest/interactor';
 
+import TextAreaInteractor from '@folio/stripes-components/lib/TextArea/tests/interactor';
+
 @interactor class StaffSlipForm {
   isLoaded = isPresent('#template-editor');
   whenLoaded() {
     return this.when(() => this.isLoaded);
   }
 
+  description = new TextAreaInteractor('[data-test-staff-slip-description]');
   hasDescription = isPresent('#input-staff-slip-description');
   descValue = value('#input-staff-slip-description');
 

--- a/test/bigtest/tests/fine-policy/fine-policy-form-test.js
+++ b/test/bigtest/tests/fine-policy/fine-policy-form-test.js
@@ -12,6 +12,10 @@ describe('FinePolicyForm', () => {
     this.visit('/settings/circulation/fine-policies?layer=add');
   });
 
+  it('should focus name field', () => {
+    expect(FinePolicyForm.aboutSection.policyName.isFocused).to.be.true;
+  });
+
   it('should be displayed', () => {
     expect(FinePolicyForm.expandAll.isPresent).to.be.true;
   });

--- a/test/bigtest/tests/lost-item-fee-policy/lost-item-fee-policy-form-test.js
+++ b/test/bigtest/tests/lost-item-fee-policy/lost-item-fee-policy-form-test.js
@@ -13,6 +13,10 @@ describe('Lost Item Fee Policy Form', () => {
       await this.visit('/settings/circulation/lost-item-fee-policy?layer=add');
     });
 
+    it('should focus name field', () => {
+      expect(LostItemFeePolicyForm.aboutSection.policyName.isFocused).to.be.true;
+    });
+
     it('should be displayed', () => {
       expect(LostItemFeePolicyForm.expandAll.isPresent).to.be.true;
     });

--- a/test/bigtest/tests/notice-policy/notice-policy-form-test.js
+++ b/test/bigtest/tests/notice-policy/notice-policy-form-test.js
@@ -21,6 +21,10 @@ describe('NoticePolicyForm', () => {
       expect(NoticePolicyForm.expandAll.isPresent).to.be.true;
     });
 
+    it('should focus name field', () => {
+      expect(NoticePolicyForm.generalSection.policyName.isFocused).to.be.true;
+    });
+
     describe('collapse all', () => {
       beforeEach(async () => {
         await NoticePolicyForm.expandAll.click();

--- a/test/bigtest/tests/patron-notice/patron-notice-form-test.js
+++ b/test/bigtest/tests/patron-notice/patron-notice-form-test.js
@@ -20,6 +20,10 @@ describe('Patron Notice Form', () => {
       expect(PatronNoticeForm.isPresent).to.be.true;
     });
 
+    it('should focus name field', () => {
+      expect(PatronNoticeForm.templateName.isFocused).to.be.true;
+    });
+
     describe('email template accordion', () => {
       beforeEach(async () => {
         await PatronNoticeForm.emaillSectionAccordion.clickHeader();

--- a/test/bigtest/tests/request-policy/request-policy-form-test.js
+++ b/test/bigtest/tests/request-policy/request-policy-form-test.js
@@ -19,6 +19,10 @@ describe('RequestPolicyForm', () => {
       await this.visit(`/settings/circulation/request-policies/${requestPolicy.id}?layer=edit`);
     });
 
+    it('should focus name field', () => {
+      expect(RequestPolicyForm.name.isFocused).to.be.true;
+    });
+
     it('has a request policy name field', () => {
       expect(RequestPolicyForm.hasName).to.be.true;
     });

--- a/test/bigtest/tests/staff-slip/staff-slip-form-test.js
+++ b/test/bigtest/tests/staff-slip/staff-slip-form-test.js
@@ -21,6 +21,10 @@ describe('StaffSlipForm', () => {
     await StaffSlipForm.whenLoaded();
   });
 
+  it('should focus description field', () => {
+    expect(StaffSlipForm.description.isFocused).to.be.true;
+  });
+
   it('has a staff slip description field', () => {
     expect(StaffSlipForm.descValue).to.equal(staffSlip.description);
   });


### PR DESCRIPTION
# Purpose
First field should be in focus for all forms in circulation settings

# Link
https://issues.folio.org/browse/UICIRC-541
