### PR TITLE
UICIRC-653: Add RTL/Jest tests for `AnonymizingTypeSelect` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add RTL/Jest testing for functions in `settings/utils/rules-string-convertors.js`. Refs UICIRC-682.
 * Add RTL/Jest testing for `FinesSection` component in `FinePolicy/components/ViewSections`. Refs UICIRC-597.
 * Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/DetailSections`. Refs UICIRC-632.
+* Add RTL/Jest testing for `AnonymizingTypeSelect` component in `settings/components/AnonymizingTypeSelect`. Refs UICIRC-653.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.js
@@ -10,7 +10,10 @@ import {
 
 const AnonymizingTypeSelect = ({ name, types }) => {
   return types.map((type, index) => (
-    <Row key={`row-${index}`}>
+    <Row
+      key={`row-${index}`}
+      data-testid="anonymizingTypeRowTestId"
+    >
       <Col xs={12}>
         <Field
           data-test-radio-button

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import { RadioButton } from '@folio/stripes/components';
+import AnonymizingTypeSelect from './AnonymizingTypeSelect';
+
+RadioButton.mockImplementation(() => null);
+Field.mockImplementation(() => null);
+
+describe('AnonymizingTypeSelect', () => {
+  const mockedProps = {
+    name: 'testName',
+    types: [
+      {
+        label: 'firstTestLabel',
+        value: 'firstTestValue',
+      },
+      {
+        label: 'secondTestLabel',
+        value: 'secondTestValue',
+      },
+    ],
+  };
+  const testAnonymizingTypeRow = (type, index) => {
+    const number = index + 1;
+    it(`should use correct props for "Field" in ${number} row`, () => {
+      const expectedResult = {
+        'data-test-radio-button': true,
+        component: RadioButton,
+        label: type.label,
+        name: `closingType.${mockedProps.name}`,
+        type: 'radio',
+        id: `${type.value}-${mockedProps.name}-radio-button`,
+        value: type.value,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(number, expectedResult, {});
+    });
+  };
+
+  beforeEach(() => {
+    Field.mockClear();
+
+    render(
+      <AnonymizingTypeSelect
+        {...mockedProps}
+      />
+    );
+  });
+
+  it(`should render ${mockedProps.types.length} rows`, () => {
+    expect(screen.getAllByTestId('anonymizingTypeRowTestId')).toHaveLength(mockedProps.types.length);
+  });
+
+  mockedProps.types.forEach(testAnonymizingTypeRow);
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -49,6 +49,7 @@ jest.mock('@folio/stripes/components', () => ({
     <div ref={ref} {...rest}>{children}</div>
   )),
   PaneMenu: jest.fn((props) => <div>{props.children}</div>),
+  RadioButton: jest.fn(() => <input type="radio" />),
   Row: jest.fn(({ children, ...rest }) => <div {...rest}>{children}</div>),
   TextArea: jest.fn((props) => <textarea {...props} />),
   TextField: jest.fn((props) => <input {...props} />),


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `AnonymizingTypeSelect` component in `settings/components/AnonymizingTypeSelect`

## Refs
https://issues.folio.org/browse/UICIRC-653

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/131968353-49806cfb-ec33-4b5c-8d70-fcde95641b40.png)