### PR TITLE
UICIRC-547: Update stripes-cli to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Update to stripes v6. Refs UICIRC-543.
 * Move moment from a regular to a peer and dev dependencies. Refs UICIRC-513.
 * Order of settings when viewing Lost Item Fee Policy not same as new/edit order. Refs UICIRC-531.
+* Update to `stripes-cli v2.0.0`. Refs UICIRC-547.
 
 ## 4.0.0 (https://github.com/folio-org/ui-circulation/tree/v4.0.0) (2020-10-13)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-components": "^9.0.0",
     "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
# Description
Update `stripes-cli` to `v2.0.0`
# Task
https://issues.folio.org/browse/UICIRC-547