### PR TITLE
UICIRC-575: Update folio/stripes-template-editor to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix a typo in the word Year(s) in the Period interval. Refs UICIRC-662.
 * Update `codemirror` and `react-codemirror2`. Refs UICIRC-576.
+. Update `folio/stripes-template-editor` to `3.0.0`. Refs UICIRC-575
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/stripes-template-editor": "^1.0.0",
+    "@folio/stripes-template-editor": "^3.0.0",
     "codemirror": "^5.61.1",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
## Purpose
Update folio/stripes-template-editor to 3.0.0

## Stories
https://issues.folio.org/browse/UICIRC-575

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/24813219/124449737-6a173d80-dd8c-11eb-82f3-d47bac0e1af6.png)
### After
![image](https://user-images.githubusercontent.com/24813219/124449822-7f8c6780-dd8c-11eb-928e-adcc62428329.png)
