### PR TITLE
UICIRC-724:  use constants instead of hardcoded value for query limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add RTL/Jest testing for `PatronNoticeDetail` component in `settings/PatronNotices`. Refs UICIRC-643.
 * Title level request setting cannot be disabled when there is an active title level request in the system. Refs UICIRC-708.
 * Add possible for resizing panel in circulation rules editor. Refs UICIRC-709.
+* Use constants instead of hardcoded value for query limits. Refs UICIRC-724.
 
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -464,7 +464,7 @@ export const feeFineNoticesTriggeringEvents = [
   },
 ];
 
-export const MAX_UNPAGED_RESOURCE_COUNT = 1000;
+export const MAX_UNPAGED_RESOURCE_COUNT = '1000';
 
 export default '';
 

--- a/src/settings/NoticePolicy/NoticePolicySettings.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.js
@@ -19,6 +19,8 @@ import NoticePolicyForm from './NoticePolicyForm';
 import normalize from './utils/normalize';
 import { NoticePolicy } from '../Models/NoticePolicy';
 
+import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
+
 class NoticePolicySettings extends React.Component {
   static manifest = Object.freeze({
     patronNoticePolicies: {
@@ -28,7 +30,7 @@ class NoticePolicySettings extends React.Component {
       throwErrors: false,
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: MAX_UNPAGED_RESOURCE_COUNT,
       },
     },
     templates: {
@@ -37,7 +39,7 @@ class NoticePolicySettings extends React.Component {
       path: 'templates',
       params: {
         query: 'cql.allRecords=1 AND category=""',
-        limit: '1000',
+        limit: MAX_UNPAGED_RESOURCE_COUNT,
       },
     },
     circulationRules: {

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import {
   sortBy,
   get,
-  reduce
+  reduce,
 } from 'lodash';
 
 import { EntryManager } from '@folio/stripes/smart-components';
@@ -47,8 +47,8 @@ class PatronNotices extends React.Component {
       params: {
         query: 'cql.allRecords=1 AND category=""',
       },
-      recordsRequired: 1000,
-      perRequest: 1000,
+      recordsRequired: MAX_UNPAGED_RESOURCE_COUNT,
+      perRequest: MAX_UNPAGED_RESOURCE_COUNT,
     },
     patronNoticePolicies: {
       type: 'okapi',

--- a/src/settings/RequestPolicy/RequestPolicySettings.js
+++ b/src/settings/RequestPolicy/RequestPolicySettings.js
@@ -11,7 +11,10 @@ import RequestPolicyForm from './RequestPolicyForm';
 import RequestPolicy from '../Models/RequestPolicy';
 import normalize from './utils/normalize';
 
-import { requestPolicyTypes } from '../../constants';
+import {
+  requestPolicyTypes,
+  MAX_UNPAGED_RESOURCE_COUNT,
+} from '../../constants';
 
 class RequestPolicySettings extends React.Component {
   static manifest = Object.freeze({
@@ -21,7 +24,7 @@ class RequestPolicySettings extends React.Component {
       path: 'request-policy-storage/request-policies',
       params: {
         query: 'cql.allRecords=1',
-        limit: '1000',
+        limit: MAX_UNPAGED_RESOURCE_COUNT,
       },
     },
     circulationRules: {


### PR DESCRIPTION
## Purpose
We should use constants instead of hardcoded value for query limits.

## Approach
I invetigated this problem a little bit deeper, and I found that:
- `params.limit` can use only `string` value (app fails if we change it to `number`);
- `recordsRequired` and `perRequest` handle what they got and parse `string` to `number` if need it (found this in `stripes-connect` code);
- in connection with all of the above this code looks a little bit worried for me
![image](https://user-images.githubusercontent.com/88130496/141257703-7135d5fb-8ba2-415d-9b6b-ce0ab2684237.png)

It's not make any problems yet, but there are a lot of places where we use such construction. In my opinion it can break the app, if `stripes` will not pass the `maxUnpagedResourceCount` by any reason.

That's the reasons why I changed `MAX_UNPAGED_RESOURCE_COUNT` from number to string. On my opinion this is the universal type for existing code.

## Refs
https://issues.folio.org/browse/UICIRC-724