### PR TITLE
UICIRC-646: Add RTL/Jest tests for `RequestPolicyDetail` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add RTL/Jest testing for `FeeFineNoticesSection` component in `NoticePolicy/components/EditSections/FeeFineNoticesSection`. Refs UICIRC-637.
 * Add RTL/Jest testing for `ExceptionCard` component in `settings/LoanHistory/ExceptionCard`. Refs UICIRC- 604.
 * Add RTL/Jest testing for `FixedDueDateScheduleDetail` component in `settings\FixedDueDateSchedule`. Refs UICIRC-608.
+* Add RTL/Jest testing for `RequestPolicyDetail` component in `src\settings\RequestPolicy`. Refs UICIRC-646.
 
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/RequestPolicy/RequestPolicyDetail.js
+++ b/src/settings/RequestPolicy/RequestPolicyDetail.js
@@ -15,6 +15,8 @@ import {
 
 import { Metadata } from '../components';
 
+export const requestTypeFormater = (requestType) => <li key={requestType}>{requestType}</li>;
+
 class RequestPolicyDetail extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -48,7 +50,7 @@ class RequestPolicyDetail extends React.Component {
 
   render() {
     const {
-      initialValues: policy = {},
+      initialValues: policy,
       stripes,
     } = this.props;
 
@@ -63,16 +65,19 @@ class RequestPolicyDetail extends React.Component {
         <Row end="xs">
           <Col data-test-expand-all xs>
             <ExpandAllButton
+              data-testid="expandAllButton"
               accordionStatus={sections}
               onToggle={this.handleExpandAll}
             />
           </Col>
         </Row>
         <AccordionSet
+          data-testid="accordionSet"
           accordionStatus={sections}
           onToggle={this.handleSectionToggle}
         >
           <Accordion
+            data-testid="generalInformation"
             open={sections.general}
             id="general"
             label={<FormattedMessage id="ui-circulation.settings.requestPolicy.generalInformation" />}
@@ -104,10 +109,13 @@ class RequestPolicyDetail extends React.Component {
                 <KeyValue
                   label={<FormattedMessage id="ui-circulation.settings.requestPolicy.policyTypes" />}
                 >
-                  <div data-test-request-types-list>
+                  <div
+                    data-testid="itemsList"
+                    data-test-request-types-list
+                  >
                     <List
                       items={requestTypes}
-                      itemFormatter={requestType => <li key={requestType}>{requestType}</li>}
+                      itemFormatter={requestTypeFormater}
                     />
                   </div>
                 </KeyValue>

--- a/src/settings/RequestPolicy/RequestPolicyDetail.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyDetail.test.js
@@ -1,0 +1,177 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  AccordionSet,
+  List,
+} from '@folio/stripes/components';
+
+import buildStripes from '../../../test/jest/__mock__/stripes.mock';
+import RequestPolicyDetail, {
+  requestTypeFormater,
+} from './RequestPolicyDetail';
+import { Metadata } from '../components';
+
+jest.mock('../components', () => ({
+  Metadata: jest.fn(() => null),
+}));
+AccordionSet.mockImplementation(jest.fn(({ children, onToggle, ...rest }) => {
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div {...rest} onClick={() => onToggle({ id: 'general' })}>
+      {children}
+    </div>
+  );
+}));
+
+const mockedStripes = buildStripes();
+
+describe('RequestPolicyDetail', () => {
+  const mockedCreatedDate = Date.now();
+  const labelIds = {
+    general: 'ui-circulation.settings.requestPolicy.generalInformation',
+    name: 'ui-circulation.settings.requestPolicy.policyName',
+    description: 'ui-circulation.settings.requestPolicy.policyDescription',
+    types: 'ui-circulation.settings.requestPolicy.policyTypes',
+  };
+  const testIds = {
+    accordionSet: 'accordionSet',
+    generalInformation: 'generalInformation',
+    expandAllButton: 'expandAllButton',
+    itemsList: 'itemsList',
+  };
+  const mockedInitialValues = {
+    name: 'testName',
+    description: 'testDescription',
+    metadata: {
+      createdDate: mockedCreatedDate,
+    },
+    requestTypes: ['testRequestTypes'],
+  };
+
+  afterEach(() => {
+    AccordionSet.mockClear();
+    Metadata.mockClear();
+    List.mockClear();
+  });
+
+  describe('with fully passed "initialValues"', () => {
+    beforeEach(() => {
+      render(
+        <RequestPolicyDetail
+          initialValues={mockedInitialValues}
+          stripes={mockedStripes}
+        />
+      );
+    });
+
+    it('should render "Expand all" button', () => {
+      expect(screen.getByText('Toggle accordion state')).toBeVisible();
+    });
+
+    it('should expand/collapse all accordions with "Expand all" button', () => {
+      expect(screen.getByTestId(testIds.generalInformation)).toHaveAttribute('open');
+
+      fireEvent.click(screen.getByTestId(testIds.expandAllButton));
+
+      expect(screen.getByTestId(testIds.generalInformation)).not.toHaveAttribute('open');
+    });
+
+    it('should render "AccordionSet"', () => {
+      expect(screen.getByTestId(testIds.accordionSet)).toBeVisible();
+    });
+
+    describe('"Accordion" open/close state', () => {
+      it('should be open by default', () => {
+        expect(screen.getByTestId(testIds.generalInformation)).toHaveAttribute('open');
+      });
+
+      it('should change from open to close', () => {
+        fireEvent.click(screen.getByTestId(testIds.accordionSet));
+
+        expect(screen.getByTestId(testIds.generalInformation)).not.toHaveAttribute('open');
+      });
+    });
+
+    describe('general information "Accordion"', () => {
+      it('should be rendered', () => {
+        const element = screen.getByTestId(testIds.generalInformation);
+
+        expect(element).toBeVisible();
+        expect(within(element).getByText(labelIds.general)).toBeVisible();
+      });
+
+      it('should render "Metadata" with passed props', () => {
+        const expectedResult = {
+          connect: mockedStripes.connect,
+          metadata: mockedInitialValues.metadata,
+        };
+
+        expect(Metadata).toHaveBeenLastCalledWith(expectedResult, {});
+      });
+
+      it('should contain "name" section with correct values', () => {
+        const element = screen.getByTestId(testIds.generalInformation);
+
+        expect(within(element).getByText(labelIds.name)).toBeVisible();
+        expect(within(element).getByText(mockedInitialValues.name)).toBeVisible();
+      });
+
+      it('should contain "description" section with correct values', () => {
+        const element = screen.getByTestId(testIds.generalInformation);
+
+        expect(within(element).getByText(labelIds.description)).toBeVisible();
+        expect(within(element).getByText(mockedInitialValues.description)).toBeVisible();
+      });
+
+      it('should contain "policy types" section with correct values', () => {
+        const element = screen.getByTestId(testIds.generalInformation);
+
+        expect(within(element).getByText(labelIds.types)).toBeVisible();
+      });
+
+      it('should execute "List" with passed props', () => {
+        const expectedResult = {
+          items: mockedInitialValues.requestTypes,
+          itemFormatter: requestTypeFormater,
+        };
+
+        expect(List).toHaveBeenLastCalledWith(expectedResult, {});
+      });
+    });
+  });
+
+  describe('with empty "initialValues"', () => {
+    beforeEach(() => {
+      render(
+        <RequestPolicyDetail
+          stripes={mockedStripes}
+        />
+      );
+    });
+
+    describe('general detail "Accordion"', () => {
+      it('should contain "description" section with correct values', () => {
+        const element = screen.getByTestId(testIds.generalInformation);
+
+        expect(within(element).getByText(labelIds.description)).toBeVisible();
+        expect(within(element).getByText('-')).toBeVisible();
+      });
+    });
+  });
+
+  describe('requestTypeFormater', () => {
+    it('should render element with passed props', () => {
+      render(requestTypeFormater(mockedInitialValues.requestTypes[0]));
+
+      expect(screen.getByText(mockedInitialValues.requestTypes[0])).toBeVisible();
+    });
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -78,6 +78,9 @@ jest.mock('@folio/stripes/components', () => ({
     children,
     ...rest
   }) => (<label htmlFor={htmlFor} id={id} {...rest}>{children}</label>)),
+  List: jest.fn(({
+    children,
+  }) => <div>{children}</div>),
   MessageBanner: jest.fn(({ children, ...rest }) => (
     <div {...rest}>{children}</div>
   )),


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `RequestPolicyDetail` component in `src\settings\RequestPolicy`

## Refs
https://issues.folio.org/browse/UICIRC-646

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/142004305-fbfc81ae-c66f-4545-a243-ca6879f02362.png)
