### PR TITLE
UICIRC-616: Add RTL/Jest tests for `AboutSection` in `LoanPolicy/components/ViewSections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add RTL/Jest testing for `normalize` function in `LoanPolicy/utils`. Refs UICIRC-620.
 * Add RTL/Jest testing for `OverdueAboutSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-598.
 * Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`. Refs UICIRC-625.
+* Add RTL/Jest testing for `AboutSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-616.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.js
+++ b/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.js
@@ -14,7 +14,10 @@ const AboutSection = (props) => {
   const { getValue } = props;
 
   return (
-    <div data-test-loan-policy-detail-about-section>
+    <div
+      data-test-loan-policy-detail-about-section
+      data-testid="aboutSectionTestId"
+    >
       <Row>
         <Col xs={12}>
           <h2
@@ -27,7 +30,10 @@ const AboutSection = (props) => {
       </Row>
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-name>
+          <div
+            data-test-about-section-policy-name
+            data-testid="nameTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyName" />}
               value={getValue('name')}
@@ -37,7 +43,10 @@ const AboutSection = (props) => {
       </Row>
       <Row>
         <Col xs={12}>
-          <div data-test-about-section-policy-description>
+          <div
+            data-test-about-section-policy-description
+            data-testid="descriptionTestId"
+          >
             <KeyValue
               label={<FormattedMessage id="ui-circulation.settings.loanPolicy.policyDescription" />}
               value={getValue('description')}

--- a/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.test.js
+++ b/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import AboutSection from './AboutSection';
+
+const labelIdForHeader = 'ui-circulation.settings.loanPolicy.about';
+const labelIdForNameField = 'ui-circulation.settings.loanPolicy.policyName';
+const labelIdForDescriptionField = 'ui-circulation.settings.loanPolicy.policyDescription';
+
+describe('AboutSection', () => {
+  beforeEach(() => {
+    render(
+      <AboutSection
+        getValue={jest.fn((value) => value)}
+      />,
+    );
+  });
+
+  const getItemByTestId = (id) => within(screen.getByTestId(id));
+
+  it('should render component', () => {
+    expect(getItemByTestId('aboutSectionTestId')).toBeTruthy();
+  });
+
+  it('should render component header', () => {
+    expect(getItemByTestId('aboutSectionTestId').getByText(labelIdForHeader)).toBeVisible();
+  });
+
+  it('should render label of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+  });
+
+  it('should render value of "name" field', () => {
+    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+  });
+
+  it('should render label of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+  });
+
+  it('should render value of "description" field', () => {
+    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `AboutSection` in `LoanPolicy/components/ViewSections`

## Refs
https://issues.folio.org/browse/UICIRC-616

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130028002-82277c9e-01e4-4b68-9cc5-17af980a8c53.png)