### PR TITLE
UICIRC-656: Add RTL/Jest testing for functions in `settings/utils`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-633.
 * Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-639.
 * Add RTL/Jest testing for `convertNamesToIdsInLine` function in `settings/utils/rules-string-convertors.js`. Refs UICIRC-686.
+* Add RTL/Jest testing for functions in `settings/utils`. Refs UICIRC-656.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ buildNPM {
   runLint = 'yes'
   runSonarqube = true
   runTest = 'yes'
-  runTestOptions = '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
+  runTestOptions = ''
 }

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "start": "stripes serve",
     "lint": "eslint .",
     "test": "yarn run test:jest && yarn run test:bigtest",
-    "test:bigtest": "stripes test karma",
+    "test:bigtest": "stripes test karma --no-fail-on-failing-test-suite",
     "test:jest": "jest --ci --coverage --colors"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -252,8 +252,8 @@
   "scripts": {
     "start": "stripes serve",
     "lint": "eslint .",
-    "test": "yarn run test:jest && yarn run test:bigtest",
-    "test:bigtest": "stripes test karma --no-fail-on-failing-test-suite",
+    "test": "yarn run test:jest",
+    "test:bigtest": "stripes test karma",
     "test:jest": "jest --ci --coverage --colors"
   },
   "devDependencies": {

--- a/src/settings/LoanPolicy/utils/normalize.test.js
+++ b/src/settings/LoanPolicy/utils/normalize.test.js
@@ -72,7 +72,7 @@ describe('LoanPolicy/utils functions', () => {
               duration: 'true',
               intervalId: null,
             },
-          }
+          },
         },
         testData,
       };
@@ -95,7 +95,7 @@ describe('LoanPolicy/utils functions', () => {
       loansPolicy: {
         period: periodTestData,
         profileId: loanProfileMap.FIXED,
-      }
+      },
     };
 
     it('should remove period', () => {
@@ -103,7 +103,7 @@ describe('LoanPolicy/utils functions', () => {
         ...mockedData,
         loansPolicy: {
           profileId: loanProfileMap.FIXED,
-        }
+        },
       };
 
       expect(checkFixedProfile(mockedData)).toEqual(expectedResult);
@@ -114,7 +114,7 @@ describe('LoanPolicy/utils functions', () => {
         loansPolicy: {
           ...mockedData.loansPolicy,
           profileId: 'not fixed',
-        }
+        },
       };
 
       expect(checkFixedProfile(dataForTest)).toEqual(dataForTest);
@@ -157,14 +157,14 @@ describe('LoanPolicy/utils functions', () => {
         differentPeriod: false,
         alternateFixedDueDateScheduleId: 'testData',
         period: 'testData',
-      }
+      },
     };
 
     it('should remove fields associated with period', () => {
       const expectedResult = {
         renewalsPolicy: {
           differentPeriod: false,
-        }
+        },
       };
 
       expect(checkDifferentRenewalPeriod(mockedData)).toEqual(expectedResult);
@@ -175,7 +175,7 @@ describe('LoanPolicy/utils functions', () => {
         renewalsPolicy: {
           ...mockedData.renewalsPolicy,
           differentPeriod: true,
-        }
+        },
       };
 
       expect(checkDifferentRenewalPeriod(dataForTest)).toEqual(dataForTest);
@@ -264,13 +264,13 @@ describe('LoanPolicy/utils functions', () => {
             testData,
           },
           testData,
-        }
+        },
       };
       const mockedData = {
         requestManagement: {
           ...expectedResult.requestManagement,
           holds: {},
-        }
+        },
       };
 
       expect(checkRequestManagementSection(mockedData)).toEqual(expectedResult);
@@ -283,13 +283,13 @@ describe('LoanPolicy/utils functions', () => {
             testData,
           },
           testData,
-        }
+        },
       };
       const mockedData = {
         requestManagement: {
           ...expectedResult.requestManagement,
           recalls: {},
-        }
+        },
       };
 
       expect(checkRequestManagementSection(mockedData)).toEqual(expectedResult);
@@ -300,7 +300,7 @@ describe('LoanPolicy/utils functions', () => {
         requestManagement: {
           recalls: {},
           holds: {},
-        }
+        },
       };
 
       expect(checkRequestManagementSection(mockedData)).toEqual({});
