### PR TITLE
UICIRC-642: Add RTL/Jest tests for `utils` in `NoticePolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add RTL/Jest testing for `OverdueAboutSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-598.
 * Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`. Refs UICIRC-625.
 * Add RTL/Jest testing for `AboutSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-616.
+* Add RTL/Jest testing for all functions in `NoticePolicy/utils`. Refs UICIRC-642.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/utils/get-templates.test.js
+++ b/src/settings/NoticePolicy/utils/get-templates.test.js
@@ -1,0 +1,59 @@
+import getTemplates from './get-templates';
+
+describe('NoticePolicy utils', () => {
+  describe('getTemplates', () => {
+    const templateWithInvalidCategory = {
+      id: 'thirdTestId',
+      name: 'thirdTestName',
+      category: 'unallowedCategory',
+      active: true,
+    };
+    const inactiveTemplate = {
+      id: 'secondTestId',
+      name: 'secondTestName',
+      category: 'testCategory',
+      active: false,
+    };
+    const validTemplate = {
+      id: 'firstTestId',
+      name: 'firstTestName',
+      category: 'testCategory',
+      active: true,
+    };
+    const mockedCategories = ['testCategory'];
+    const transformedTemplate = {
+      value: 'firstTestId',
+      label: 'firstTestName',
+    };
+
+    it('should remove template with invalid category', () => {
+      expect(getTemplates([templateWithInvalidCategory], mockedCategories)).toEqual([]);
+    });
+
+    it('should remove inactive template', () => {
+      expect(getTemplates([inactiveTemplate], mockedCategories)).toEqual([]);
+    });
+
+    it('should transform valid template correctly', () => {
+      expect(getTemplates([validTemplate], mockedCategories)).toEqual([transformedTemplate]);
+    });
+
+    it('should return empty array if templates was not passed', () => {
+      expect(getTemplates(undefined, mockedCategories)).toEqual([]);
+    });
+
+    it('should return empty array if "allowedCategories" is not passed', () => {
+      expect(getTemplates(validTemplate)).toEqual([]);
+    });
+
+    it('should process data correctly', () => {
+      const dataForTest = [
+        templateWithInvalidCategory,
+        inactiveTemplate,
+        validTemplate,
+      ];
+
+      expect(getTemplates(dataForTest, mockedCategories)).toEqual([transformedTemplate]);
+    });
+  });
+});

--- a/src/settings/NoticePolicy/utils/normalize.js
+++ b/src/settings/NoticePolicy/utils/normalize.js
@@ -16,7 +16,7 @@ import {
   userInitiatedTimeBasedFeeFineEventsIds,
 } from '../../../constants';
 
