### PR TITLE
UICIRC-632: Add RTL/Jest test for `GeneralSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-634.
 * Add RTL/Jest testing for functions in `settings/utils/rules-string-convertors.js`. Refs UICIRC-682.
 * Add RTL/Jest testing for `FinesSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-597.
+* Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-632.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.js
+++ b/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.js
@@ -28,6 +28,7 @@ const GeneralSection = (props) => {
   return (
     <div data-test-notice-policy-detail-general-section>
       <Accordion
+        data-testid="generalInformationTestId"
         open={isOpen}
         id="generalNoticePolicy"
         label={<FormattedMessage id="ui-circulation.settings.loanPolicy.generalInformation" />}
@@ -36,7 +37,7 @@ const GeneralSection = (props) => {
           connect={connect}
           metadata={metadata}
         />
-        <Row>
+        <Row data-testid="policyNameTestId">
           <Col
             xs={12}
             data-notice-policy-name
@@ -47,7 +48,7 @@ const GeneralSection = (props) => {
             />
           </Col>
         </Row>
-        <Row>
+        <Row data-testid="policyActiveTestId">
           <Col
             xs={12}
             data-notice-policy-active
@@ -58,7 +59,7 @@ const GeneralSection = (props) => {
             />
           </Col>
         </Row>
-        <Row>
+        <Row data-testid="policyDescriptionTestId">
           <Col
             xs={12}
             data-notice-policy-description

--- a/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import { Metadata } from '../../../../components';
+import GeneralSection from './GeneralSection';
+
+jest.mock('../../../../components', () => ({
+  Metadata: jest.fn(() => null),
+}));
+
+describe('GeneralSection', () => {
+  const mockedMetadata = {
+    data: 'mockedMetadata',
+  };
+  const mockedName = 'mockedPolicyName';
+  const mockedDescription = 'mockedPolicyDescription';
+  const getItemById = (id) => within(screen.getByTestId(id));
+  const generalInformationId = 'ui-circulation.settings.loanPolicy.generalInformation';
+  const policyNameId = 'ui-circulation.settings.noticePolicy.policyName';
+  const activeLabelId = 'ui-circulation.settings.noticePolicy.active';
+  const activeStatusId = 'ui-circulation.settings.loanPolicy.yes';
+  const inactiveStatusId = 'ui-circulation.settings.loanPolicy.no';
+  const policyDescriptionId = 'ui-circulation.settings.loanPolicy.policyDescription';
+  const sectionTesting = (policy, labelId, contentValue) => {
+    it(`should render "policy ${policy}" section correctly`, () => {
+      expect(screen.getByTestId(`policy${policy}TestId`)).toBeVisible();
+      expect(getItemById(`policy${policy}TestId`).getByText(labelId)).toBeVisible();
+      expect(getItemById(`policy${policy}TestId`).getByText(contentValue)).toBeVisible();
+    });
+  };
+
+  describe('with positive props', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          isOpen
+          isPolicyActive
+          policyName={mockedName}
+          policyDescription={mockedDescription}
+          connect={jest.fn}
+          metadata={mockedMetadata}
+        />
+      );
+    });
+
+    it('should render general information section correctly', () => {
+      expect(screen.getByTestId('generalInformationTestId')).toBeVisible();
+      expect(getItemById('generalInformationTestId').getByText(generalInformationId)).toBeVisible();
+    });
+
+    it('should pass "isOpen" property correctly', () => {
+      expect(screen.getByTestId('generalInformationTestId')).toHaveAttribute('open');
+    });
+
+    it('should execute "Metadata" with correct props', () => {
+      const expectedResult = {
+        connect: jest.fn,
+        metadata: mockedMetadata,
+      };
+
+      expect(Metadata).toHaveBeenLastCalledWith(expectedResult, {});
+    });
+
+    sectionTesting('Name', policyNameId, mockedName);
+
+    sectionTesting('Active', activeLabelId, activeStatusId);
+
+    sectionTesting('Description', policyDescriptionId, mockedDescription);
+  });
+
+  describe('with negative props', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          isOpen={false}
+          policyName={mockedName}
+          policyDescription={mockedDescription}
+          connect={jest.fn}
+          metadata={mockedMetadata}
+        />
+      );
+    });
+
+    it('should pass "isOpen" property correctly', () => {
+      expect(screen.getByTestId('generalInformationTestId')).not.toHaveAttribute('open');
+    });
+
+    sectionTesting('Active', activeLabelId, inactiveStatusId);
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `GeneralSection` component in `NoticePolicy/components/DetailSections`

## Refs
https://issues.folio.org/browse/UICIRC-632

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131353992-7cb215f1-0a43-4513-abff-0e63a4e4d1e2.png)