### PR TITLE
UICIRC-693 provide read-only access to loan policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Title level request setting cannot be disabled when there is an active title level request in the system. Refs UICIRC-708.
 * Add possible for resizing panel in circulation rules editor. Refs UICIRC-709.
 * Use constants instead of hardcoded value for query limits. Refs UICIRC-724.
+* Provide read-only access to loan policies. Refs UICIRC-693.
 
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -73,20 +73,28 @@
         "visible": true
       },
       {
-        "permissionName": "ui-circulation.settings.loan-policies",
-        "displayName": "Settings (Circ): Can create, edit and remove loan policies",
+        "permissionName": "ui-circulation.settings.view-loan-policies",
+        "displayName": "Settings (Circ): Can view loan policies",
         "subPermissions": [
           "circulation-storage.loan-policies.collection.get",
           "circulation-storage.loan-policies.item.get",
-          "circulation-storage.loan-policies.item.post",
-          "circulation-storage.loan-policies.item.put",
-          "circulation-storage.loan-policies.item.delete",
-          "circulation-storage.loan-policies.collection.delete",
           "circulation-storage.fixed-due-date-schedules.collection.get",
           "circulation-storage.fixed-due-date-schedules.item.get",
           "users.collection.get",
           "users.item.get",
           "settings.circulation.enabled"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-circulation.settings.loan-policies",
+        "displayName": "Settings (Circ): Can create, edit and remove loan policies",
+        "subPermissions": [
+          "ui-circulation.settings.view-loan-policies",
+          "circulation-storage.loan-policies.item.post",
+          "circulation-storage.loan-policies.item.put",
+          "circulation-storage.loan-policies.item.delete",
+          "circulation-storage.loan-policies.collection.delete"
         ],
         "visible": true
       },

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ class Circulation extends Component {
             route: 'loan-policies',
             label: <FormattedMessage id="ui-circulation.settings.index.loanPolicies" />,
             component: LoanPolicySettings,
-            perm: 'ui-circulation.settings.loan-policies',
+            perm: 'ui-circulation.settings.view-loan-policies',
           },
         ],
       },

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -471,6 +471,7 @@
 
   "permission.settings.cancellation-reasons": "Settings (Circ): Can create, edit and remove cancellation reasons",
   "permission.settings.loan-history": "Settings (Circ): Can view loan history",
+  "permission.settings.view-loan-policies": "Settings (Circ): Can view loan policies",
   "permission.settings.loan-policies": "Settings (Circ): Can create, edit and remove loan policies",
   "permission.settings.notice-policies": "Settings (Circ): Can create, edit and remove notice policies",
   "permission.settings.circulation-rules": "Settings (Circ): Can create, edit and remove circulation rules",


### PR DESCRIPTION
Provide a new permission set that grants read-only access to loan
policies, similar to those for overdue fines policies and lost item fees
policies.

Refs [UICIRC-693](https://issues.folio.org/browse/UICIRC-693)
