### PR TITLE
UICIRC-682: Add RTL/Jest tests for "rules-string-convertors" in "settings/utils"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add RTL/Jest testing for `AboutSection` component in `LoanPolicy/components/EditSections`. Refs UICIRC-612.
 * Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/EditSections`. Refs UICIRC-622.
 * Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-634.
+* Add RTL/Jest testing for functions in `settings/utils/rules-string-convertors.js`. Refs UICIRC-682.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -241,7 +241,7 @@ export const loanUserInitiatedEventsIds = {
 
 export const loanTimeBasedEventsIds = {
   DUE_DATE: 'Due date',
-  AGED_TO_LOST: 'Aged to lost'
+  AGED_TO_LOST: 'Aged to lost',
 };
 
 export const loanNoticesTriggeringEvents = [
@@ -279,7 +279,7 @@ export const requestUserInitiatedEventsIds = {
   RECALL_REQUEST: 'Recall request',
   HOLD: 'Hold request',
   PAGE: 'Paging request',
-  CANCEL: 'Request cancellation'
+  CANCEL: 'Request cancellation',
 };
 
 export const requestTimeBasedEventsIds = {
@@ -326,7 +326,7 @@ export const staffSlipMap = {
   HOLD: 'Hold',
   TRANSIT: 'Transit',
   PICK_SLIP: 'Pick slip',
-  REQUEST_DELIVERY: 'Request delivery'
+  REQUEST_DELIVERY: 'Request delivery',
 };
 
 export const patronNoticeCategoryIds = {
@@ -414,7 +414,7 @@ export const POLICY = {
 
 export const EDITOR_KEYWORD = {
   FALLBACK_POLICY: 'fallback-policy',
-  PRIORITY: 'priority'
+  PRIORITY: 'priority',
 };
 
 export const EDITOR_SPECIAL_SYMBOL = {
@@ -425,6 +425,8 @@ export const EDITOR_SPECIAL_SYMBOL = {
   COLON: ':',
   NEGATION: '!',
 };
+
+export const WHITE_SPACE = ' ';
 
 export const LOCATION_RULES_TYPES = [
   RULES_TYPE.INSTITUTION,

--- a/src/settings/utils/rules-string-convertors.js
+++ b/src/settings/utils/rules-string-convertors.js
@@ -11,11 +11,11 @@ import {
   EDITOR_SPECIAL_SYMBOL,
 } from '../../constants';
 
-function isPriorityLine(lineContent) {
+export function isPriorityLine(lineContent) {
   return lineContent.includes(EDITOR_KEYWORD.PRIORITY);
 }
 
-function isCommentSymbol(symbol) {
+export function isCommentSymbol(symbol) {
   const {
     HASH,
     SLASH,
@@ -24,7 +24,7 @@ function isCommentSymbol(symbol) {
   return symbol === HASH || symbol === SLASH;
 }
 
-function isWordsSeparatingSymbol(symbol) {
+export function isWordsSeparatingSymbol(symbol) {
   const {
     PLUS,
     COLON,
@@ -33,7 +33,7 @@ function isWordsSeparatingSymbol(symbol) {
   return symbol === ' ' || symbol === PLUS || symbol === COLON;
 }
 
-function convertNamesToIdsInLine(line, records, itemsTypes) {
+export function convertNamesToIdsInLine(line, records, itemsTypes) {
   if (isPriorityLine(line)) return line;
 
   let replacedString = '';

--- a/src/settings/utils/rules-string-convertors.test.js
+++ b/src/settings/utils/rules-string-convertors.test.js
@@ -1,0 +1,100 @@
+import {
+  isPriorityLine,
+  isCommentSymbol,
+  isWordsSeparatingSymbol,
+  convertNamesToIds,
+  convertIdsToNames,
+} from './rules-string-convertors';
+import {
+  EDITOR_SPECIAL_SYMBOL,
+  WHITE_SPACE,
+} from '../../constants';
+
+describe('settings utils', () => {
+  describe('isPriorityLine', () => {
+    it('should return true if line is priority', () => {
+      const mockedLineContent = 'test data with priority';
+
+      expect(isPriorityLine(mockedLineContent)).toBe(true);
+    });
+
+    it('should return false if line is not priority', () => {
+      const mockedLineContent = 'test data';
+
+      expect(isPriorityLine(mockedLineContent)).toBe(false);
+    });
+  });
+
+  describe('isCommentSymbol', () => {
+    const { HASH, SLASH } = EDITOR_SPECIAL_SYMBOL;
+
+    it(`should return true if symbol is "${HASH}"`, () => {
+      expect(isCommentSymbol(HASH)).toBe(true);
+    });
+
+    it(`should return true if symbol is "${SLASH}"`, () => {
+      expect(isCommentSymbol(SLASH)).toBe(true);
+    });
+
+    it(`should return false if symbol is not "${HASH}" or "${SLASH}"`, () => {
+      Object.values(EDITOR_SPECIAL_SYMBOL).forEach(item => {
+        if (item !== HASH && item !== SLASH) {
+          expect(isCommentSymbol(item)).toBe(false);
+        }
+      });
+    });
+  });
+
+  describe('isWordsSeparatingSymbol', () => {
+    const { PLUS, COLON } = EDITOR_SPECIAL_SYMBOL;
+
+    it(`should return true if symbol is "${PLUS}"`, () => {
+      expect(isWordsSeparatingSymbol(PLUS)).toBe(true);
+    });
+
+    it(`should return true if symbol is "${COLON}"`, () => {
+      expect(isWordsSeparatingSymbol(COLON)).toBe(true);
+    });
+
+    it('should return true if symbol is "white space"', () => {
+      expect(isWordsSeparatingSymbol(WHITE_SPACE)).toBe(true);
+    });
+
+    it(`should return false if symbol is not "${PLUS}", "${COLON}" or "white space"`, () => {
+      Object.values(EDITOR_SPECIAL_SYMBOL).forEach(item => {
+        if (item !== PLUS && item !== COLON) {
+          expect(isWordsSeparatingSymbol(item)).toBe(false);
+        }
+      });
+    });
+  });
+
+  describe('convertNamesToIds', () => {
+    it('should replace name with corresponding id correctly', () => {
+      const mockedLineContent = 'fallback-policy: l firstTestName \nl secondTestName';
+      const mockedRecords = {
+        l: {
+          'firstTestName': 'firstTestData',
+          'secondTestName': 'secondTestData',
+        },
+      };
+      const expectedResult = 'fallback-policy: l firstTestData \nl secondTestData';
+
+      expect(convertNamesToIds(mockedLineContent, mockedRecords)).toBe(expectedResult);
+    });
+  });
+
+  describe('convertIdsToNames', () => {
+    it('should replace id with corresponding name correctly', () => {
+      const mockedLineContent = 'key testData';
+      const mockedRecords = {
+        key: {
+          'expected-name': 'testData',
+        },
+      };
+      const expectedResult = 'key expected-name';
+
+      expect(convertIdsToNames(mockedLineContent, mockedRecords)).toBe(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for "rules-string-convertors" in "settings/utils"

## Refs
https://issues.folio.org/browse/UICIRC-682

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/130914138-0b837ea5-7cec-476f-8541-94eb70fbe15b.png)