### PR TITLE
UICIRC-430 improve location display in circ rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Add RTL/Jest testing for `RequestNoticesSection` component in `NoticePolicy/components/EditSections`. Refs UICIRC-640.
 * Add RTL/Jest testing for `OverdueFinesSection` and `OverdueFinesSectionColumn` components in `FinePolicy/components/EditSections/RangeSection`. Refs UICIRC-596.
 * Add RTL/Jest testing for `Period` component in `settings/components/Period`. Refs UICIRC-655.
+* Improve circ rules location list display, at least a tiny bit. Refs UICIRC-430.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -179,7 +179,7 @@
 }
 
 .CodeMirror-hints-list ul li {
-  height: 12px;
+  height: auto;
 }
 
 .CodeMirror-hints-list.CodeMirror-hints-multiple-selection ul {

--- a/src/settings/lib/RuleEditor/CodeMirrorCustom.css
+++ b/src/settings/lib/RuleEditor/CodeMirrorCustom.css
@@ -90,9 +90,9 @@
   width: 100%;
 }
 
+/* wrapper for the _entire_ list, not a single list-item */
 .CodeMirror-checkbox-container {
   width: 100%;
-  height: 12px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
The CSS rules governing the line-height of a single location-item are
completely impenetrable to me, but removing the `height` attribute on
the container element somehow, mysteriously, fixes the display. It
appears that what's happening is a bunch of block-level elements with a
too-short line-height are stacked, such that the line below clips that
above, but I couldn't figure out how to change the line-height for a
single element anywhere.

Refs [UICIRC-430](https://issues.folio.org/browse/UICIRC-430)

