### PR TITLE
UICIRC-480: UI fee/fine date/time token previews are hard-coded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add RTL/Jest testing for `ExceptionCard` component in `settings/LoanHistory/ExceptionCard`. Refs UICIRC- 604.
 * Add RTL/Jest testing for `FixedDueDateScheduleDetail` component in `settings\FixedDueDateSchedule`. Refs UICIRC-608.
 * Add RTL/Jest testing for `RequestPolicyDetail` component in `src\settings\RequestPolicy`. Refs UICIRC-646.
+* UI fee/fine date/time token previews are hard-coded. Refs UICIRC-480.
 
 ## [6.0.0] (https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/PatronNotices/PatronNoticeDetail.js
+++ b/src/settings/PatronNotices/PatronNoticeDetail.js
@@ -14,7 +14,7 @@ import {
 } from '@folio/stripes/components';
 import { PreviewModal, tokensReducer } from '@folio/stripes-template-editor';
 
-import tokens from './tokens';
+import getTokens from './tokens';
 
 class PatronNoticeDetail extends React.Component {
   static propTypes = {
@@ -62,12 +62,17 @@ class PatronNoticeDetail extends React.Component {
   render() {
     const {
       initialValues: notice,
-      intl: { formatMessage },
+      intl: {
+        formatMessage,
+        locale,
+      },
     } = this.props;
     const {
       accordions,
       openPreview,
     } = this.state;
+
+    const tokens = getTokens(locale);
 
     const emailTemplate = get(notice, 'localizedTemplates.en.body', '');
     const parsedEmailTemplate = this.parser.parseWithInstructions(emailTemplate, () => true, this.rules);

--- a/src/settings/PatronNotices/PatronNoticeForm.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.js
@@ -22,7 +22,7 @@ import {
 import stripesFinalForm from '@folio/stripes/final-form';
 import { TemplateEditor } from '@folio/stripes-template-editor';
 
-import tokens from './tokens';
+import getTokens from './tokens';
 import TokensList from './TokensList';
 import { patronNoticeCategories } from '../../constants';
 import {
@@ -145,10 +145,13 @@ class PatronNoticeForm extends React.Component {
     const {
       handleSubmit,
       initialValues,
-      intl: { formatMessage },
+      intl: {
+        formatMessage,
+        locale,
+      },
       form: { getFieldState }
     } = this.props;
-
+    const tokens = getTokens(locale);
     const isActive = initialValues && initialValues.active;
     const category = getFieldState('category')?.value;
 

--- a/src/settings/PatronNotices/TokensList/TokensList.test.js
+++ b/src/settings/PatronNotices/TokensList/TokensList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isString } from 'lodash';
+
 import {
   screen,
   render,
@@ -8,8 +8,10 @@ import {
 
 import '../../../../test/jest/__mock__';
 
-import tokensProps from '../tokens';
 import TokensList from './TokensList';
+import getTokensProps from '../tokens';
+
+import { LOCALE_FOR_TESTS } from '../utils/constantsForMoment';
 
 jest.mock('@folio/stripes-template-editor', () => ({
   TokensSection: jest.fn(({
@@ -61,8 +63,10 @@ jest.mock('@folio/stripes-template-editor', () => ({
         )}
       </ul>
     </div>
-  ))
+  )),
 }));
+
+const tokensProps = getTokensProps(LOCALE_FOR_TESTS);
 
 const testTokensSection = (sectionTestId) => {
   describe(`View ${sectionTestId} TokensSection`, () => {
@@ -113,5 +117,3 @@ describe('View TokensList', () => {
     testTokensSection('feeFineAction');
   });
 });
-
-

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -1,6 +1,8 @@
 import { patronNoticeCategoryIds } from '../../constants';
+import { generatePreviewDateValue } from './utils';
+import { DATE_FORMAT_WITH_TIME } from './utils/constantsForMoment';
 
-const formats = {
+const getTokens = (locale) => ({
   item: [
     {
       token: 'item.title',
@@ -118,22 +120,22 @@ const formats = {
     },
     {
       token: 'request.requestExpirationDate',
-      previewValue: 'Mar 31 30, 2020',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [patronNoticeCategoryIds.REQUEST],
     },
     {
       token: 'request.requestExpirationDateTime',
-      previewValue: 'Mar 31, 2020 23:59',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [patronNoticeCategoryIds.REQUEST],
     },
     {
       token: 'request.holdShelfExpirationDate',
-      previewValue: 'Jun 30, 2020',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [patronNoticeCategoryIds.REQUEST],
     },
     {
       token: 'request.holdShelfExpirationDateTime',
-      previewValue: 'Jun 30, 2020 23:59',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [patronNoticeCategoryIds.REQUEST],
     },
     {
@@ -150,7 +152,7 @@ const formats = {
   loan: [
     {
       token: 'loan.dueDate',
-      previewValue: 'Dec 31, 2019',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -160,7 +162,7 @@ const formats = {
     },
     {
       token: 'loan.dueDateTime',
-      previewValue: 'Dec 31, 2019 22:00',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -170,7 +172,7 @@ const formats = {
     },
     {
       token: 'loan.initialBorrowDate',
-      previewValue: 'Jan 1, 2019',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -180,7 +182,7 @@ const formats = {
     },
     {
       token: 'loan.initialBorrowDateTime',
-      previewValue: 'Jan 1, 2019 11:00',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -190,7 +192,7 @@ const formats = {
     },
     {
       token: 'loan.checkedInDate',
-      previewValue: 'Dec 15, 2019',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -200,7 +202,7 @@ const formats = {
     },
     {
       token: 'loan.checkedInDateTime',
-      previewValue: 'Dec 15, 2019 13:24',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [
         patronNoticeCategoryIds.LOAN,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -294,7 +296,7 @@ const formats = {
     },
     {
       token: 'feeCharge.chargeDate',
-      previewValue: 'Jun 30, 2020',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -304,7 +306,7 @@ const formats = {
     },
     {
       token: 'feeCharge.chargeDateTime',
-      previewValue: 'Jun 30, 2020 11:00',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
@@ -352,7 +354,7 @@ const formats = {
     },
     {
       token: 'feeAction.actionDate',
-      previewValue: 'Jul 10, 2020',
+      previewValue: generatePreviewDateValue(locale),
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_ACTION,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_ADJUSTMENT,
@@ -360,7 +362,7 @@ const formats = {
     },
     {
       token: 'feeAction.actionDateTime',
-      previewValue: 'Jul 10, 2020 8:00',
+      previewValue: generatePreviewDateValue(locale, DATE_FORMAT_WITH_TIME),
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_ACTION,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_ADJUSTMENT,
@@ -391,6 +393,7 @@ const formats = {
       ],
     },
   ],
-};
+});
 
-export default formats;
+
+export default getTokens;

--- a/src/settings/PatronNotices/tokens.test.js
+++ b/src/settings/PatronNotices/tokens.test.js
@@ -1,0 +1,110 @@
+import getTokens from './tokens';
+import {
+  DATE_FORMAT_WITHOUT_TIME,
+  DATE_FORMAT_WITH_TIME,
+} from './utils/constantsForMoment';
+
+jest.mock('./utils', () => ({
+  generatePreviewDateValue: jest.fn((locale, format = 'll') => ({
+    locale,
+    format,
+  })),
+}));
+
+describe('getTokens', () => {
+  const testLocale = 'testLocale';
+  const expectedShortResult = {
+    locale: testLocale,
+    format: DATE_FORMAT_WITHOUT_TIME,
+  };
+  const expectedLongResult = {
+    locale: testLocale,
+    format: DATE_FORMAT_WITH_TIME,
+  };
+  const fieldsForCheck = [
+    {
+      category: 'request',
+      name: 'request.requestExpirationDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'request',
+      name: 'request.requestExpirationDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'request',
+      name: 'request.holdShelfExpirationDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'request',
+      name: 'request.holdShelfExpirationDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.dueDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.dueDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.initialBorrowDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.initialBorrowDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.checkedInDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'loan',
+      name: 'loan.checkedInDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'feeFineCharge',
+      name: 'feeCharge.chargeDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'feeFineCharge',
+      name: 'feeCharge.chargeDateTime',
+      expectedResult: expectedLongResult,
+    },
+    {
+      category: 'feeFineAction',
+      name: 'feeAction.actionDate',
+      expectedResult: expectedShortResult,
+    },
+    {
+      category: 'feeFineAction',
+      name: 'feeAction.actionDateTime',
+      expectedResult: expectedLongResult,
+    },
+  ];
+  const result = getTokens(testLocale);
+  const tokenTest = ({
+    category,
+    name,
+    expectedResult,
+  }) => {
+    it(`should have correctly preview value for ${name} token`, () => {
+      const tokenForCheck = result[category].find(element => element.token === name);
+
+      expect(tokenForCheck.previewValue).toEqual(expectedResult);
+    });
+  };
+
+  fieldsForCheck.forEach(tokenTest);
+});

--- a/src/settings/PatronNotices/utils/constantsForMoment.js
+++ b/src/settings/PatronNotices/utils/constantsForMoment.js
@@ -1,0 +1,4 @@
+export const DATE_FORMAT_WITHOUT_TIME = 'll';
+export const DATE_FORMAT_WITH_TIME = 'lll';
+
+export const LOCALE_FOR_TESTS = 'en';

--- a/src/settings/PatronNotices/utils/index.js
+++ b/src/settings/PatronNotices/utils/index.js
@@ -1,0 +1,2 @@
+export { default as generatePreviewDateValue } from './preview';
+export { default as template } from './template';

--- a/src/settings/PatronNotices/utils/preview.js
+++ b/src/settings/PatronNotices/utils/preview.js
@@ -1,0 +1,9 @@
+import moment from 'moment';
+
+import { DATE_FORMAT_WITHOUT_TIME } from './constantsForMoment';
+
+const generatePreviewDateValue = (locale, formatToTransform = DATE_FORMAT_WITHOUT_TIME) => (
+  moment().locale(locale).format(formatToTransform)
+);
+
+export default generatePreviewDateValue;

--- a/src/settings/PatronNotices/utils/preview.test.js
+++ b/src/settings/PatronNotices/utils/preview.test.js
@@ -1,0 +1,29 @@
+import moment from 'moment';
+
+import generatePreviewDateValue from './preview';
+
+import {
+  DATE_FORMAT_WITHOUT_TIME,
+  DATE_FORMAT_WITH_TIME,
+  LOCALE_FOR_TESTS,
+} from './constantsForMoment';
+
+describe('generatePreviewDateValue', () => {
+  it('should return formated date for passed locale in short format when second prop is not passed', () => {
+    const expectedResult = moment().locale(LOCALE_FOR_TESTS).format(DATE_FORMAT_WITHOUT_TIME);
+
+    expect(generatePreviewDateValue(LOCALE_FOR_TESTS)).toEqual(expectedResult);
+  });
+
+  it('should return formated date for passed locale in short format', () => {
+    const expectedResult = moment().locale(LOCALE_FOR_TESTS).format(DATE_FORMAT_WITHOUT_TIME);
+
+    expect(generatePreviewDateValue(LOCALE_FOR_TESTS, DATE_FORMAT_WITHOUT_TIME)).toEqual(expectedResult);
+  });
+
+  it('should return formated date for passed locale in long format', () => {
+    const expectedResult = moment().locale(LOCALE_FOR_TESTS).format(DATE_FORMAT_WITH_TIME);
+
+    expect(generatePreviewDateValue(LOCALE_FOR_TESTS, DATE_FORMAT_WITH_TIME)).toEqual(expectedResult);
+  });
+});

--- a/src/settings/PatronNotices/utils/template.js
+++ b/src/settings/PatronNotices/utils/template.js
@@ -1,4 +1,4 @@
-export function template(str) {
+function template(str) {
   return (o) => {
     return str.replace(/{{([^{}]*)}}/g, (a, b) => {
       const r = o[b];
@@ -7,4 +7,4 @@ export function template(str) {
   };
 }
 
-export default {};
+export default template;

--- a/test/jest/__mock__/intl.mock.js
+++ b/test/jest/__mock__/intl.mock.js
@@ -3,6 +3,7 @@ import React from 'react';
 jest.mock('react-intl', () => {
   const intl = {
     formatMessage: ({ id }) => id,
+    locale: 'en',
   };
 
   return {


### PR DESCRIPTION
## Purpose
UI fee/fine date/time token previews are hard-coded.

## Approach
Now we set preview values depends on tenant locale. This locale we get from `intl.locale`.
Below I attached two screenshots for different locales. 

## Refs
https://issues.folio.org/browse/UICIRC-480

## Screenshots
For en-US locale:
![image](https://user-images.githubusercontent.com/88130496/145770140-3f62f0c4-133c-4164-935e-5d99d2e8effd.png)

For en-GB locale:
![image](https://user-images.githubusercontent.com/88130496/145770305-76f68f08-3bfa-4f44-a5a4-22c0d2a6a2d5.png)

