### PR TITLE
UICIRC-624: Add RTL/Jest tests for `RadioGroup` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Add RTL/Jest testing for functions in `settings/utils`. Refs UICIRC-656.
 * Add RTL/Jest testing for `LoansSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-617.
 * Add RTL/Jest testing for `RequestManagementSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-618.
+* Add RTL/Jest testing for `RadioGroup` component in `LostItemFeePolicy/components/EditSections`. Refs UICIRC-624.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.js
@@ -20,6 +20,7 @@ const RadioGroup = (props) => (
       <Row>
         <Col xs={6}>
           <Label
+            data-testid="chargeAmountItemTestId"
             htmlFor="chargeAmount"
             id="chargeAmount-label"
           >
@@ -27,7 +28,7 @@ const RadioGroup = (props) => (
           </Label>
         </Col>
       </Row>
-      <Row>
+      <Row data-testid="actualCostTestId">
         <Col
           xs={3}
           data-test-charge-type-actual
@@ -42,7 +43,7 @@ const RadioGroup = (props) => (
           />
         </Col>
       </Row>
-      <Row>
+      <Row data-testid="setCostTestId">
         <Col
           xs={2}
           data-test-charge-type-another

--- a/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.test.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import {
+  RadioButton,
+  TextField,
+} from '@folio/stripes/components';
+import RadioGroup from './RadioGroup';
+
+const catchFunction = jest.fn();
+
+Field.mockImplementation(({ label, ...rest }) => {
+  catchFunction({ ...rest });
+
+  return (
+    <div>
+      {label}
+    </div>
+  );
+});
+
+describe('RadioGroup', () => {
+  const chargeAmountItemLabelId = 'ui-circulation.settings.lostItemFee.chargeAmountItem';
+  const actualCostLabelId = 'ui-circulation.settings.lostItemFee.actualCost';
+  const setCostLabelId = 'ui-circulation.settings.lostItemFee.setCost';
+  const chargeAmountLabelId = 'ui-circulation.settings.lostItemFee.chargeAmount';
+
+  const getById = (id) => within(screen.getByTestId(id));
+  const mockedOnBlure = jest.fn();
+
+  beforeEach(() => {
+    render(
+      <RadioGroup
+        onBlur={mockedOnBlure}
+      />
+    );
+  });
+
+  afterEach(() => {
+    Field.mockClear();
+  });
+
+  it('should render label of component correctly', () => {
+    expect(getById('chargeAmountItemTestId').getByText(chargeAmountItemLabelId)).toBeVisible();
+    expect(screen.getByTestId('chargeAmountItemTestId')).toHaveAttribute('for', 'chargeAmount');
+    expect(screen.getByTestId('chargeAmountItemTestId')).toHaveAttribute('id', 'chargeAmount-label');
+  });
+
+  it('should use correct props for "Field" in "actual cost" section', () => {
+    const expectedResult = {
+      name: 'chargeAmountItem.chargeType',
+      component: RadioButton,
+      id: 'chargeAmount',
+      value: 'actualCost',
+      type: 'radio',
+    };
+
+    expect(getById('actualCostTestId').getByText(actualCostLabelId)).toBeVisible();
+    expect(catchFunction).toHaveBeenNthCalledWith(1, expectedResult);
+  });
+
+  it('should use correct props for "Field" in "set cost" section', () => {
+    const expectedResult = {
+      name: 'chargeAmountItem.chargeType',
+      component: RadioButton,
+      value: 'anotherCost',
+      type: 'radio',
+    };
+
+    expect(getById('setCostTestId').getByText(setCostLabelId)).toBeVisible();
+    expect(catchFunction).toHaveBeenNthCalledWith(2, expectedResult);
+  });
+
+  it('should use correct props for "Field" in "charge amount" section', () => {
+    const expectedResult = {
+      'aria-label': chargeAmountLabelId,
+      name: 'chargeAmountItem.amount',
+      component: TextField,
+      type: 'number',
+      format: mockedOnBlure,
+      formatOnBlur: true,
+    };
+
+    expect(Field).toHaveBeenNthCalledWith(3, expectedResult, {});
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -45,6 +45,12 @@ jest.mock('@folio/stripes/components', () => ({
       </div>
     </div>
   )),
+  Label: jest.fn(({
+    htmlFor,
+    id,
+    children,
+    ...rest
+  }) => (<label htmlFor={htmlFor} id={id} {...rest}>{children}</label>)),
   PaneFooter: jest.fn(({ ref, children, ...rest }) => (
     <div ref={ref} {...rest}>{children}</div>
   )),


### PR DESCRIPTION
## Purpose
Add RTL/Jest tests for `RadioGroup` component in `LostItemFeePolicy/components/EditSections`

## Refs
https://issues.folio.org/browse/UICIRC-624

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/132352592-c38d8d55-edcf-4581-89e5-03cb11702274.png)