### PR TITLE
UICIRC-568: Fix limit in policy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add settings up for Jest/RTL tests. Refs UICIRC-557.
 * Also support `circulation` `10.0`. Refs UICIRC-563.
 * Support configurable audio themes. Refs UICIRC-556.
+* Fix limit in policy settings. Fixes UICIRC-568.
 
 ## 5.0.1 (https://github.com/folio-org/ui-circulation/tree/v5.0.1) (2021-04-21)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.0...v5.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -462,4 +462,6 @@ export const feeFineNoticesTriggeringEvents = [
   },
 ];
 
+export const MAX_UNPAGED_RESOURCE_COUNT = 1000;
+
 export default '';

--- a/src/settings/FinePolicy/FinePolicySettings.js
+++ b/src/settings/FinePolicy/FinePolicySettings.js
@@ -13,17 +13,17 @@ import FinePolicy from '../Models/FinePolicy';
 import FinePolicyDetail from './FinePolicyDetail';
 import FinePolicyForm from './FinePolicyForm';
 import normalize from './utils/normalize';
+import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
 
 class FinePolicySettings extends React.Component {
   static manifest = Object.freeze({
     finePolicies: {
       type: 'okapi',
       records: 'overdueFinePolicies',
-      perRequest: 100,
       path: 'overdue-fines-policies',
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
       throwErrors: false,
     },

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleManager.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleManager.js
@@ -17,21 +17,28 @@ import FixedDueDateScheduleDetail from './FixedDueDateScheduleDetail';
 import FixedDueDateScheduleForm from './FixedDueDateScheduleForm';
 
 import FixedDueDateSchedule from '../Models/FixedDueDateSchedule';
+import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
 
 class FixedDueDateScheduleManager extends React.Component {
   static manifest = Object.freeze({
     fixedDueDateSchedules: {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
-      perRequest: 100,
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
+      params: {
+        query: 'cql.allRecords=1',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
+      }
     },
     loanPolicies: {
       type: 'okapi',
       records: 'loanPolicies',
-      perRequest: 100,
       path: 'loan-policy-storage/loan-policies',
       dataKey: 'loan-policies',
+      params: {
+        query: 'cql.allRecords=1',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
+      }
     },
   });
 

--- a/src/settings/LoanPolicy/LoanPolicySettings.js
+++ b/src/settings/LoanPolicy/LoanPolicySettings.js
@@ -13,28 +13,27 @@ import LoanPolicyDetail from './LoanPolicyDetail';
 import LoanPolicyForm from './LoanPolicyForm';
 import LoanPolicy from '../Models/LoanPolicy';
 import { normalize } from './utils/normalize';
+import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
 
 class LoanPolicySettings extends React.Component {
   static manifest = Object.freeze({
     loanPolicies: {
       type: 'okapi',
       records: 'loanPolicies',
-      perRequest: 100,
       path: 'loan-policy-storage/loan-policies',
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
     },
     fixedDueDateSchedules: {
       type: 'okapi',
       records: 'fixedDueDateSchedules',
-      perRequest: 100,
       path: 'fixed-due-date-schedule-storage/fixed-due-date-schedules',
       resourceShouldRefresh: true,
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
     },
   });

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.js
@@ -17,17 +17,17 @@ import LostItemFeePolicyDetail from './LostItemFeePolicyDetail';
 import LostItemFeePolicyForm from './LostItemFeePolicyForm';
 import LostItemFeePolicy from '../Models/LostItemFeePolicy';
 import normalize from './utils/normalize';
+import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
 
 class LostItemFeePolicySettings extends React.Component {
   static manifest = Object.freeze({
     lostItemFeePolicies: {
       type: 'okapi',
       records: 'lostItemFeePolicies',
-      perRequest: 100,
       path: 'lost-item-fees-policies',
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
       throwErrors: false,
     },

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -12,7 +12,10 @@ import { stripesConnect } from '@folio/stripes/core';
 
 import PatronNoticeDetail from './PatronNoticeDetail';
 import PatronNoticeForm from './PatronNoticeForm';
-import { patronNoticeCategories } from '../../constants';
+import {
+  patronNoticeCategories,
+  MAX_UNPAGED_RESOURCE_COUNT,
+} from '../../constants';
 
 class PatronNotices extends React.Component {
   static propTypes = {
@@ -53,7 +56,7 @@ class PatronNotices extends React.Component {
       path: 'patron-notice-policy-storage/patron-notice-policies',
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
       throwErrors: false,
     },

--- a/test/bigtest/tests/fixed-due-date-schedule/fixed-due-date-schedule-validation-test.js
+++ b/test/bigtest/tests/fixed-due-date-schedule/fixed-due-date-schedule-validation-test.js
@@ -65,13 +65,7 @@ describe('Fixed Due Date Schedule Validation', () => {
 
     beforeEach(async function () {
       this.visit(`settings/circulation/fixed-due-date-schedules/${schedule.id}?layer=edit`);
-    });
-
-    beforeEach(async function () {
       await FddsForm.whenLoaded();
-    });
-
-    beforeEach(async () => {
       await FddsForm.fillName('test');
       await FddsForm.clickSave();
     });


### PR DESCRIPTION
The `limit` was already set to correct value `1000` but it was overwritten by `perRequest`.

This PR removes `perRequest` and replaces `limit` with `maxUnpagedResourceCount` introduced by @MikeTaylor in: https://github.com/folio-org/ui-inventory/pull/1359

`maxUnpagedResourceCount` is set to `1000` by default.

https://issues.folio.org/browse/UICIRC-568

