### PR TITLE
UICIRC-695: Add RTL/Jest tests for `RenewalsSection` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Add RTL/Jest testing for `TokensList` component in `settings/StaffSlips/TokensList`. Refs UICIRC-651.
 * Add RTL/Jest testing for `ScheduleCard` component in `FixedDueDateSchedule/components/EditSections/components`. Refs UICIRC-602.
 * Add RTL/Jest testing for `ExceptionsList` component in `settings/LoanHistory`. Refs UICIRC-605.
+* Add RTL/Jest testing for `RenewalsSection` component in `LoanPolicy/components/ViewSections`. Refs UICIRC-695.
 
 ## [5.1.0] (https://github.com/folio-org/ui-circulation/tree/v5.1.0) (2021-06-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.0.1...v5.1.0)

--- a/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.js
+++ b/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import {
   Col,
@@ -19,6 +19,9 @@ const RenewalsSection = (props) => {
     getPeriodValue,
     getScheduleValue,
     getValue,
+    intl:{
+      formatMessage,
+    },
   } = props;
 
   if (!isVisible) {
@@ -26,23 +29,26 @@ const RenewalsSection = (props) => {
   }
 
   const altRenewalScheduleLabel = policy.isProfileRolling()
-    ? <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSDueDateLimit" />
-    : <FormattedMessage id="ui-circulation.settings.loanPolicy.altFDDSforRenewals" />;
+    ? formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSDueDateLimit' })
+    : formatMessage({ id: 'ui-circulation.settings.loanPolicy.altFDDSforRenewals' });
 
   return (
     <div data-test-loan-policy-detail-renewals-section>
-      <Row>
+      <Row data-testid="renewals">
         <Col xs={12}>
           <h2 data-test-renewals-section-header>
-            <FormattedMessage id="ui-circulation.settings.loanPolicy.renewals" />
+            {formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewals' })}
           </h2>
         </Col>
       </Row>
       <Row>
         <Col xs={12}>
-          <div data-test-renewals-section-renewable>
+          <div
+            data-testid="renewable"
+            data-test-renewals-section-renewable
+          >
             <KeyValue
-              label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewable" />}
+              label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewable' })}
               value={getCheckboxValue('renewable')}
             />
           </div>
@@ -51,9 +57,12 @@ const RenewalsSection = (props) => {
       { policy.isRenewable() &&
         <Row>
           <Col xs={12}>
-            <div data-test-renewals-section-unlimited-renewals>
+            <div
+              data-testid="unlimitedRenewals"
+              data-test-renewals-section-unlimited-renewals
+            >
               <KeyValue
-                label={<FormattedMessage id="ui-circulation.settings.loanPolicy.unlimitedRenewals" />}
+                label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.unlimitedRenewals' })}
                 value={getCheckboxValue('renewalsPolicy.unlimited')}
               />
             </div>
@@ -63,9 +72,12 @@ const RenewalsSection = (props) => {
         <div>
           <Row>
             <Col xs={12}>
-              <div data-test-renewals-section-number-renewals-allowed>
+              <div
+                data-testid="numRenewalsAllowed"
+                data-test-renewals-section-number-renewals-allowed
+              >
                 <KeyValue
-                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.numRenewalsAllowed" />}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.numRenewalsAllowed' })}
                   value={getValue('renewalsPolicy.numberAllowed')}
                 />
               </div>
@@ -76,9 +88,12 @@ const RenewalsSection = (props) => {
         <>
           <Row>
             <Col xs={12}>
-              <div data-test-renewals-section-renew-from>
+              <div
+                data-testid="renewFrom"
+                data-test-renewals-section-renew-from
+              >
                 <KeyValue
-                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewFrom" />}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewFrom' })}
                   value={getDropdownValue('renewalsPolicy.renewFromId', renewFromOptions)}
                 />
               </div>
@@ -86,9 +101,12 @@ const RenewalsSection = (props) => {
           </Row>
           <Row>
             <Col xs={12}>
-              <div data-test-renewals-section-renewal-period-different>
+              <div
+                data-testid="renewalPeriodDifferent"
+                data-test-renewals-section-renewal-period-different
+              >
                 <KeyValue
-                  label={<FormattedMessage id="ui-circulation.settings.loanPolicy.renewalPeriodDifferent" />}
+                  label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent' })}
                   value={getCheckboxValue('renewalsPolicy.differentPeriod')}
                 />
               </div>
@@ -99,9 +117,12 @@ const RenewalsSection = (props) => {
       <div>
         <Row>
           <Col xs={12}>
-            <div data-test-renewals-section-alternate-loan-period-renewals>
+            <div
+              data-testid="alternateLoanPeriodRenewals"
+              data-test-renewals-section-alternate-loan-period-renewals
+            >
               <KeyValue
-                label={<FormattedMessage id="ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals" />}
+                label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals' })}
                 value={getPeriodValue('renewalsPolicy.period')}
               />
             </div>
@@ -112,7 +133,10 @@ const RenewalsSection = (props) => {
         <div>
           <Row>
             <Col xs={12}>
-              <div data-test-renewals-section-alternate-fixed-due-date-schedule-id>
+              <div
+                data-testid="altFDDS"
+                data-test-renewals-section-alternate-fixed-due-date-schedule-id
+              >
                 <KeyValue
                   label={altRenewalScheduleLabel}
                   value={getScheduleValue('renewalsPolicy.alternateFixedDueDateScheduleId')}
@@ -134,6 +158,7 @@ RenewalsSection.propTypes = {
   getPeriodValue: PropTypes.func.isRequired,
   getCheckboxValue: PropTypes.func.isRequired,
   getScheduleValue: PropTypes.func.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
-export default RenewalsSection;
+export default injectIntl(RenewalsSection);

--- a/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.test.js
+++ b/src/settings/LoanPolicy/components/ViewSections/RenewalsSection/RenewalsSection.test.js
@@ -1,0 +1,293 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../../../test/jest/__mock__';
+
+import {
+  KeyValue,
+} from '@folio/stripes/components';
+import RenewalsSection from './RenewalsSection';
+
+import { renewFromOptions } from '../../../../../constants';
+
+KeyValue.mockImplementation(jest.fn(() => null));
+
+describe('RenewalsSection', () => {
+  const labelIds = {
+    altFDDSDueDateLimit: 'ui-circulation.settings.loanPolicy.altFDDSDueDateLimit',
+    altFDDSforRenewals: 'ui-circulation.settings.loanPolicy.altFDDSforRenewals',
+    renewals: 'ui-circulation.settings.loanPolicy.renewals',
+    renewable: 'ui-circulation.settings.loanPolicy.renewable',
+    unlimitedRenewals: 'ui-circulation.settings.loanPolicy.unlimitedRenewals',
+    numRenewalsAllowed: 'ui-circulation.settings.loanPolicy.numRenewalsAllowed',
+    renewFrom: 'ui-circulation.settings.loanPolicy.renewFrom',
+    renewalPeriodDifferent: 'ui-circulation.settings.loanPolicy.renewalPeriodDifferent',
+    alternateLoanPeriodRenewals: 'ui-circulation.settings.loanPolicy.alternateLoanPeriodRenewals',
+  };
+  const testIds = {
+    renewals: 'renewals',
+    renewable: 'renewable',
+    unlimitedRenewals: 'unlimitedRenewals',
+    numRenewalsAllowed: 'numRenewalsAllowed',
+    renewFrom: 'renewFrom',
+    renewalPeriodDifferent: 'renewalPeriodDifferent',
+    alternateLoanPeriodRenewals: 'alternateLoanPeriodRenewals',
+    altFDDS: 'altFDDS',
+  };
+  const orderOfKeyValueCall = {
+    renewable: 1,
+    unlimitedRenewals: 2,
+    numRenewalsAllowed: 3,
+    renewFrom: 4,
+    renewalPeriodDifferent: 5,
+    alternateLoanPeriodRenewals: 6,
+    altFDDS: 7,
+  };
+  const mockedPolicy = {
+    isProfileRolling: () => true,
+    isUnlimitedRenewals: () => false,
+    isDifferentPeriod: () => true,
+    isRenewable: () => true,
+  };
+  const mockedGetCheckbox = jest.fn((id) => ({ id, func: 'getCheckboxValue' }));
+  const mockedGetDropdown = jest.fn((id, options) => ({ id, options }));
+  const mockedGetPeriod = jest.fn((id) => ({ id, func: 'getPeriodValue' }));
+  const mockedGetSchedule = jest.fn((id) => ({ id, func: 'getScheduleValue' }));
+  const mockedGetValue = jest.fn((id) => ({ id, func: 'getValue' }));
+  const defaultProps = {
+    isVisible: true,
+    policy: mockedPolicy,
+    getCheckboxValue: mockedGetCheckbox,
+    getDropdownValue: mockedGetDropdown,
+    getPeriodValue: mockedGetPeriod,
+    getScheduleValue: mockedGetSchedule,
+    getValue: mockedGetValue,
+  };
+  const getById = (id) => within(screen.getByTestId(id));
+
+  afterEach(() => {
+    KeyValue.mockClear();
+  });
+
+  describe('with props which allows render all sections', () => {
+    beforeEach(() => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+        />
+      );
+    });
+
+    it('should render main label', () => {
+      expect(getById(testIds.renewals).getByText(labelIds.renewals)).toBeVisible();
+    });
+
+    it('should render "renewable" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.renewable,
+        value: {
+          id: 'renewable',
+          func: 'getCheckboxValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.renewable)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.renewable, expectedProps, {});
+    });
+
+    it('should render "unlimitedRenewals" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.unlimitedRenewals,
+        value: {
+          id: 'renewalsPolicy.unlimited',
+          func: 'getCheckboxValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.unlimitedRenewals)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.unlimitedRenewals, expectedProps, {});
+    });
+
+    it('should render "numRenewalsAllowed" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.numRenewalsAllowed,
+        value: {
+          id: 'renewalsPolicy.numberAllowed',
+          func: 'getValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.numRenewalsAllowed)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.numRenewalsAllowed, expectedProps, {});
+    });
+
+    it('should render "renewFrom" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.renewFrom,
+        value: {
+          id: 'renewalsPolicy.renewFromId',
+          options: renewFromOptions,
+        },
+      };
+
+      expect(screen.getByTestId(testIds.renewFrom)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.renewFrom, expectedProps, {});
+    });
+
+    it('should render "renewalPeriodDifferent" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.renewalPeriodDifferent,
+        value: {
+          id: 'renewalsPolicy.differentPeriod',
+          func: 'getCheckboxValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.renewalPeriodDifferent)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.renewalPeriodDifferent, expectedProps, {});
+    });
+
+    it('should render "alternateLoanPeriodRenewals" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.alternateLoanPeriodRenewals,
+        value: {
+          id: 'renewalsPolicy.period',
+          func: 'getPeriodValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.alternateLoanPeriodRenewals)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.alternateLoanPeriodRenewals, expectedProps, {});
+    });
+
+    it('should render "altFDDS" section correctly', () => {
+      const expectedProps = {
+        label: labelIds.altFDDSDueDateLimit,
+        value: {
+          id: 'renewalsPolicy.alternateFixedDueDateScheduleId',
+          func: 'getScheduleValue',
+        },
+      };
+
+      expect(screen.getByTestId(testIds.altFDDS)).toBeVisible();
+      expect(KeyValue).toHaveBeenNthCalledWith(orderOfKeyValueCall.altFDDS, expectedProps, {});
+    });
+  });
+
+  describe('when "isProfileRolling" returns false', () => {
+    beforeEach(() => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+          policy={{
+            ...mockedPolicy,
+            isProfileRolling: () => false,
+          }}
+        />
+      );
+    });
+
+    it('should not render "alternateLoanPeriodRenewals" section', () => {
+      expect(screen.queryByTestId(testIds.alternateLoanPeriodRenewals)).not.toBeInTheDocument();
+    });
+
+    it('should render "altFDDS" section correctly', () => {
+      expect(KeyValue).toHaveBeenLastCalledWith(expect.objectContaining({
+        label: labelIds.altFDDSforRenewals,
+      }), {});
+    });
+  });
+
+  describe('when "isUnlimitedRenewals" return true', () => {
+    it('should not render "numRenewalsAllowed" section', () => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+          policy={{
+            ...mockedPolicy,
+            isUnlimitedRenewals: () => true,
+          }}
+        />
+      );
+
+      expect(screen.queryByTestId(testIds.numRenewalsAllowed)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when "isDifferentPeriod" return false', () => {
+    beforeEach(() => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+          policy={{
+            ...mockedPolicy,
+            isDifferentPeriod: () => false,
+          }}
+        />
+      );
+    });
+
+    it('should not render "alternateLoanPeriodRenewals" section', () => {
+      expect(screen.queryByTestId(testIds.alternateLoanPeriodRenewals)).not.toBeInTheDocument();
+    });
+
+    it('should not render "altFDDS" section', () => {
+      expect(screen.queryByTestId(testIds.altFDDS)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when "isRenewable" return false', () => {
+    beforeEach(() => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+          policy={{
+            ...mockedPolicy,
+            isRenewable: () => false,
+          }}
+        />
+      );
+    });
+
+    it('should not render "unlimitedRenewals" section', () => {
+      expect(screen.queryByTestId(testIds.unlimitedRenewals)).not.toBeInTheDocument();
+    });
+
+    it('should not render "numRenewalsAllowed" section', () => {
+      expect(screen.queryByTestId(testIds.numRenewalsAllowed)).not.toBeInTheDocument();
+    });
+
+    it('should not render "renewFrom" section', () => {
+      expect(screen.queryByTestId(testIds.renewFrom)).not.toBeInTheDocument();
+    });
+
+    it('should not render "renewalPeriodDifferent" section', () => {
+      expect(screen.queryByTestId(testIds.renewalPeriodDifferent)).not.toBeInTheDocument();
+    });
+
+    it('should not render "alternateLoanPeriodRenewals" section', () => {
+      expect(screen.queryByTestId(testIds.alternateLoanPeriodRenewals)).not.toBeInTheDocument();
+    });
+
+    it('should not render "altFDDS" section', () => {
+      expect(screen.queryByTestId(testIds.altFDDS)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when "isVisible" is false', () => {
+    it('should not redner anything', () => {
+      render(
+        <RenewalsSection
+          {...defaultProps}
+          isVisible={false}
+        />
+      );
+
+      expect(screen.queryByTestId(testIds.renewals)).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `RenewalsSection` component in `LoanPolicy/components/ViewSections`

## Refs
https://issues.folio.org/browse/UICIRC-695

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/135222260-17a099c9-b09e-4b15-83ed-03d30256ae0c.png)