### PR TITLE
UICIRC-639: Add RTL/Jest tests for `LoanNoticesSection` component in `NoticePolicy/components/EditSections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Add RTL/Jest testing for `AnonymizingTypeSelect` component in `settings/components/AnonymizingTypeSelect`. Refs UICIRC-653.
 * Add RTL/Jest testing for `Metadata` component in `settings/components`. Refs UICIRC-652.
 * Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-633.
+* Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-639.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.js
+++ b/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.js
@@ -13,6 +13,10 @@ import {
   uponAndAfterSendEvents,
 } from '../../../../../constants';
 
+export const getSendEvents = (triggeringEvent) => {
+  return triggeringEvent === loanTimeBasedEventsIds.AGED_TO_LOST ? uponAndAfterSendEvents : noticesSendEvents;
+};
+
 class LoanNoticesSection extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
@@ -22,10 +26,6 @@ class LoanNoticesSection extends React.Component {
       label: PropTypes.string.isRequired,
     })).isRequired,
   };
-
-  getSendEvents = (triggeringEvent) => {
-    return triggeringEvent === loanTimeBasedEventsIds.AGED_TO_LOST ? uponAndAfterSendEvents : noticesSendEvents;
-  }
 
   render() {
     const {
@@ -37,6 +37,7 @@ class LoanNoticesSection extends React.Component {
     return (
       <div data-test-notice-policy-form-loan-notices-section>
         <Accordion
+          data-testid="editLoanNotices"
           id="editLoanNotices"
           open={isOpen}
           label={<FormattedMessage id="ui-circulation.settings.noticePolicy.loanNotices" />}
@@ -47,7 +48,7 @@ class LoanNoticesSection extends React.Component {
             component={NoticesList}
             policy={policy}
             templates={templates}
-            getSendEvents={this.getSendEvents}
+            getSendEvents={getSendEvents}
             sendEventTriggeringIds={values(loanTimeBasedEventsIds)}
             triggeringEvents={loanNoticesTriggeringEvents}
           />

--- a/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import { FieldArray } from 'react-final-form-arrays';
+import NoticesList from '../components';
+import LoanNoticesSection, {
+  getSendEvents,
+} from './LoanNoticesSection';
+import {
+  loanNoticesTriggeringEvents,
+  loanTimeBasedEventsIds,
+  uponAndAfterSendEvents,
+  noticesSendEvents,
+} from '../../../../../constants';
+
+jest.mock('react-final-form-arrays', () => ({
+  FieldArray: jest.fn(() => null),
+}));
+
+jest.mock('../components', () => jest.fn(() => null));
+
+describe('LoanNoticesSection', () => {
+  const mockedPolicy = {
+    policy: 'testPolicyData',
+  };
+  const mockedTemplates = [
+    {
+      value: 'firstTestValue',
+      label: 'firstTestLabel',
+    },
+    {
+      value: 'secondTestValue',
+      label: 'secondTestLabel',
+    },
+  ];
+
+  describe('when it is open', () => {
+    const loanNoticesId = 'ui-circulation.settings.noticePolicy.loanNotices';
+
+    beforeEach(() => {
+      render(
+        <LoanNoticesSection
+          isOpen
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    afterEach(() => {
+      FieldArray.mockClear();
+    });
+
+    it('should render accordion with label', () => {
+      expect(within(screen.getByTestId('editLoanNotices')).getByText(loanNoticesId)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('editLoanNotices')).toHaveAttribute('open');
+    });
+
+    it('should execute "FieldArray" with correct props', () => {
+      const expectedResult = {
+        name: 'loanNotices',
+        sectionKey: 'loanNotices',
+        component: NoticesList,
+        policy: mockedPolicy,
+        templates: mockedTemplates,
+        getSendEvents,
+        sendEventTriggeringIds: Object.values(loanTimeBasedEventsIds),
+        triggeringEvents: loanNoticesTriggeringEvents,
+      };
+
+      expect(FieldArray).toHaveBeenCalledWith(expectedResult, {});
+    });
+  });
+
+  describe('when it is not open', () => {
+    beforeEach(() => {
+      render(
+        <LoanNoticesSection
+          isOpen={false}
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('editLoanNotices')).not.toHaveAttribute('open');
+    });
+  });
+
+  describe('getSendEvents function', () => {
+    it('should return "uponAndAfterSendEvents"', () => {
+      expect(getSendEvents(loanTimeBasedEventsIds.AGED_TO_LOST)).toEqual(uponAndAfterSendEvents);
+    });
+
+    it('should return "noticesSendEvents"', () => {
+      expect(getSendEvents('somethingElse')).toEqual(noticesSendEvents);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `LoanNoticesSection` function in `NoticePolicy/components/EditSections`

## Refs
https://issues.folio.org/browse/UICIRC-639

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131801675-d5bf347c-f891-43cb-8a02-e4f1aff78477.png)