### PR TITLE
UICIRC-598: Add RTL/Jest tests for `OverdueAboutSection` in `FinePolicy/components/ViewSections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
 * Update `folio/stripes-template-editor` to `3.0.0`. Refs UICIRC-575
 * Fix bug causing incorrect validation in lost item fee policies. Fixes UICIRC-667, UICIRC-668.
 * Add RTL/Jest testing for `ScedulesList` component. Refs UICIRC-601.
-* Add RTL/Jest testing for `OverdueAboutSection` component. Refs UICIRC-595. 
+* Add RTL/Jest testing for `OverdueAboutSection` component in `FinePolicy/components/EditSections`. Refs UICIRC-595.
 * Add RTL/Jest testing for `normalize` function in `FinePolicy/utils`. Refs UICIRC-599.
 * Add RTL/Jest testing for `normalize` function in `LostItemFeePolicy/utils`. Refs UICIRC-628.
 * Add RTL/Jest testing for `FeeFineNoticesSection` component. Refs UICIRC-631.
 * Add RTL/Jest testing for `normalize` function in `LoanHistory/utils`. Refs UICIRC-607.
 * Add RTL/Jest testing for `normalize` function in `LoanPolicy/utils`. Refs UICIRC-620.
+* Add RTL/Jest testing for `OverdueAboutSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-598.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.js
+++ b/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.js
@@ -12,10 +12,16 @@ const OverdueAboutSection = (props) => {
   const { getValue } = props;
 
   return (
-    <div data-test-fine-policy-detail-about-section>
+    <div
+      data-test-fine-policy-detail-about-section
+      data-testid="overdueAboutSectionTestId"
+    >
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-name>
+          <div
+            data-test-about-section-policy-name
+            data-testid="nameTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.finePolicy.overdueFinePolicyName" />}
               value={getValue('name')}
@@ -25,7 +31,10 @@ const OverdueAboutSection = (props) => {
       </Row>
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-description>
+          <div
+            data-test-about-section-policy-description
+            data-testid="descriptionTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.finePolicy.description" />}
               value={getValue('description') || '-'}

--- a/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.test.js
+++ b/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import OverdueAboutSection from './OverdueAboutSection';
+
+const labelIdForNameField = 'ui-circulation.settings.finePolicy.overdueFinePolicyName';
+const labelIdForDescriptionField = 'ui-circulation.settings.finePolicy.description';
+
+describe('OverdueAboutSection', () => {
+  beforeEach(() => {
+    render(
+      <OverdueAboutSection
+        getValue={jest.fn((value) => value)}
+      />,
+    );
+  });
+
+  const getItemByTestId = (id) => within(screen.getByTestId(id));
+
+  it('should render component', () => {
+    expect(screen.getByTestId('overdueAboutSectionTestId')).toBeTruthy();
+  });
+
+  it('should render label of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+  });
+
+  it('should render value of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+  });
+
+  it('should render label of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+  });
+
+  it('should render value of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+  });
+
+  it('should render dash if description has not found', () => {
+    render(
+      <OverdueAboutSection
+        getValue={jest.fn(() => false)}
+      />,
+    );
+
+    expect(screen.getByText('-')).toBeVisible();
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -31,6 +31,20 @@ jest.mock('@folio/stripes/components', () => ({
       <span {...rest} />
     </button>
   )),
+  KeyValue: jest.fn(({
+    label,
+    children,
+    value,
+  }) => (
+    <div>
+      <div>
+        {label}
+      </div>
+      <div>
+        {children || value}
+      </div>
+    </div>
+  )),
   PaneFooter: jest.fn(({ ref, children, ...rest }) => (
     <div ref={ref} {...rest}>{children}</div>
   )),


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `OverdueAboutSection` in `FinePolicy/components/ViewSections`

## Refs
https://issues.folio.org/browse/UICIRC-598

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130021688-b1e61c41-30cb-4e25-bcbf-3b4c4532f961.png)