### PR TITLE
UICIRC-555: Add changes to test  'should render updated policy name' for stable work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update the .gitignore file. Refs UICIRC-550.
 * Add pull request template. Refs UICIRC-551.
+* Add changes to test `updating an existing lost item fee policy` for stable work. Refs UICIRC-555.
 
 ## 5.0.0 (https://github.com/folio-org/ui-circulation/tree/v5.0.0) (2021-03-09)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v4.0.2...v5.0.0)

--- a/test/bigtest/tests/lost-item-fee-policy/lost-item-fee-policy-edit-test.js
+++ b/test/bigtest/tests/lost-item-fee-policy/lost-item-fee-policy-edit-test.js
@@ -26,11 +26,8 @@ describe('LostItemFeePolicyEdit', () => {
 
     describe('updating an existing lost item fee policy', () => {
       beforeEach(async function () {
-        await LostItemFeePolicyForm
-          .aboutSection.policyNameValue.fill(newLoanPolicyName)
-          .lostItemFeeSection.lostItemFee.fill('0')
-          .lostItemFeeSection.replacementAllowed.selectAndBlur('Yes')
-          .save();
+        await LostItemFeePolicyForm.aboutSection.policyNameValue.fill(newLoanPolicyName);
+        await LostItemFeePolicyForm.save();
       });
 
       it('should render updated policy name', () => {


### PR DESCRIPTION
## Purpose
We have a test that sometimes failed. All our tests should work stable.

## Approach
In scope of current test we tried update field that not rendered yet. We test only  that 'should render updated policy name' this mean that we can update only policy name field. In accordance that we need check 'should render updated policy name' we can remove 
.lostItemFeeSection.lostItemFee.fill('0')
.lostItemFeeSection.replacementAllowed.selectAndBlur('Yes')
and we don't need add whenLoaded here. 

Also .lostItemFeeSection.lostItemFee.fill('0') not work in current case should be fillAndBlur and in current case (our test data) we cannot set current field to 0 will be validation error.

## Refs
https://issues.folio.org/browse/UICIRC-555

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
