### PR TITLE
UICIRC-577: Add translation key "mod-circulation.noItemFoundForBarcode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Support configurable audio themes. Refs UICIRC-556.
 * Fix limit in policy settings. Fixes UICIRC-568.
 * Larger query limits for circulation-rules related queries. Fixes UICIRC-568.
+* Add translation key "mod-circulation.noItemFoundForBarcode". Refs UICIRC-577.
 
 ## 5.0.1 (https://github.com/folio-org/ui-circulation/tree/v5.0.1) (2021-04-21)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.0...v5.0.1)

--- a/translations/ui-circulation/de.json
+++ b/translations/ui-circulation/de.json
@@ -444,5 +444,7 @@
     "settings.checkout.audioTheme": "Select audio-alerts theme",
     "settings.checkout.audioTheme.classic": "Classico",
     "settings.checkout.audioTheme.modern": "Moderna",
-    "settings.checkout.audioTheme.future": "Futura"
+    "settings.checkout.audioTheme.future": "Futura",
+
+    "mod-circulation.noItemFoundForBarcode", "Es existiert kein Exemplar mit dem Barcode {itemBarcode}"
 }

--- a/translations/ui-circulation/de.json
+++ b/translations/ui-circulation/de.json
@@ -446,5 +446,5 @@
     "settings.checkout.audioTheme.modern": "Moderna",
     "settings.checkout.audioTheme.future": "Futura",
 
-    "mod-circulation.noItemFoundForBarcode", "Es existiert kein Exemplar mit dem Barcode {itemBarcode}"
+    "mod-circulation.noItemFoundForBarcode": "Es existiert kein Exemplar mit dem Barcode {itemBarcode}"
 }

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -465,5 +465,7 @@
   "permission.settings.other-settings": "Settings (Circ): Can create, edit and remove other settings",
   "permission.settings.notice-templates": "Settings (Circ): Can create, edit and remove patron notice templates",
   "permission.settings.overdue-fines-policies": "Settings (Circ): Can create, edit and remove overdue fine policies",
-  "permission.settings.lost-item-fees-policies": "Settings (Circ): Can create, edit and remove lost item fee policies"
+  "permission.settings.lost-item-fees-policies": "Settings (Circ): Can create, edit and remove lost item fee policies",
+
+  "mod-circulation.noItemFoundForBarcode", "No item with barcode {itemBarcode} exists"
 }

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -467,5 +467,5 @@
   "permission.settings.overdue-fines-policies": "Settings (Circ): Can create, edit and remove overdue fine policies",
   "permission.settings.lost-item-fees-policies": "Settings (Circ): Can create, edit and remove lost item fee policies",
 
-  "mod-circulation.noItemFoundForBarcode", "No item with barcode {itemBarcode} exists"
+  "mod-circulation.noItemFoundForBarcode": "No item with barcode {itemBarcode} exists"
 }


### PR DESCRIPTION
mod-circulation may send the translation key

"ui-circulation.mod-circulation.noItemFoundForBarcode"

This PR adds the translation key.

There are several front-end apps that call mod-circulation and may get this translation key.

Processing the translation key is out of scope.
Generating the translation key is out of scope.

For details see
* https://issues.folio.org/browse/UIREQ-603 "Internationalize back-end failure messages"
* https://issues.folio.org/browse/CIRC-1146 "Internationalize back-end failure messages"
  = https://github.com/folio-org/mod-circulation/pull/879/files

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?