### PR TITLE
UICIRC-648: Add RTL/Jest tests for `GeneralSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Add RTL/Jest testing for `FinesSection` component in `FinePolicy/components/EditSections`. Refs UICIRC-594.
 * Add RTL/Jest testing for `RenewalsSection` component in `LoanPolicy/components/EditSections`. Refs UICIRC-614.
 * Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-638.
+* Add RTL/Jest testing for `GeneralSection` component in `RequestPolicy/components/EditSections`. Refs UICIRC-648.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -16,6 +16,31 @@ import {
 import { Metadata } from '../../../../components';
 import { requestPolicyTypes } from '../../../../../constants';
 
+export const renderTypes = () => {
+  const items = requestPolicyTypes.map((name, index) => (
+    <Row key={`request-policy-type-${index}`}>
+      <Col xs={12}>
+        <Field
+          component={Checkbox}
+          type="checkbox"
+          id={`${name.toLowerCase()}-checkbox`}
+          label={name}
+          name={`requestTypes[${index}]`}
+        />
+      </Col>
+    </Row>
+  ));
+
+  return (
+    <>
+      <p data-testid="policyTypes">
+        <FormattedMessage id="ui-circulation.settings.requestPolicy.policyTypes" />
+      </p>
+      {items}
+    </>
+  );
+};
+
 class GeneralSection extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
@@ -23,31 +48,6 @@ class GeneralSection extends React.Component {
     connect: PropTypes.func.isRequired,
     validateName: PropTypes.func.isRequired,
   };
-
-  renderTypes = () => {
-    const items = requestPolicyTypes.map((name, index) => (
-      <Row key={`request-policy-type-${index}`}>
-        <Col xs={12}>
-          <Field
-            component={Checkbox}
-            type="checkbox"
-            id={`${name.toLowerCase()}-checkbox`}
-            label={name}
-            name={`requestTypes[${index}]`}
-          />
-        </Col>
-      </Row>
-    ));
-
-    return (
-      <>
-        <p>
-          <FormattedMessage id="ui-circulation.settings.requestPolicy.policyTypes" />
-        </p>
-        {items}
-      </>
-    );
-  }
 
   render() {
     const {
@@ -59,6 +59,7 @@ class GeneralSection extends React.Component {
 
     return (
       <Accordion
+        data-testid="generalRequestPolicyForm"
         id="generalRequestPolicyForm"
         open={isOpen}
         label={<FormattedMessage id="ui-circulation.settings.requestPolicy.generalInformation" />}
@@ -69,6 +70,7 @@ class GeneralSection extends React.Component {
         />
         <div data-test-request-policy-name>
           <Field
+            data-testid="requestPolicyName"
             id="request_policy_name"
             name="name"
             required
@@ -79,6 +81,7 @@ class GeneralSection extends React.Component {
           />
         </div>
         <Field
+          data-testid="requestPolicyDescription"
           id="request_policy_description"
           name="description"
           label={<FormattedMessage id="ui-circulation.settings.requestPolicy.policyDescription" />}
@@ -86,7 +89,7 @@ class GeneralSection extends React.Component {
         />
         <FieldArray
           name="requestTypes"
-          component={this.renderTypes}
+          component={renderTypes}
         />
       </Accordion>
     );

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
@@ -1,0 +1,175 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import { FieldArray } from 'react-final-form-arrays';
+import { Field } from 'react-final-form';
+
+import {
+  TextArea,
+  TextField,
+  Checkbox,
+} from '@folio/stripes/components';
+import { Metadata } from '../../../../components';
+import GeneralSection, {
+  renderTypes,
+} from './GeneralSection';
+import { requestPolicyTypes } from '../../../../../constants';
+
+jest.mock('react-final-form-arrays', () => ({
+  FieldArray: jest.fn(() => null),
+}));
+jest.mock('../../../../components', () => ({
+  Metadata: jest.fn(() => null),
+}));
+
+describe('GeneralSection', () => {
+  const testIds = {
+    policyTypes: 'policyTypes',
+    general: 'generalRequestPolicyForm',
+    name: 'requestPolicyName',
+    description: 'requestPolicyDescription',
+  };
+  const labelIds = {
+    accordion: 'ui-circulation.settings.requestPolicy.generalInformation',
+    name: 'ui-circulation.settings.requestPolicy.policyName',
+    description: 'ui-circulation.settings.requestPolicy.policyDescription',
+  };
+  const fieldCallOrderByPlace = {
+    name: 1,
+    description: 2,
+  };
+  const mockedMetadata = {
+    data: 'testData',
+  };
+  const mockedConnect = jest.fn();
+  const mockedValidateName = jest.fn();
+  const getById = (id) => within(screen.getByTestId(id));
+  const defaultProps = {
+    isOpen: true,
+    metadata: mockedMetadata,
+    connect: mockedConnect,
+    validateName: mockedValidateName,
+  };
+
+  afterEach(() => {
+    Metadata.mockClear();
+    Field.mockClear();
+    FieldArray.mockClear();
+  });
+
+  describe('when "isOpen" prop is true', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          {...defaultProps}
+        />
+      );
+    });
+
+    it('should render accordion label', () => {
+      expect(getById(testIds.general).getByText(labelIds.accordion)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId(testIds.general)).toHaveAttribute('open');
+    });
+
+    it('should execute "Metadata" with passed props', () => {
+      const expectedResult = {
+        connect: mockedConnect,
+        metadata: mockedMetadata,
+      };
+
+      expect(Metadata).toHaveBeenLastCalledWith(expectedResult, {});
+    });
+
+    it('should execute "Field" associated with "name" with passed props', () => {
+      const expectedResult = {
+        id: 'request_policy_name',
+        name: 'name',
+        required: true,
+        autoFocus: true,
+        component: TextField,
+        validate: mockedValidateName,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(fieldCallOrderByPlace.name, expect.objectContaining(expectedResult), {});
+      expect(getById(testIds.name).getByText(labelIds.name)).toBeVisible();
+    });
+
+    it('should execute "Field" associated with "description" with passed props', () => {
+      const expectedResult = {
+        id: 'request_policy_description',
+        name: 'description',
+        component: TextArea,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(fieldCallOrderByPlace.description, expect.objectContaining(expectedResult), {});
+      expect(getById(testIds.description).getByText(labelIds.description)).toBeVisible();
+    });
+
+    it('should execute "FieldArray" with passed props', () => {
+      const expectedResult = {
+        name: 'requestTypes',
+        component: renderTypes,
+      };
+
+      expect(FieldArray).toHaveBeenLastCalledWith(expectedResult, {});
+    });
+  });
+
+  describe('when "isOpen" prop is false', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          {...defaultProps}
+          isOpen={false}
+        />
+      );
+    });
+
+    it('should render accordion label', () => {
+      expect(getById(testIds.general).getByText(labelIds.accordion)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId(testIds.general)).not.toHaveAttribute('open');
+    });
+  });
+
+  describe('renderTypes', () => {
+    const policyTypesLabelId = 'ui-circulation.settings.requestPolicy.policyTypes';
+    const polycyTypeTest = (name, index) => {
+      const number = index + 1;
+      const expectedResult = {
+        component: Checkbox,
+        type: 'checkbox',
+        id: `${name.toLowerCase()}-checkbox`,
+        label: name,
+        name: `requestTypes[${index}]`,
+      };
+
+      it(`should render ${number} policy with right props`, () => {
+        expect(Field).toHaveBeenNthCalledWith(number, expectedResult, {});
+      });
+    };
+
+    beforeEach(() => {
+      render(
+        renderTypes()
+      );
+    });
+
+    it('should render main label', () => {
+      expect(getById(testIds.policyTypes).getByText(policyTypesLabelId)).toBeVisible();
+    });
+
+    requestPolicyTypes.forEach(polycyTypeTest);
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `GeneralSection` component in `RequestPolicy/components/EditSections`

## Refs
https://issues.folio.org/browse/UICIRC-648

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/133563177-22bf95b2-03f8-4f61-b474-37f564f82d38.png)