### PR TITLE
UICIRC-640: Add RTL/Jest testing for `RequestNoticesSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add RTL/Jest testing for `RequestManagementSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-618.
 * Add RTL/Jest testing for `RadioGroup` component in `LostItemFeePolicy/components/EditSections`. Refs UICIRC-624.
 * Increment `stripes` to `v7`, `react` to `v17`. Refs UICIRC-676.
+* Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-640.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.js
+++ b/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.js
@@ -12,6 +12,10 @@ import {
   uponAndBeforeSendEvents,
 } from '../../../../../constants';
 
+export const getSendEvents = () => {
+  return uponAndBeforeSendEvents;
+};
+
 class RequestNoticesSection extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
@@ -21,10 +25,6 @@ class RequestNoticesSection extends React.Component {
       label: PropTypes.string.isRequired,
     })).isRequired,
   };
-
-  getSendEvents = () => {
-    return uponAndBeforeSendEvents;
-  }
 
   render() {
     const {
@@ -36,6 +36,7 @@ class RequestNoticesSection extends React.Component {
     return (
       <div data-test-notice-policy-form-request-notices-section>
         <Accordion
+          data-testid="editRequestNotices"
           id="editRequestNotices"
           open={isOpen}
           label={<FormattedMessage id="ui-circulation.settings.noticePolicy.requestNotices" />}
@@ -45,7 +46,7 @@ class RequestNoticesSection extends React.Component {
             sectionKey="requestNotices"
             component={NoticesList}
             policy={policy}
-            getSendEvents={this.getSendEvents}
+            getSendEvents={getSendEvents}
             sendEventTriggeringIds={values(requestTimeBasedEventsIds)}
             templates={templates}
             triggeringEvents={requestNoticesTriggeringEvents}

--- a/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
@@ -5,15 +5,23 @@ import {
   within,
 } from '@testing-library/react';
 
+import { FieldArray } from 'react-final-form-arrays';
+
 import '../../../../../../test/jest/__mock__';
 
-import RequestNoticesSection from './RequestNoticesSection';
-import NoticeCard from '../components';
+import NoticesList from '../components';
+import RequestNoticesSection, {
+  getSendEvents,
+} from './RequestNoticesSection';
 import {
   requestTimeBasedEventsIds,
   uponAndBeforeSendEvents,
   requestNoticesTriggeringEvents,
 } from '../../../../../constants';
+
+jest.mock('react-final-form-arrays', () => ({
+  FieldArray: jest.fn(() => null),
+}));
 
 jest.mock('../components', () => jest.fn(() => null));
 
@@ -36,7 +44,7 @@ describe('RequestNoticesSection', () => {
   ];
   const requestNoticesId = 'ui-circulation.settings.noticePolicy.requestNotices';
 
-  describe('when "isOpen" prop is true', () => {
+  describe('with positive props', () => {
     beforeEach(() => {
       render(
         <RequestNoticesSection
@@ -47,35 +55,31 @@ describe('RequestNoticesSection', () => {
       );
     });
 
-    afterEach(() => {
-      NoticeCard.mockClear();
-    });
-
     it('should render accordion label correctly', () => {
-      expect(within(screen.getByTestId('viewRequestNoticesTestId')).getByText(requestNoticesId)).toBeVisible();
+      expect(within(screen.getByTestId('editRequestNotices')).getByText(requestNoticesId)).toBeVisible();
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewRequestNoticesTestId')).toHaveAttribute('open');
+      expect(screen.getByTestId('editRequestNotices')).toHaveAttribute('open');
     });
 
-    it('should execute each "NoticeCard" with correct props', () => {
-      mockedPolicy.requestNotices.forEach((notice, index) => {
-        const expectedResult = {
-          index,
-          notice,
-          sendEvents: uponAndBeforeSendEvents,
-          sendEventTriggeringIds: Object.values(requestTimeBasedEventsIds),
-          templates: mockedTemplates,
-          triggeringEvents: requestNoticesTriggeringEvents,
-        };
+    it('should execute "FieldArray" with correct props', () => {
+      const expectedProps = {
+        name: 'requestNotices',
+        sectionKey: 'requestNotices',
+        component: NoticesList,
+        policy: mockedPolicy,
+        getSendEvents,
+        sendEventTriggeringIds: Object.values(requestTimeBasedEventsIds),
+        templates: mockedTemplates,
+        triggeringEvents: requestNoticesTriggeringEvents,
+      };
 
-        expect(NoticeCard).toHaveBeenNthCalledWith(index + 1, expectedResult, {});
-      });
+      expect(FieldArray).toHaveBeenLastCalledWith(expectedProps, {});
     });
   });
 
-  describe('when "isOpen" prop is false', () => {
+  describe('with negative props', () => {
     beforeEach(() => {
       render(
         <RequestNoticesSection
@@ -87,7 +91,13 @@ describe('RequestNoticesSection', () => {
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewRequestNoticesTestId')).not.toHaveAttribute('open');
+      expect(screen.getByTestId('editRequestNotices')).not.toHaveAttribute('open');
+    });
+  });
+
+  describe('getSendEvents', () => {
+    it('should return list of "uponAndBeforeSendEvents"', () => {
+      expect(getSendEvents()).toEqual(uponAndBeforeSendEvents);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/EditSections`

## Refs
https://issues.folio.org/browse/UICIRC-640

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/133435376-e6357809-658c-4b44-a5d3-6f386aff004d.png)