@@ -374,7 +374,7 @@ describe('LoanPolicy/utils functions', () => {
         ...mockedData,
         loansPolicy: {
           profileId: loanProfileMap.FIXED,
-        }
+        },
       };
       const expectedResult = {
         ...dataForTest,
@@ -470,7 +470,7 @@ describe('LoanPolicy/utils functions', () => {
             duration: 'true',
             intervalId: null,
           },
-        }
+        },
       },
       testData,
     };
@@ -478,7 +478,7 @@ describe('LoanPolicy/utils functions', () => {
       ...reusableCommonData,
       loansPolicy,
       requestManagement,
-      testData
+      testData,
     };
 
     it('should process all fields correctly', () => {

--- a/src/settings/utils/location-code-formatters.test.js
+++ b/src/settings/utils/location-code-formatters.test.js
@@ -1,0 +1,126 @@
+import {
+  formatCampusCode,
+  formatCampusDisplayCode,
+  formatLibraryCode,
+  formatLibraryDisplayCode,
+  formatLocationCode,
+  formatLocationDisplayCode,
+} from './location-code-formatters';
+import * as replacer from './with-dash-replacer';
+
+const replacerSpy = jest.spyOn(replacer, 'default');
+
+describe('settings utils', () => {
+  const mockedLibrarysData = {
+    records: [
+      {
+        id: ' testLibraryId ',
+        campusId: ' campusTestId ',
+        code: ' libraryTestCode ',
+      },
+      {
+        id: ' something ',
+        campusId: ' testId ',
+        code: ' libraryTestCode ',
+      },
+    ],
+  };
+  const mockedCampusesData = {
+    records: [
+      {
+        id: ' campusTestId ',
+        code: ' campus-test-code ',
+        institutionId: ' testInstitutionId ',
+      },
+      {
+        id: ' somethingElse ',
+        code: ' campusTestCode ',
+        institutionId: ' testId ',
+      },
+    ],
+  };
+  const mockedInstitutionsData = {
+    records: [
+      {
+        id: ' testInstitutionId ',
+        code: ' institutionTestCode ',
+      },
+      {
+        id: ' somethingElse ',
+        code: ' institutionTestCode ',
+      },
+    ],
+  };
+  const mockedLocationData = {
+    libraryId: ' testLibraryId ',
+    code: ' locationTestCode ',
+    name: 'LocationName',
+  };
+
+  afterEach(() => {
+    replacerSpy.mockClear();
+  });
+
+  describe('formatCampusCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'institutionTestCode>campus-test-code';
+
+      expect(formatCampusCode(mockedCampusesData.records[0], mockedInstitutionsData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedInstitutionsData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(2, mockedCampusesData.records[0].code);
+    });
+  });
+
+  describe('formatCampusDisplayCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'campus-test-code (institutionTestCode)';
+
+      expect(formatCampusDisplayCode(mockedCampusesData.records[0], mockedInstitutionsData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedCampusesData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(2, mockedInstitutionsData.records[0].code);
+    });
+  });
+
+  describe('formatLibraryCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'institutionTestCode>campus-test-code>libraryTestCode';
+
+      expect(formatLibraryCode(mockedLibrarysData.records[0], mockedInstitutionsData, mockedCampusesData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedInstitutionsData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(2, mockedCampusesData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(3, mockedLibrarysData.records[0].code);
+    });
+  });
+
+  describe('formatLibraryDisplayCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'libraryTestCode (institutionTestCode-campus-test-code)';
+
+      expect(formatLibraryDisplayCode(mockedLibrarysData.records[0], mockedInstitutionsData, mockedCampusesData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedLibrarysData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(2, mockedInstitutionsData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(3, mockedCampusesData.records[0].code);
+    });
+  });
+
+  describe('formatLocationCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'institutionTestCode>campus-test-code>libraryTestCode>locationTestCode';
+
+      expect(formatLocationCode(mockedLocationData, mockedInstitutionsData, mockedCampusesData, mockedLibrarysData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedInstitutionsData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(2, mockedCampusesData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(3, mockedLibrarysData.records[0].code);
+      expect(replacerSpy).toHaveBeenNthCalledWith(4, mockedLocationData.code);
+    });
+  });
+
+  describe('formatLocationDisplayCode', () => {
+    it('should find, process and concat codes correctly', () => {
+      const expectedResult = 'locationTestCode (LocationName)';
+
+      expect(formatLocationDisplayCode(mockedLocationData)).toBe(expectedResult);
+      expect(replacerSpy).toHaveBeenNthCalledWith(1, mockedLocationData.code);
+    });
+  });
+});

--- a/src/settings/utils/options-generator.js
+++ b/src/settings/utils/options-generator.js
@@ -11,6 +11,7 @@ export default (formatMessage = noop, config = {}, placeholder = '') => {
   if (!isEmpty(placeholder)) {
     options.push(
       <option
+        data-testid="placeholderTestId"
         value=""
         key="x"
       >
@@ -19,9 +20,10 @@ export default (formatMessage = noop, config = {}, placeholder = '') => {
     );
   }
 
-  forEach(config, ({ value, label }) => {
+  forEach(config, ({ value, label }, index) => {
     options.push(
       <option
+        data-testid={`optionTestId-${index}`}
         value={value}
         key={value}
       >

--- a/src/settings/utils/options-generator.test.js
+++ b/src/settings/utils/options-generator.test.js
@@ -1,0 +1,72 @@
+import { noop } from 'lodash';
+
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import optionsGenerator from './options-generator';
+
+describe('settings utils', () => {
+  describe('optionsGenerator', () => {
+    const mockedFormatMessage = jest.fn(({ id }) => id);
+    const getById = (id) => within(screen.getByTestId(id));
+    const optionTest = (config) => {
+      config.forEach((item, index) => {
+        expect(screen.getByTestId(`optionTestId-${index}`)).toBeVisible();
+        expect(getById(`optionTestId-${index}`).getByText(item.label)).toBeVisible();
+      });
+    };
+    const mockedConfigData = [
+      {
+        value: 'first',
+        label: 'firstTestLabel',
+      },
+      {
+        value: 'second',
+        label: 'secondTestLabel',
+      },
+    ];
+    const mockedPlaceholder = 'Test PLaceholder';
+
+    afterEach(() => {
+      mockedFormatMessage.mockClear();
+    });
+
+    it('should return empty array if placeholder and config is not passed', () => {
+      const result = optionsGenerator(mockedFormatMessage);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return array only with placeholder if config is not passed', () => {
+      const result = optionsGenerator(mockedFormatMessage, {}, mockedPlaceholder);
+
+      render(result.map((item) => item));
+
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+      expect(screen.getByText('Test PLaceholder')).toBeVisible();
+      expect(mockedFormatMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return array with two options and no placeholder', () => {
+      const result = optionsGenerator(mockedFormatMessage, mockedConfigData, '');
+
+      render(result.map((item) => item));
+
+      expect(screen.queryByTestId('placeholderTestId')).not.toBeInTheDocument();
+      expect(screen.getAllByRole('option')).toHaveLength(2);
+      expect(mockedFormatMessage).toHaveBeenCalledTimes(2);
+      optionTest(mockedConfigData);
+    });
+
+    it('should not return anything as formated message if formatMessage function is not passed', () => {
+      const result = optionsGenerator(noop, mockedConfigData, mockedPlaceholder);
+
+      render(result.map((item) => item));
+
+      expect(screen.queryAllByText(/Test/)).toHaveLength(0);
+    });
+  });
+});

--- a/src/settings/utils/with-dash-replacer.test.js
+++ b/src/settings/utils/with-dash-replacer.test.js
@@ -1,0 +1,17 @@
+import replacer from './with-dash-replacer';
+
+describe('settings utils', () => {
+  describe('replacer', () => {
+    it('should remove any not a word character at start of the line', () => {
+      expect(replacer('  ^&;\ntest')).toBe('test');
+    });
+
+    it('should remove any not a word character at the end of the line', () => {
+      expect(replacer('test  ^&;\n')).toBe('test');
+    });
+
+    it('should replace any not a word characters in the middle of the string to "-"', () => {
+      expect(replacer('test  &&^^::\ntest')).toBe('test-test');
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `location-code-formatters`, `options-generator`, `with-dash-replacer` in `settings/utils`

## Refs
https://issues.folio.org/browse/UICIRC-656

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130214295-e7cc2043-6bbb-4dd2-8e2a-e6361b9d74d1.png)