### PR TITLE
UICIRC-634: Add RTL/Jest tests for `RequestNoticesSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Investigate possibility to run tests successfully. Refs UICIRC-681.
 * Add RTL/Jest testing for `AboutSection` component in `LoanPolicy/components/EditSections`. Refs UICIRC-612.
 * Add RTL/Jest testing for `LostItemFeeAboutSection` component in `LostItemFeePolicy/components/EditSections`. Refs UICIRC-622.
+* Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-634.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.js
+++ b/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.js
@@ -35,6 +35,7 @@ class RequestNoticesSection extends React.Component {
     return (
       <div data-test-notice-policy-detail-request-notices-section>
         <Accordion
+          data-testid="viewRequestNoticesTestId"
           id="viewRequestNotices"
           open={isOpen}
           label={<FormattedMessage id="ui-circulation.settings.noticePolicy.requestNotices" />}

--- a/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import RequestNoticesSection from './RequestNoticesSection';
+import NoticeCard from '../components';
+import {
+  requestTimeBasedEventsIds,
+  uponAndBeforeSendEvents,
+  requestNoticesTriggeringEvents,
+} from '../../../../../constants';
+
+jest.mock('../components', () => jest.fn(() => null));
+
+describe('RequestNoticesSection', () => {
+  const mockedPolicy = {
+    requestNotices: [
+      'firstTestNotice',
+      'secondTestNotice',
+    ],
+  };
+  const mockedTemplates = [
+    {
+      value: 'firstTemplate',
+      label: 'fitstTemplateData',
+    },
+    {
+      value: 'secondTemplate',
+      label: 'secondTemplateData',
+    },
+  ];
+  const requestNoticesId = 'ui-circulation.settings.noticePolicy.requestNotices';
+
+  describe('with positive props', () => {
+    beforeEach(() => {
+      render(
+        <RequestNoticesSection
+          isOpen
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    afterEach(() => {
+      NoticeCard.mockClear();
+    });
+
+    it('should render accordion label correctly', () => {
+      expect(within(screen.getByTestId('viewRequestNoticesTestId')).getByText(requestNoticesId)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('viewRequestNoticesTestId')).toHaveAttribute('open');
+    });
+
+    it('should execute each "NoticeCard" with correct props', () => {
+      mockedPolicy.requestNotices.forEach((notice, index) => {
+        const expectedResult = {
+          index,
+          notice,
+          sendEvents: uponAndBeforeSendEvents,
+          sendEventTriggeringIds: Object.values(requestTimeBasedEventsIds),
+          templates: mockedTemplates,
+          triggeringEvents: requestNoticesTriggeringEvents,
+        };
+
+        expect(NoticeCard).toHaveBeenNthCalledWith(index + 1, expectedResult, {});
+      });
+    });
+  });
+
+  describe('with negative props', () => {
+    beforeEach(() => {
+      render(
+        <RequestNoticesSection
+          isOpen={false}
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('viewRequestNoticesTestId')).not.toHaveAttribute('open');
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `RequestNoticesSection` component in `NoticePolicy/components/DetailSections`

## Refs
https://issues.folio.org/browse/UICIRC-634

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131468460-ccc73b8a-aeee-4a7f-873d-f765338ad54e.png)