### PR TITLE
UICIRC-708: change modal description wording

### DIFF
--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -305,7 +305,7 @@
   "settings.titleLevelRequests.desription": "Select templates for the following patron notices. If no template is selected, no notice will be sent.",
   "settings.titleLevelRequests.defaultTemplateValue": "Select notice",
   "settings.titleLevelRequests.forbiddenDisableTlrModal.title": "Cannot change \"Allow title level requests\"",
-  "settings.titleLevelRequests.forbiddenDisableTlrModal.description": "\"Allow title requests\" cannot be changed because it is in use by one or more requests",
+  "settings.titleLevelRequests.forbiddenDisableTlrModal.description": "\"Allow title level requests\" cannot be changed because it is in use by one or more requests",
 
   "settings.noticePolicy.addNotice": "Add notice",
   "settings.noticePolicy.countableNotice": "Notice {counter}",


### PR DESCRIPTION
## Purpose
Fix wording mistake in description of modal.

Main changes for [UICIRC-708](https://issues.folio.org/browse/UICIRC-708) was described in https://github.com/folio-org/ui-circulation/pull/814

## Refs
https://issues.folio.org/browse/UICIRC-708