### PR TITLE
UICIRC-686: Add RTL/Jest tests for `convertNamesToIdsInLine` function in `settings/utils`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add RTL/Jest testing for `Metadata` component in `settings/components`. Refs UICIRC-652.
 * Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-633.
 * Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-639.
+* Add RTL/Jest testing for `convertNamesToIdsInLine` function in `settings/utils/rules-string-convertors.js`. Refs UICIRC-686.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/utils/rules-string-convertors.test.js
+++ b/src/settings/utils/rules-string-convertors.test.js
@@ -4,6 +4,7 @@ import {
   isWordsSeparatingSymbol,
   convertNamesToIds,
   convertIdsToNames,
+  convertNamesToIdsInLine,
 } from './rules-string-convertors';
 import {
   EDITOR_SPECIAL_SYMBOL,
@@ -95,6 +96,40 @@ describe('settings utils', () => {
       const expectedResult = 'key expected-name';
 
       expect(convertIdsToNames(mockedLineContent, mockedRecords)).toBe(expectedResult);
+    });
+  });
+
+  describe('convertNamesToIdsInLine', () => {
+    const mockedRecords = {
+      l: {
+        'example-loan-policy': 'testData',
+      },
+    };
+    const mockedItemsTypes = ['l'];
+
+    it('should return unchanged data if line is priority', () => {
+      const mockedLineContent = 'test priority test';
+
+      expect(convertNamesToIdsInLine(mockedLineContent)).toBe(mockedLineContent);
+    });
+
+    it('should not change data if invalid type is passed', () => {
+      const mockedLineContent = 'fallback-policy: r example-loan-policy';
+
+      expect(convertNamesToIdsInLine(mockedLineContent, mockedRecords, mockedItemsTypes)).toBe(mockedLineContent);
+    });
+
+    it('should not change data if have no correct key in rule record', () => {
+      const mockedLineContent = 'fallback-policy: l something';
+
+      expect(convertNamesToIdsInLine(mockedLineContent, mockedRecords, mockedItemsTypes)).toBe(mockedLineContent);
+    });
+
+    it('should not transform comment part in passed string', () => {
+      const mockedLineContent = 'fallback-policy: !l example-loan-policy /l example-loan-policy';
+      const expectedResult = 'fallback-policy: !l testData /l example-loan-policy';
+
+      expect(convertNamesToIdsInLine(mockedLineContent, mockedRecords, mockedItemsTypes)).toBe(expectedResult);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `convertNamesToIdsInLine` function in `settings/utils/rules-string-convertors.js`

## Refs
https://issues.folio.org/browse/UICIRC-686

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131665780-b3c79629-88b3-465b-b789-89315dc73e7a.png)
![image](https://user-images.githubusercontent.com/88130496/131665348-3137c734-7cd5-4668-8b45-476d1e6925f7.png)