### PR TITLE
UICIRC-604: Add RTL/Jest tests for `ExceptionCard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Provide read-only access to loan policies. Refs UICIRC-693.
 * Prevent deletion of policies if they're in use. Refs UICIRC-669.
 * Add RTL/Jest testing for `FeeFineNoticesSection` component in `NoticePolicy/components/EditSections/FeeFineNoticesSection`. Refs UICIRC-637.
-
+* Add RTL/Jest testing for `ExceptionCard` component in `settings/LoanHistory/ExceptionCard`. Refs UICIRC- 604.
 
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/LoanHistory/ExceptionCard.js
+++ b/src/settings/LoanHistory/ExceptionCard.js
@@ -81,7 +81,7 @@ class ExceptionCard extends Component {
         data-test-exception-card
       >
         <Col xs={12}>
-          <Row>
+          <Row data-testid="paymentMethod">
             <p className={css.exceptionCardHeader}>
               <FormattedMessage id="ui-circulation.settings.loanHistory.paymentMethodLabel" />
             </p>
@@ -99,6 +99,7 @@ class ExceptionCard extends Component {
             </Col>
             <Col xs={1}>
               <IconButton
+                data-testid="removeButton"
                 icon="trash"
                 data-test-remove-exception-icon
                 onClick={this.onRemove}

--- a/src/settings/LoanHistory/ExceptionCard.test.js
+++ b/src/settings/LoanHistory/ExceptionCard.test.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import {
+  IconButton,
+  Select,
+} from '@folio/stripes/components';
+
+import ExceptionCard from './ExceptionCard';
+import AnonymizingTypeSelectContainer from '../components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer';
+import {
+  closingTypes,
+  closedLoansRules,
+} from '../../constants';
+
+jest.mock('../components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer', () => jest.fn(() => null));
+Field.mockImplementation(({ children }) => {
+  return (
+    <div data-testid="selectPaymentMethod">
+      {children}
+    </div>
+  );
+});
+
+describe('ExceptionCard', () => {
+  const labelIds = {
+    paymentMethodLabel: 'ui-circulation.settings.loanHistory.paymentMethodLabel',
+    paymentMethodSelect: 'ui-circulation.settings.loanHistory.paymentMethodSelect',
+    selectPaymentMethod: 'ui-circulation.settings.loanHistory.selectPaymentMethod',
+  };
+  const testIds = {
+    paymentMethod: 'paymentMethod',
+    removeButton: 'removeButton',
+    selectPaymentMethod: 'selectPaymentMethod',
+  };
+  const mockedPathToException = 'testPathToException';
+  const mockedPaymentMethods = [
+    {
+      value: 'firstTestValue',
+      label: 'firstTestLabel',
+    },
+    {
+      value: 'secondTestValue',
+      label: 'secondTestLabel',
+    },
+  ];
+  const mockedExceptionIndex = 1;
+  const mockedOnRemoveException = jest.fn();
+
+  beforeEach(() => {
+    render(
+      <ExceptionCard
+        pathToException={mockedPathToException}
+        paymentMethods={mockedPaymentMethods}
+        exceptionIndex={mockedExceptionIndex}
+        onRemoveException={mockedOnRemoveException}
+      />
+    );
+  });
+
+  afterEach(() => {
+    AnonymizingTypeSelectContainer.mockClear();
+    Field.mockClear();
+    IconButton.mockClear();
+    mockedOnRemoveException.mockClear();
+  });
+
+  it('should render label for payment method', () => {
+    const element = within(screen.getByTestId(testIds.paymentMethod));
+
+    expect(element.getByText(labelIds.paymentMethodLabel)).toBeVisible();
+  });
+
+  it('should execute "Field" with passed props', () => {
+    const expectedResult = {
+      'aria-label': labelIds.paymentMethodSelect,
+      name: `${mockedPathToException}.paymentMethod`,
+      component: Select,
+    };
+
+    expect(Field).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+  });
+
+  it('should execute "IconButton" with passed props', () => {
+    expect(IconButton).toHaveBeenCalledWith(expect.objectContaining({ icon: 'trash' }), {});
+  });
+
+  it('should call "onRemove" with correct props on button click', () => {
+    expect(mockedOnRemoveException).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId(testIds.removeButton));
+
+    expect(mockedOnRemoveException).toHaveBeenCalledWith(mockedExceptionIndex);
+  });
+
+  it('should execute "AnonymizingTypeSelectContainer" with passed props', () => {
+    const expectedResult = {
+      name: closedLoansRules.WITH_FEES_FINES,
+      path: mockedPathToException,
+      types: closingTypes,
+    };
+
+    expect(AnonymizingTypeSelectContainer).toHaveBeenCalledWith(expectedResult, {});
+  });
+
+  describe('payment method options', () => {
+    const expectedResult = [
+      {
+        value: '',
+        label: labelIds.selectPaymentMethod,
+      },
+      ...mockedPaymentMethods,
+    ];
+
+    expectedResult.forEach((item, index) => {
+      it(`should correctly render ${index + 1} option`, () => {
+        const elements = screen.getAllByRole('option');
+        const singleOption = elements[index];
+
+        expect(singleOption).toHaveAttribute('value', item.value);
+        expect(within(singleOption).getByText(item.label)).toBeVisible();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `ExceptionCard` component in `settings/LoanHistory/ExceptionCard`.

## Refs
https://issues.folio.org/browse/UICIRC-604

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/141763853-7374d44e-15d9-4020-9177-919247bac9aa.png)
