### PR TITLE
UICIRC-652: Add RTL/Jest tests for `Metadata` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Add RTL/Jest testing for `FinesSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-597.
 * Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-632.
 * Add RTL/Jest testing for `AnonymizingTypeSelect` component in `settings/components/AnonymizingTypeSelect`. Refs UICIRC-653.
+* Add RTL/Jest testing for `Metadata` component in `settings/components`. Refs UICIRC-652.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
@@ -27,6 +27,7 @@ describe('AnonymizingTypeSelect', () => {
   };
   const testAnonymizingTypeRow = (type, index) => {
     const number = index + 1;
+
     it(`should use correct props for "Field" in ${number} row`, () => {
       const expectedResult = {
         'data-test-radio-button': true,
@@ -43,13 +44,15 @@ describe('AnonymizingTypeSelect', () => {
   };
 
   beforeEach(() => {
-    Field.mockClear();
-
     render(
       <AnonymizingTypeSelect
         {...mockedProps}
       />
     );
+  });
+
+  afterEach(() => {
+    Field.mockClear();
   });
 
   it(`should render ${mockedProps.types.length} rows`, () => {

--- a/src/settings/components/Metadata/Metadata.js
+++ b/src/settings/components/Metadata/Metadata.js
@@ -32,7 +32,7 @@ class Metadata extends React.Component {
     }
 
     return (
-      <Row>
+      <Row data-testid="metadataTestId">
         <Col xs={12}>
           <this.cViewMetaData metadata={metadata} />
         </Col>

--- a/src/settings/components/Metadata/Metadata.test.js
+++ b/src/settings/components/Metadata/Metadata.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import Metadata from './Metadata';
+
+describe('Metadata', () => {
+  const mockedConnect = jest.fn((Component) => {
+    return class extends React.Component {
+      render() {
+        return (
+          <Component
+            data-testid="connectedComponentTestId"
+            {...this.props}
+          />
+        );
+      }
+    };
+  });
+
+  describe('if "metadata" props is valid', () => {
+    const mockedMetadata = {
+      createdDate: 'testData',
+    };
+
+    beforeEach(() => {
+      render(
+        <Metadata
+          connect={mockedConnect}
+          metadata={mockedMetadata}
+        />
+      );
+    });
+
+    afterEach(() => {
+      mockedConnect.mockClear();
+    });
+
+    it('should render component', () => {
+      expect(screen.getByTestId('metadataTestId')).toBeVisible();
+    });
+
+    it('should use "connect" function on correct component', () => {
+      expect(mockedConnect).toHaveBeenCalled();
+      expect(screen.getByTestId('connectedComponentTestId')).toBeVisible();
+    });
+
+    it('should receive correct props', () => {
+      expect(within(screen.getByTestId('connectedComponentTestId')).getByText(`${mockedMetadata.createdDate}`));
+    });
+  });
+
+  describe('if "metadata" props is invalid', () => {
+    it('should not render element if "metadata" not passed', () => {
+      render(
+        <Metadata
+          connect={mockedConnect}
+        />
+      );
+
+      expect(screen.queryByTestId('metadataTestId')).not.toBe();
+    });
+
+    it('should not render element if "createdDate" in "metadata" is absent', () => {
+      render(
+        <Metadata
+          connect={mockedConnect}
+          metadata={{ testData: 'testData' }}
+        />
+      );
+
+      expect(screen.queryByTestId('metadataTestId')).not.toBe();
+    });
+  });
+});

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -4,3 +4,4 @@ import './intl.mock';
 import './stripesIcon.mock';
 import './stripesComponents.mock';
 import './finalFormComponents.mock';
+import './stripesSmartComponents.mock';

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+jest.mock('@folio/stripes/smart-components', () => ({
+  ViewMetaData: jest.fn(({ metadata, ...rest }) => (
+    <div {...rest}>{metadata.createdDate}</div>
+  )),
+}));


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `Metadata` component in `settings/components`

## Refs
https://issues.folio.org/browse/UICIRC-652

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131849541-1d186e19-bfed-4d9a-b0c0-ce8ac9b287bc.png)