### PR TITLE
UICIRC-662: Fix a typo in the word Year(s) in the Period interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## [6.0.0] (IN PROGRESS)
+
+* Fix a typo in the word Year(s) in the Period interval. Refs UICIRC-662.
+
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)
 

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -260,7 +260,7 @@
   "settings.common.days": "Day(s)",
   "settings.common.weeks": "Week(s)",
   "settings.common.months": "Month(s)",
-  "settings.common.years": "Years(s)",
+  "settings.common.years": "Year(s)",
   "settings.common.blankPlaceholder": " ",
   "settings.common.close": "Close",
   "settings.common.print": "Print",


### PR DESCRIPTION
## Purpose
Fix a typo in the word Year(s) in the Period interval

## Stories
https://issues.folio.org/browse/UICIRC-662

## Screenshot
### Before 
![image](https://user-images.githubusercontent.com/24813219/122566783-99ba0c00-d050-11eb-95d3-0f2b455e3dfc.png)

### After
![image](https://user-images.githubusercontent.com/24813219/122566983-d5ed6c80-d050-11eb-94b3-474669fd2f23.png)