-const setRealTimeFlag = (sectionKey, policy) => {
+export const setRealTimeFlag = (sectionKey, policy) => {
   const noticePolicy = cloneDeep(policy);
   const isTrueSet = value => value === 'true';
   const sendInRealTime = [
@@ -50,7 +50,7 @@ export const setSendHowValue = (sectionKey, policy) => {
   return noticePolicy;
 };
 
-const checkNoticeHiddenFields = (sectionKey, allowedIds, policy) => {
+export const checkNoticeHiddenFields = (sectionKey, allowedIds, policy) => {
   const noticePolicy = cloneDeep(policy);
 
   forEach(noticePolicy[sectionKey], (item, index) => {

--- a/src/settings/NoticePolicy/utils/normalize.test.js
+++ b/src/settings/NoticePolicy/utils/normalize.test.js
@@ -1,0 +1,332 @@
+import normalize, {
+  setRealTimeFlag,
+  setSendHowValue,
+  checkNoticeHiddenFields,
+} from './normalize';
+import { Notice } from '../../Models/NoticePolicy';
+import NoticeSendOptions from '../../Models/NoticePolicy/NoticeSendOptions';
+import { userInitiatedTimeBasedFeeFineEventsIds } from '../../../constants';
+
+describe('NoticePolicy utils', () => {
+  const defaultSendOptions = {
+    sendEvery: 'testData',
+    sendBy: 'testData',
+    sendHow: 'testData',
+  };
+
+  describe('setRealTimeFlag', () => {
+    it('should change "realTime" flag from "true" to true', () => {
+      const mockedData = {
+        testSection: [
+          {
+            realTime: 'true',
+          },
+        ],
+      };
+      const expectedResult = {
+        testSection: [
+          {
+            realTime: true,
+          },
+        ],
+      };
+
+      expect(setRealTimeFlag('testSection', mockedData)).toEqual(expectedResult);
+    });
+
+    it('should change "realTime" flag to false if any value exclude "true" is passed', () => {
+      const mockedData = {
+        testSection: [
+          {
+            realTime: 'not true',
+          },
+        ],
+      };
+      const expectedResult = {
+        testSection: [
+          {
+            realTime: false,
+          },
+        ],
+      };
+
+      expect(setRealTimeFlag('testSection', mockedData)).toEqual(expectedResult);
+    });
+
+    it('should set "realTime" to true if type of event is included in sendInRealTime list', () => {
+      const sendOptions = {
+        sendWhen: 'Hold expiration',
+      };
+      const mockedData = {
+        testSection: [
+          {
+            sendOptions,
+          },
+        ],
+      };
+      const expectedResult = {
+        testSection: [
+          {
+            sendOptions,
+            realTime: true,
+          },
+        ],
+      };
+
+      expect(setRealTimeFlag('testSection', mockedData)).toEqual(expectedResult);
+    });
+
+    it('should set "realTime" flag to false if type of event is not in sendInRealTime list', () => {
+      const sendOptions = {
+        sendWhen: 'not included type',
+      };
+      const mockedData = {
+        'testSection': [
+          {
+            sendOptions,
+          },
+        ],
+      };
+      const expectedResult = {
+        'testSection': [
+          {
+            sendOptions,
+            realTime: false,
+          },
+        ],
+      };
+
+      expect(setRealTimeFlag('testSection', mockedData)).toEqual(expectedResult);
+    });
+  });
+
+  describe('setSendHowValue', () => {
+    it('should set "sendHow" key', () => {
+      const mockedData = {
+        testSection: [
+          {
+            sendOptions: {
+              sendWhen: userInitiatedTimeBasedFeeFineEventsIds.ATL_FINE_ITEM_RETURNED,
+            },
+          },
+        ],
+      };
+      const expectedResult = {
+        testSection: [
+          {
+            sendOptions: {
+              sendWhen: userInitiatedTimeBasedFeeFineEventsIds.ATL_FINE_ITEM_RETURNED,
+              sendHow: 'Upon At',
+            },
+          },
+        ],
+      };
+
+      expect(setSendHowValue('testSection', mockedData)).toEqual(expectedResult);
+    });
+
+    it('should not set "sendHow" key', () => {
+      const mockedData = {
+        testSection: [
+          {
+            sendOptions: {
+              sendWhen: 'not included type',
+            },
+          },
+        ],
+      };
+
+      expect(setSendHowValue('testSection', mockedData)).toEqual(mockedData);
+    });
+  });
+
+  describe('checkNoticeHiddenFields', () => {
+    beforeEach(() => {
+      jest.spyOn(NoticeSendOptions.prototype, 'isSendOptionsAvailable').mockImplementation(() => true);
+      jest.spyOn(NoticeSendOptions.prototype, 'isBeforeOrAfter').mockImplementation(() => true);
+      jest.spyOn(NoticeSendOptions.prototype, 'isLoanDueDateTimeSelected').mockImplementation(() => true);
+      jest.spyOn(Notice.prototype, 'isRecurring').mockImplementation(() => true);
+    });
+
+    afterAll(() => {
+      jest.spyOn(NoticeSendOptions.prototype, 'isSendOptionsAvailable').mockRestore();
+      jest.spyOn(NoticeSendOptions.prototype, 'isBeforeOrAfter').mockRestore();
+      jest.spyOn(NoticeSendOptions.prototype, 'isLoanDueDateTimeSelected').mockRestore();
+      jest.spyOn(Notice.prototype, 'isRecurring').mockRestore();
+    });
+
+    const mockedData = {
+      testSection: [
+        {
+          sendOptions: defaultSendOptions,
+          frequency: 'testData',
+        },
+      ],
+    };
+
+    it('should remove "frequency" and clear "sendOptions" fields if "isSendOptionsAvailable" return false', () => {
+      const expectedResult = {
+        testSection: [
+          {
+            sendOptions: {},
+          },
+        ],
+      };
+
+      jest.spyOn(NoticeSendOptions.prototype, 'isSendOptionsAvailable').mockImplementation(() => false);
+
+      expect(checkNoticeHiddenFields('testSection', [], mockedData)).toEqual(expectedResult);
+    });
+
+    it('should remove "sendBy", "sendEvery" and "frequency" fields if "isBeforeOrAfter" return false', () => {
+      const expectedResult = {
+        testSection: [
+          {
+            sendOptions: {
+              sendHow: 'testData',
+            },
+          },
+        ],
+      };
+
+      jest.spyOn(NoticeSendOptions.prototype, 'isBeforeOrAfter').mockImplementation(() => false);
+
+      expect(checkNoticeHiddenFields('testSection', [], mockedData)).toEqual(expectedResult);
+    });
+
+    it('should remove "realTime" field if "isLoanDueDateTimeSelected" return false', () => {
+      const dataForTest = {
+        testSection: [
+          {
+            ...mockedData.testSection[0],
+            realTime: 'testData',
+          },
+        ],
+      };
+
+      jest.spyOn(NoticeSendOptions.prototype, 'isLoanDueDateTimeSelected').mockImplementation(() => false);
+
+      expect(checkNoticeHiddenFields('testSection', [], dataForTest)).toEqual(mockedData);
+    });
+
+    it('should remove "sendEvery" field if "isRecurring" return false', () => {
+      const expectedResult = {
+        'testSection': [
+          {
+            sendOptions: {
+              sendBy: 'testData',
+              sendHow: 'testData',
+            },
+            frequency: 'testData',
+          }
+        ],
+      };
+
+      jest.spyOn(Notice.prototype, 'isRecurring').mockImplementation(() => false);
+
+      expect(checkNoticeHiddenFields('testSection', [], mockedData)).toEqual(expectedResult);
+    });
+
+    it('should not remove any fields', () => {
+      expect(checkNoticeHiddenFields('testSection', [], mockedData)).toEqual(mockedData);
+    });
+  });
+
+  describe('normalize', () => {
+    const mockedData = {
+      loanNotices: [
+        {
+          sendOptions: defaultSendOptions,
+          realTime: 'true',
+          frequency: 'testData',
+        },
+        {
+          sendOptions: defaultSendOptions,
+          realTime: 'false',
+          frequency: 'testData',
+        },
+      ],
+      requestNotices: [
+        {
+          sendOptions: {
+            ...defaultSendOptions,
+            sendWhen: 'Hold expiration',
+          },
+          frequency: 'testData',
+        },
+        {
+          sendOptions: {
+            ...defaultSendOptions,
+            sendWhen: 'Hold expiration',
+          },
+          frequency: 'testData',
+        },
+      ],
+      feeFineNotices: [
+        {
+          sendOptions: {
+            ...defaultSendOptions,
+            sendWhen: userInitiatedTimeBasedFeeFineEventsIds.ATL_FINE_ITEM_RETURNED,
+          },
+          realTime: true,
+          frequency: 'testData',
+        },
+        {
+          sendOptions: {
+            ...defaultSendOptions,
+            sendWhen: 'not included type',
+          },
+          realTime: false,
+          frequency: 'testData',
+        },
+      ],
+    };
+    const expectedResult = {
+      feeFineNotices: [
+        {
+          realTime: true,
+          sendOptions: {
+            sendHow: 'Upon At',
+            sendWhen: userInitiatedTimeBasedFeeFineEventsIds.ATL_FINE_ITEM_RETURNED,
+          },
+        },
+        {
+          realTime: false,
+          sendOptions: {
+            sendWhen: 'not included type',
+          },
+        },
+      ],
+      loanNotices: [
+        {
+          realTime: false,
+          sendOptions: {},
+        },
+        {
+          realTime: false,
+          sendOptions: {},
+        },
+      ],
+      requestNotices: [
+        {
+          realTime: true,
+          sendOptions: {
+            sendHow: 'testData',
+            sendWhen: 'Hold expiration',
+          },
+        },
+        {
+          realTime: true,
+          sendOptions: {
+            sendHow: 'testData',
+            sendWhen: 'Hold expiration',
+          },
+        },
+      ],
+    };
+
+    it('should process all fields correctly', () => {
+      expect(normalize(mockedData)).toEqual(expectedResult);
+    });
+  });
+});

--- a/src/settings/NoticePolicy/utils/notice-description.test.js
+++ b/src/settings/NoticePolicy/utils/notice-description.test.js
@@ -1,0 +1,57 @@
+import noticeDescription from './notice-description';
+import {
+  timeBasedFeeFineEventsIds,
+  userInitiatedTimeBasedFeeFineEventsIds,
+  loanUserInitiatedEventsIds,
+  loanTimeBasedEventsIds,
+  requestItemStateChangeEventsIds,
+  requestUserInitiatedEventsIds,
+  requestTimeBasedEventsIds,
+} from '../../../constants';
+
+const mockedData = {
+  'postponedEvents': [
+    loanUserInitiatedEventsIds.CHECK_IN,
+    loanUserInitiatedEventsIds.CHECK_OUT,
+  ],
+  'realTimeEvents': [
+    loanUserInitiatedEventsIds.RENEWED,
+    loanUserInitiatedEventsIds.MANUAL_DUE_DATE_CHANGE,
+    loanUserInitiatedEventsIds.ITEM_RECALLED,
+    requestItemStateChangeEventsIds.AVAILABLE,
+    ...Object.values(requestUserInitiatedEventsIds),
+    ...Object.values(requestTimeBasedEventsIds),
+    timeBasedFeeFineEventsIds.RENEWED,
+    timeBasedFeeFineEventsIds.RETURNED,
+    userInitiatedTimeBasedFeeFineEventsIds.ATL_FINE_ITEM_RETURNED,
+  ],
+  'conditionalEvents': [
+    timeBasedFeeFineEventsIds.ATL_FINE_CHARGED,
+    loanTimeBasedEventsIds.AGED_TO_LOST,
+  ]
+};
+const eachArrOfKeysTesting = (arrName) => {
+  it(`should return right message key when process ${arrName} events`, () => {
+    const expectedMessageKey = `ui-circulation.settings.noticePolicy.notices.${arrName}.notification`;
+
+    mockedData[`${arrName}Events`].forEach(item => {
+      expect(noticeDescription(item)).toBe(expectedMessageKey);
+    });
+  });
+};
+
+describe('NoticePolicy utils', () => {
+  describe('noticeDescription', () => {
+    const listOfEventTypes = [
+      'postponed',
+      'realTime',
+      'conditional',
+    ];
+
+    listOfEventTypes.forEach(item => eachArrOfKeysTesting(item));
+
+    it('should return null if eventId is invalid', () => {
+      expect(noticeDescription('invalidId')).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `utils` in `NoticePolicy`

## Approach
In `noticeDescription` tests main function for testing was extracted for posibility run tests for each type of events

## Refs
https://issues.folio.org/browse/UICIRC-642

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130023771-975d572a-2e4a-412a-9151-b84e853e2169.png)