### PR TITLE
UICIRC-633: Add RTL/Jest tests for `LoanNoticesSection` component in `NoticePolicy/components/DetailSections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-632.
 * Add RTL/Jest testing for `AnonymizingTypeSelect` component in `settings/components/AnonymizingTypeSelect`. Refs UICIRC-653.
 * Add RTL/Jest testing for `Metadata` component in `settings/components`. Refs UICIRC-652.
+* Add RTL/Jest testing for `LoanNoticesSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-633.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.js
+++ b/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.js
@@ -35,6 +35,7 @@ class LoanNoticesSection extends React.Component {
     return (
       <div data-test-notice-policy-detail-loan-notices-section>
         <Accordion
+          data-testid="viewLoanNoticesTestId"
           id="viewLoanNotices"
           open={isOpen}
           label={<FormattedMessage id="ui-circulation.settings.noticePolicy.loanNotices" />}

--- a/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import LoanNoticesSection from './LoanNoticesSection';
+import NoticeCard from '../components';
+import {
+  noticesSendEvents,
+  loanTimeBasedEventsIds,
+  loanNoticesTriggeringEvents,
+} from '../../../../../constants';
+
+jest.mock('../components', () => jest.fn(() => null));
+
+describe('LoanNoticesSection', () => {
+  const mockedPolicy = {
+    loanNotices: ['firstTestNotice', 'secondTestNotice'],
+  };
+  const mockedTemplates = [
+    {
+      value: 'firstTestValue',
+      label: 'firstTestLabel',
+    },
+    {
+      value: 'secondTestValue',
+      label: 'secondTestLabel',
+    },
+  ];
+  const loanNoticesId = 'ui-circulation.settings.noticePolicy.loanNotices';
+  const eachNoticeTest = (notice, index) => {
+    const number = index + 1;
+    const expectedResult = {
+      index,
+      notice,
+      sendEvents: noticesSendEvents,
+      sendEventTriggeringIds: Object.values(loanTimeBasedEventsIds),
+      templates: mockedTemplates,
+      triggeringEvents: loanNoticesTriggeringEvents,
+    };
+
+    it(`should execute ${number} "NoticeCard" with correct props`, () => {
+      expect(NoticeCard).toHaveBeenNthCalledWith(number, expectedResult, {});
+    });
+  };
+
+  describe('when it is open', () => {
+    beforeEach(() => {
+      render(
+        <LoanNoticesSection
+          isOpen
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    afterEach(() => {
+      NoticeCard.mockClear();
+    });
+
+    it('should render accrodion with label', () => {
+      expect(screen.getByTestId('viewLoanNoticesTestId')).toBeVisible();
+      expect(within(screen.getByTestId('viewLoanNoticesTestId')).getByText(loanNoticesId)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('viewLoanNoticesTestId')).toHaveAttribute('open');
+    });
+
+    mockedPolicy.loanNotices.map(eachNoticeTest);
+  });
+
+  describe('when it is not open', () => {
+    beforeEach(() => {
+      render(
+        <LoanNoticesSection
+          isOpen={false}
+          policy={mockedPolicy}
+          templates={mockedTemplates}
+        />
+      );
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId('viewLoanNoticesTestId')).not.toHaveAttribute('open');
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `LoanNoticesSection` function in `NoticePolicy/components/DetailSections`

## Refs
https://issues.folio.org/browse/UICIRC-633

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131807442-791d36f7-6b84-4886-9018-a36efced2ecf.png)