### PR TITLE
UICIRC-576: update `codemirror` and `react-codemirror2`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.0.0] (IN PROGRESS)
 
 * Fix a typo in the word Year(s) in the Period interval. Refs UICIRC-662.
+* Update `codemirror` and `react-codemirror2`. Refs UICIRC-576.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
   },
   "dependencies": {
     "@folio/stripes-template-editor": "^1.0.0",
+    "codemirror": "^5.61.1",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "final-form-set-field-data": "^1.0.2",
@@ -301,7 +302,7 @@
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.33",
     "prop-types": "^15.5.10",
-    "react-codemirror2": "^1.0.0",
+    "react-codemirror2": "^7.2.1",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0"
   },

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Codemirror from 'codemirror'; // eslint-disable-line import/no-extraneous-dependencies
-import CodeMirror from 'react-codemirror2';
+import { Controlled as CodeMirror } from 'react-codemirror2';
 import { injectIntl } from 'react-intl';
 import {
   noop,
@@ -366,6 +366,11 @@ class RulesEditor extends React.Component {
         value={this.state.code}
         onFocus={() => this.handleFocus(true)}
         onBlur={() => this.handleFocus(false)}
+        onBeforeChange={(editor, data, value) => {
+          this.setState({
+            code: value,
+          });
+        }}
         onChange={(editor, metadata, value) => this.props.onChange(value)}
       />
     );


### PR DESCRIPTION
## Purpose
Update `codemirror` and `react-codemirror2`.

## Approach
We can update `react-codemirror2` from `1.0.0` to `7.2.1` and `codemirror` from version `5.29.0` (https://github.com/scniro/react-codemirror2/blob/1.0.0/package.json#L35) to `5.61.1`. We have breaking changes in `react-codemirror2` version `3.0.0`. In `react-codemirror2` version `3.0.0` was added `Controlled` and `UnControlled` components instead of `CodeMirror` component (https://github.com/scniro/react-codemirror2/tree/3.0.0). We can easy fix current problem migrate to `Controlled` component and adding `onBeforeChange` (https://github.com/scniro/react-codemirror2#controlled-usage).

## Stories
https://issues.folio.org/browse/UICIRC-576