### PR TITLE
UICIRC-638: Add RTL/Jest tests for `GeneralSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Improve circ rules location list display, at least a tiny bit. Refs UICIRC-430.
 * Add RTL/Jest testing for `FinesSection` component in `FinePolicy/components/EditSections`. Refs UICIRC-594.
 * Add RTL/Jest testing for `RenewalsSection` component in `LoanPolicy/components/EditSections`. Refs UICIRC-614.
+* Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-638.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -31,6 +31,7 @@ class GeneralSection extends React.Component {
     return (
       <div data-test-notice-policy-form-general-section>
         <Accordion
+          data-testid="general"
           id="general"
           open={isOpen}
           label={<FormattedMessage id="ui-circulation.settings.noticePolicy.generalInformation" />}
@@ -39,7 +40,10 @@ class GeneralSection extends React.Component {
             connect={connect}
             metadata={metadata}
           />
-          <div data-test-general-section-policy-name>
+          <div
+            data-test-general-section-policy-name
+            data-testid="nameField"
+          >
             <Field
               id="notice_policy_name"
               name="name"
@@ -49,7 +53,10 @@ class GeneralSection extends React.Component {
               component={TextField}
             />
           </div>
-          <div data-test-general-section-active>
+          <div
+            data-test-general-section-active
+            data-testid="activeField"
+          >
             <Field
               id="notice_policy_active"
               name="active"
@@ -59,7 +66,10 @@ class GeneralSection extends React.Component {
               component={Checkbox}
             />
           </div>
-          <div data-test-general-section-policy-description>
+          <div
+            data-test-general-section-policy-description
+            data-testid="descriptionField"
+          >
             <Field
               id="notice_policy_description"
               name="description"

--- a/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/GeneralSection/GeneralSection.test.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import {
+  TextArea,
+  TextField,
+  Checkbox,
+} from '@folio/stripes/components';
+import { Metadata } from '../../../../components';
+import GeneralSection from './GeneralSection';
+import styles from './GeneralSection.css';
+
+jest.mock('../../../../components', () => ({
+  Metadata: jest.fn(() => null),
+}));
+
+describe('GeneralSection', () => {
+  const testIds = {
+    general: 'general',
+    nameField: 'nameField',
+    activeField: 'activeField',
+    descriptionField: 'descriptionField',
+  };
+  const labelIds = {
+    general: 'ui-circulation.settings.noticePolicy.generalInformation',
+    name: 'ui-circulation.settings.noticePolicy.policyName',
+    active: 'ui-circulation.settings.noticePolicy.active',
+    description: 'ui-circulation.settings.noticePolicy.policyDescription',
+  };
+  const fieldCallOrderByPlace = {
+    name: 1,
+    active: 2,
+    description: 3,
+  };
+  const getById = (id) => within(screen.getByTestId(id));
+  const mockedMetadata = {
+    data: 'testData',
+  };
+  const mockedConnect = jest.fn();
+  const defaultProps = {
+    isOpen: true,
+    metadata: mockedMetadata,
+    connect: mockedConnect,
+  };
+
+  afterEach(() => {
+    Field.mockClear();
+    Metadata.mockClear();
+  });
+
+  describe('when "isOpen" prop is true', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          {...defaultProps}
+        />
+      );
+    });
+
+    it('should render main label', () => {
+      expect(getById(testIds.general).getByText(labelIds.general)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId(testIds.general)).toHaveAttribute('open');
+    });
+
+    it('should execute "Metadata" with passed props', () => {
+      const expectedResult = {
+        connect: mockedConnect,
+        metadata: mockedMetadata,
+      };
+
+      expect(Metadata).toHaveBeenLastCalledWith(expectedResult, {});
+    });
+
+    it('should execute "Field" associated with "name" with passed props', () => {
+      const expectedResult = {
+        id: 'notice_policy_name',
+        name: 'name',
+        required: true,
+        autoFocus: true,
+        component: TextField,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(fieldCallOrderByPlace.name, expect.objectContaining(expectedResult), {});
+      expect(getById(testIds.nameField).getByText(labelIds.name)).toBeVisible();
+    });
+
+    it('should execute "Field" associated with "active" with passed props', () => {
+      const expectedResult = {
+        id: 'notice_policy_active',
+        name: 'active',
+        type: 'checkbox',
+        className: styles.checkbox,
+        component: Checkbox,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(fieldCallOrderByPlace.active, expect.objectContaining(expectedResult), {});
+      expect(getById(testIds.activeField).getByText(labelIds.active)).toBeVisible();
+    });
+
+    it('should execute "Field" associated with "description" with passed props', () => {
+      const expectedResult = {
+        id: 'notice_policy_description',
+        name: 'description',
+        component: TextArea,
+      };
+
+      expect(Field).toHaveBeenNthCalledWith(fieldCallOrderByPlace.description, expect.objectContaining(expectedResult), {});
+      expect(getById(testIds.descriptionField).getByText(labelIds.description)).toBeVisible();
+    });
+  });
+
+  describe('when "isOpen" prop is false', () => {
+    beforeEach(() => {
+      render(
+        <GeneralSection
+          {...defaultProps}
+          isOpen={false}
+        />
+      );
+    });
+
+    it('should render main label', () => {
+      expect(getById(testIds.general).getByText(labelIds.general)).toBeVisible();
+    });
+
+    it('should pass "isOpen" prop correctly', () => {
+      expect(screen.getByTestId(testIds.general)).not.toHaveAttribute('open');
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `GeneralSection` component in `NoticePolicy/components/EditSections`

## Refs
https://issues.folio.org/browse/UICIRC-638

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/133572113-9e3a99b8-60e1-449e-b01f-87c3be357af0.png)