### PR TITLE
UICIRC-631: add RTL/Jest tests for FeeFineNoticesSection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add RTL/Jest testing for `OverdueAboutSection` component. Refs UICIRC-595. 
 * Add RTL/Jest testing for `normalize` function in `FinePolicy/utils`. Refs UICIRC-599.
 * Add RTL/Jest testing for `normalize` function in `LostItemFeePolicy/utils`. Refs UICIRC-628.
+* Add RTL/Jest testing for `FeeFineNoticesSection` component. Refs UICIRC-631.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.js
+++ b/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.js
@@ -34,6 +34,7 @@ class FeeFineNoticesSection extends React.Component {
 
     return (
       <Accordion
+        data-testid="accordionTestId"
         id="viewFeeFineNotices"
         open={isOpen}
         label={<FormattedMessage id="ui-circulation.settings.noticePolicy.feeFineNotices" />}

--- a/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import FeeFineNoticesSection from './FeeFineNoticesSection';
+import NoticeCard from '../components';
+import {
+  feeFineNoticesTriggeringEvents,
+  timeBasedFeeFineEventsIds,
+  uponAndAfterSendEvents,
+} from '../../../../../constants';
+
+jest.mock('../components', () => (
+  jest.fn(() => null)
+));
+
+const labelId = 'ui-circulation.settings.noticePolicy.feeFineNotices';
+const isOpen = true;
+
+const mockedFeeFineNotice = {
+  format: 'Email',
+  frequency: 'Recurring',
+  realTime: true,
+  sendOptions: {
+    sendHow: 'After',
+    sendWhen: 'Overdue fine returned',
+    sendBy: {
+      duration: 1,
+      intervalId: 'Weeks',
+    },
+    sendEvery: {
+      duration: 2,
+      intervalId: 'Months',
+    },
+  },
+  templateId: 'aff275cf-e292-42f9-bc4f-e381fa6a391c',
+};
+
+const mockedPolicy = {
+  feeFineNotices: [
+    mockedFeeFineNotice,
+    {
+      ...mockedFeeFineNotice,
+      realTime: false,
+      templateId: 'aff275cf-bc4f-e292-42f9-e381fa6a391c',
+    },
+  ],
+};
+
+const mockedTemplates = [
+  {
+    label: 'first test template',
+    value: 'templateId-1',
+  },
+  {
+    label: 'second test template',
+    value: 'templateId-2',
+  }
+];
+
+const expectedProps = {
+  triggeringEvents: feeFineNoticesTriggeringEvents,
+  sendEventTriggeringIds: Object.values(timeBasedFeeFineEventsIds),
+  sendEvents: uponAndAfterSendEvents,
+  templates: mockedTemplates,
+};
+
+const eachRowTesting = (notice, index) => {
+  const number = index + 1;
+  const expectedPropsForEachRow = {
+    ...expectedProps,
+    notice,
+    index,
+  };
+
+  it(`should accept correct props at the ${number} call`, () => {
+    expect(NoticeCard).toHaveBeenNthCalledWith(number, expectedPropsForEachRow, {});
+  });
+};
+
+describe('FeeFineNoticesSection', () => {
+  beforeEach(() => {
+    render(
+      <FeeFineNoticesSection
+        isOpen={isOpen}
+        policy={mockedPolicy}
+        templates={mockedTemplates}
+      />
+    );
+  });
+
+  it('should render component', () => {
+    expect(screen.getByTestId('accordionTestId')).toBeTruthy();
+  });
+
+  it('should render label', () => {
+    expect(screen.getByText(labelId)).toBeTruthy();
+  });
+
+  it('should have `open` attribute', () => {
+    expect(screen.getByTestId('accordionTestId')).toHaveAttribute('open');
+  });
+
+  describe('inner NoticeCard component', () => {
+    mockedPolicy.feeFineNotices.map(eachRowTesting);
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,6 +1,12 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
+  Accordion: jest.fn(({ children, label, ...rest }) => (
+    <section {...rest}>
+      <div>{label}</div>
+      {children}
+    </section>
+  )),
   Badge: jest.fn((props) => (
     <span>
       <span>{props.children}</span>


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for FeeFineNoticesSection component

## Approach
Test for correct props accept was extracted in separate function for more comfortable check for each part of incoming data

## Refs
https://issues.folio.org/browse/UICIRC-631

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/129339342-67df1a78-ed1a-4d74-8f19-1dd1b745c5da.png)