### PR TITLE
UICIRC-703 sort locations by code, name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 6.something IN PROGRESS
+
+* Locations display as `{code} {name}` and thus should be sorted by code, name. Refs UICIRC-703.
+
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)
 

--- a/src/settings/CirculationRules.js
+++ b/src/settings/CirculationRules.js
@@ -140,7 +140,7 @@ class CirculationRules extends React.Component {
       records: 'locations',
       path: 'locations',
       params: {
-        query: 'cql.allRecords=1 sortby name',
+        query: 'cql.allRecords=1 sortby code name',
         limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || MAX_UNPAGED_RESOURCE_COUNT,
       },
       resourceShouldRefresh: true,


### PR DESCRIPTION
Locations are displayed as `{code} {name}` and thus should be sorted in
the circulation rules editor sorted in that order. Previously, they were
sorted by `name`, which made navigating the list very confusing.

Refs [UICIRC-703](https://issues.folio.org/browse/UICIRC-703), [UICIRC-430](https://issues.folio.org/browse/UICIRC-430)
