### PR TITLE
UICIRC-671: Support `feesfines` interface version `17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/ViewSections`. Refs UICIRC-625.
 * Add RTL/Jest testing for `AboutSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-616.
 * Add RTL/Jest testing for all functions in `NoticePolicy/utils`. Refs UICIRC-642.
+* Support `feesfines` interface version `17.0`. Refs UICIRC-671.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "patron-notice-policy-storage": "0.11",
       "location-units": "2.0",
       "locations": "3.0",
-      "feesfines": "16.0"
+      "feesfines": "16.0 17.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Do not merge

## Purpose
Support `feesfines` interface version `17.0`

## Approach
We should merge all associated task with https://issues.folio.org/browse/MODFEE-98 in the same time. In scope of https://issues.folio.org/browse/MODFEE-98 was added the standard UUID regular expression pattern to all the id fields in the Fees/Fines module JSON schemas. All changes was tested in scope https://issues.folio.org/browse/MODFEE-197.

## Refs
https://issues.folio.org/browse/UICIRC-671

#### TODOS and Open Questions
@zburke @mkuklis  Could you please clarify do we need to add someone else for review this task?