### PR TITLE
UICIRC-625: Add RTL/Jest tests for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add RTL/Jest testing for `normalize` function in `LoanHistory/utils`. Refs UICIRC-607.
 * Add RTL/Jest testing for `normalize` function in `LoanPolicy/utils`. Refs UICIRC-620.
 * Add RTL/Jest testing for `OverdueAboutSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-598.
+* Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`. Refs UICIRC-625.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
+++ b/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
@@ -12,10 +12,16 @@ const LostItemFeeAboutSection = (props) => {
   const { getValue } = props;
 
   return (
-    <div data-test-loan-policy-detail-about-section>
+    <div
+      data-test-loan-policy-detail-about-section
+      data-testid="lostItemFeeAboutSectionTestId"
+    >
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-name>
+          <div
+            data-test-about-section-policy-name
+            data-testid="nameTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.lostItemFee.lostItemFeePolicyName" />}
               value={getValue('name')}
@@ -25,7 +31,10 @@ const LostItemFeeAboutSection = (props) => {
       </Row>
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-description>
+          <div
+            data-test-about-section-policy-description
+            data-testid="descriptionTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.lostItemFee.description" />}
               value={getValue('description') || '-'}

--- a/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
+++ b/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import LostItemFeeAboutSection from './LostItemFeeAboutSection';
+
+const labelIdForNameField = 'ui-circulation.settings.lostItemFee.lostItemFeePolicyName';
+const labelIdForDescriptionField = 'ui-circulation.settings.lostItemFee.description';
+
+describe('LostItemFeeAboutSection', () => {
+  beforeEach(() => {
+    render(
+      <LostItemFeeAboutSection
+        getValue={jest.fn((value) => value)}
+      />,
+    );
+  });
+
+  const getItemByTestId = (id) => within(screen.getByTestId(id));
+
+  it('should render component', () => {
+    expect(getItemByTestId('lostItemFeeAboutSectionTestId')).toBeTruthy();
+  });
+
+  it('should render label of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+  });
+
+  it('should render value of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+  });
+
+  it('should render label of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+  });
+
+  it('should render value of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+  });
+
+  it('should render dash if description has not found', () => {
+    render(
+      <LostItemFeeAboutSection
+        getValue={jest.fn(() => false)}
+      />,
+    );
+
+    expect(screen.getByText('-')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`

## Refs
https://issues.folio.org/browse/UICIRC-625

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130031041-03a06cc3-1a5a-4709-bb05-5e013abffbdc.png)