### PR TITLE
UICIRC-578: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Support configurable audio themes. Refs UICIRC-556.
 * Fix limit in policy settings. Fixes UICIRC-568.
 * Larger query limits for circulation-rules related queries. Fixes UICIRC-568.
+* Also support `inventory` `11.0`. Refs UICIRC-578.
 
 ## 5.0.1 (https://github.com/folio-org/ui-circulation/tree/v5.0.1) (2021-04-21)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "@folio/stripes-template-editor"
     ],
     "okapiInterfaces": {
-      "circulation": "9.0 10.0",
+      "circulation": "9.0 10.0 11.0",
       "configuration": "2.0",
       "fixed-due-date-schedules-storage": "2.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UICIRC-578