### PR TITLE
UICIRC-592: Add Jest/RTL tests for `CheckoutSettings` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add RTL/Jest testing for `RequestPolicyDetail` component in `src\settings\RequestPolicy`. Refs UICIRC-646.
 * UI fee/fine date/time token previews are hard-coded. Refs UICIRC-480.
 * Also support `circulation` `12.0`. Refs UICIRC-729.
+* Add RTL/Jest testing for `CheckoutSettings` component in `src/settings/CheckoutSettings`. Refs UICIRC-592.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/CheckoutSettings/CheckoutSettings.js
+++ b/src/settings/CheckoutSettings/CheckoutSettings.js
@@ -1,18 +1,102 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import {
   head,
   isEmpty,
 } from 'lodash';
+import PropTypes from 'prop-types';
 
 import { stripesShape, withStripes } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
 import CheckoutSettingsForm from './CheckoutSettingsForm';
 
+export const DEFAULT_INITIAL_CONFIG = {
+  audioAlertsEnabled: false,
+  audioTheme: 'classic',
+  checkoutTimeout: true,
+  checkoutTimeoutDuration: 3,
+  prefPatronIdentifier: '',
+  useCustomFieldsAsIdentifiers: false,
+};
+
+export const getInitialValues = (settings) => {
+  let config;
+
+  const value = isEmpty(settings) ? '' : head(settings).value;
+
+  try {
+    config = { ...DEFAULT_INITIAL_CONFIG, ...JSON.parse(value) };
+  } catch (e) {
+    config = DEFAULT_INITIAL_CONFIG;
+  }
+
+  // This section unfortunately must assume knowledge of how the IDs and Custom Field IDs
+  // are rendered in CheckoutSettingsForm. IDs can be toggled on and off by a checkbox,
+  // but because there can be /a lot/ of custom fields, the custom fields to use as a checkout ID
+  // must be selected by a multiselect. As a result, we need to split out those customFields
+  // into the `custom` object.
+  const { prefPatronIdentifier } = config;
+  const identifiers = { custom: [] };
+  (prefPatronIdentifier ? prefPatronIdentifier.split(',') : []).forEach(identifier => {
+    if (identifier.startsWith('customFields.')) {
+      identifiers.custom.push({ value: identifier });
+    } else {
+      identifiers[identifier] = true;
+    }
+  });
+
+  return {
+    audioAlertsEnabled: config.audioAlertsEnabled,
+    audioTheme: config.audioTheme,
+    checkoutTimeout: config.checkoutTimeout,
+    checkoutTimeoutDuration: config.checkoutTimeoutDuration,
+    identifiers,
+    useCustomFieldsAsIdentifiers: config.useCustomFieldsAsIdentifiers,
+  };
+};
+
+export const normalize = ({
+  audioAlertsEnabled,
+  audioTheme,
+  checkoutTimeout,
+  checkoutTimeoutDuration,
+  identifiers,
+  useCustomFieldsAsIdentifiers,
+}) => {
+  // As in `getInitialValues`, we must assume knowledge of how the IDs and Custom Field IDs
+  // are rendered in CheckoutSettingsForm. IDs can be toggled on and off by a checkbox,
+  // but because there can be /a lot/ of custom fields, the custom fields to use as a checkout ID
+  // must be selected by a multiselect. As a result, here we need to merge the custom field IDs
+  // with the regular IDs before we `join` it all into a string.
+  const { custom: customFieldIdentifiers, ...defaultIdentifers } = identifiers;
+  const selectedDefaultPatronIdentifiers = Object.entries(defaultIdentifers)
+    .filter(([_key, value]) => value === true)
+    .map(([key]) => key);
+
+  const selectedCustomFieldPatronIdentifiers = customFieldIdentifiers.map(i => i.value);
+
+  const prefPatronIdentifier = [
+    ...selectedDefaultPatronIdentifiers,
+    ...selectedCustomFieldPatronIdentifiers,
+  ].join(',');
+
+  const otherSettings = JSON.stringify({
+    audioAlertsEnabled,
+    audioTheme,
+    checkoutTimeout,
+    checkoutTimeoutDuration: parseInt(checkoutTimeoutDuration, 10),
+    prefPatronIdentifier,
+    useCustomFieldsAsIdentifiers,
+  });
+
+  return otherSettings;
+};
+
 class CheckoutSettings extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -21,101 +105,21 @@ class CheckoutSettings extends React.Component {
     this.configManager = props.stripes.connect(ConfigManager);
   }
 
-  getInitialValues(settings) {
-    let config;
-
-    const value = isEmpty(settings) ? '' : head(settings).value;
-
-    const defaultConfig = {
-      audioAlertsEnabled: false,
-      audioTheme: 'classic',
-      checkoutTimeout: true,
-      checkoutTimeoutDuration: 3,
-      prefPatronIdentifier: '',
-      useCustomFieldsAsIdentifiers: false,
-    };
-
-    try {
-      config = { ...defaultConfig, ...JSON.parse(value) };
-    } catch (e) {
-      config = defaultConfig;
-    }
-
-    // This section unfortunately must assume knowledge of how the IDs and Custom Field IDs
-    // are rendered in CheckoutSettingsForm. IDs can be toggled on and off by a checkbox,
-    // but because there can be /a lot/ of custom fields, the custom fields to use as a checkout ID
-    // must be selected by a multiselect. As a result, we need to split out those customFields
-    // into the `custom` object.
-    const { prefPatronIdentifier } = config;
-    const identifiers = { custom: [] };
-    (prefPatronIdentifier ? prefPatronIdentifier.split(',') : []).forEach(identifier => {
-      if (identifier.startsWith('customFields.')) {
-        identifiers.custom.push({ value: identifier });
-      } else {
-        identifiers[identifier] = true;
-      }
-    });
-
-    return {
-      audioAlertsEnabled: config.audioAlertsEnabled,
-      audioTheme: config.audioTheme,
-      checkoutTimeout: config.checkoutTimeout,
-      checkoutTimeoutDuration: config.checkoutTimeoutDuration,
-      identifiers,
-      useCustomFieldsAsIdentifiers: config.useCustomFieldsAsIdentifiers,
-    };
-  }
-
-  normalize = ({
-    audioAlertsEnabled,
-    audioTheme,
-    checkoutTimeout,
-    checkoutTimeoutDuration,
-    identifiers,
-    useCustomFieldsAsIdentifiers,
-  }) => {
-    // As in `getInitialValues`, we must assume knowledge of how the IDs and Custom Field IDs
-    // are rendered in CheckoutSettingsForm. IDs can be toggled on and off by a checkbox,
-    // but because there can be /a lot/ of custom fields, the custom fields to use as a checkout ID
-    // must be selected by a multiselect. As a result, here we need to merge the custom field IDs
-    // with the regular IDs before we `join` it all into a string.
-    const { custom: customFieldIdentifiers, ...defaultIdentifers } = identifiers;
-    const selectedDefaultPatronIdentifiers = Object.entries(defaultIdentifers)
-      .filter(([_key, value]) => value === true)
-      .map(([key]) => key);
-
-    const selectedCustomFieldPatronIdentifiers = customFieldIdentifiers.map(i => i.value);
-
-    const prefPatronIdentifier = [
-      ...selectedDefaultPatronIdentifiers,
-      ...selectedCustomFieldPatronIdentifiers,
-    ].join(',');
-
-    const otherSettings = JSON.stringify({
-      audioAlertsEnabled,
-      audioTheme,
-      checkoutTimeout,
-      checkoutTimeoutDuration: parseInt(checkoutTimeoutDuration, 10),
-      prefPatronIdentifier,
-      useCustomFieldsAsIdentifiers,
-    });
-
-    return otherSettings;
-  };
-
   render() {
+    const { formatMessage } = this.props.intl;
+
     return (
       <this.configManager
-        label={<FormattedMessage id="ui-circulation.settings.index.otherSettings" />}
+        label={formatMessage({ id: 'ui-circulation.settings.index.otherSettings' })}
         moduleName="CHECKOUT"
         configName="other_settings"
-        getInitialValues={this.getInitialValues}
+        getInitialValues={getInitialValues}
         configFormComponent={CheckoutSettingsForm}
         stripes={this.props.stripes}
-        onBeforeSave={this.normalize}
+        onBeforeSave={normalize}
       />
     );
   }
 }
 
-export default withStripes(CheckoutSettings);
+export default injectIntl(withStripes(CheckoutSettings));

--- a/src/settings/CheckoutSettings/CheckoutSettings.test.js
+++ b/src/settings/CheckoutSettings/CheckoutSettings.test.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { omit } from 'lodash';
+
+import '../../../test/jest/__mock__';
+
+import { ConfigManager } from '@folio/stripes/smart-components';
+
+import CheckoutSettings, {
+  DEFAULT_INITIAL_CONFIG,
+  getInitialValues,
+  normalize,
+} from './CheckoutSettings';
+import CheckoutSettingsForm from './CheckoutSettingsForm';
+
+describe('CheckoutSettings', () => {
+  const labelIds = {
+    otherSettings: 'ui-circulation.settings.index.otherSettings',
+  };
+  const mockedStripes = {
+    connect: jest.fn(component => component),
+  };
+
+  beforeEach(() => {
+    render(
+      <CheckoutSettings
+        stripes={mockedStripes}
+      />
+    );
+  });
+
+  it('should execute `ConfigManager` with passed props', () => {
+    const expectedResult = {
+      label: labelIds.otherSettings,
+      moduleName: 'CHECKOUT',
+      configName: 'other_settings',
+      getInitialValues,
+      configFormComponent: CheckoutSettingsForm,
+      stripes: mockedStripes,
+      onBeforeSave: normalize,
+    };
+
+    expect(ConfigManager).toHaveBeenCalledWith(expectedResult, {});
+  });
+});
+
+describe('getInitialValues', () => {
+  const defaultExpectedConfig = {
+    ...omit(DEFAULT_INITIAL_CONFIG, 'prefPatronIdentifier'),
+    identifiers: {
+      custom: [],
+    },
+  };
+
+  it('should return default expected config if `settings` is empty', () => {
+    expect(getInitialValues([])).toEqual(defaultExpectedConfig);
+  });
+
+  it('should return default expected config if invalid settings are passed', () => {
+    expect(getInitialValues([{ value: "{'settings':'testSettings'}" }])).toEqual(defaultExpectedConfig);
+  });
+
+  it('should correctly process passed `prefPatronIdentifier` field', () => {
+    const customField = 'customFields.testCustomField';
+    const commonField = 'testIdentifier';
+    const mockedConfigValue = {
+      prefPatronIdentifier: `${customField},${commonField}`,
+    };
+    const configForTest = [{
+      value: JSON.stringify(mockedConfigValue),
+    }];
+    const expectedResult = {
+      ...defaultExpectedConfig,
+      identifiers: {
+        custom: [
+          { value: customField },
+        ],
+        [commonField]: true,
+      },
+    };
+
+    expect(getInitialValues(configForTest)).toEqual(expectedResult);
+  });
+
+  it('should correctly pass fields from `settings`', () => {
+    const mockedConfig = {
+      audioAlertsEnabled: 'testAudioAlertsEnabled',
+      audioTheme: 'testAudioTheme',
+      checkoutTimeout: 'testCheckoutTimeout',
+      checkoutTimeoutDuration: 'testCheckoutTimeoutDuration',
+      useCustomFieldsAsIdentifiers: 'testUseCustomFieldsAsIdentifiers',
+    };
+    const configForTest = [{
+      value: JSON.stringify(mockedConfig),
+    }];
+    const expectedResult = {
+      ...mockedConfig,
+      identifiers: {
+        custom: [],
+      },
+    };
+
+    expect(getInitialValues(configForTest)).toEqual(expectedResult);
+  });
+});
+
+describe('normalize', () => {
+  it('should correctly process passed `identifiers` field', () => {
+    const identifiers = {
+      custom: [
+        { value: 'firstCustomIdentifire' },
+        { value: 'secondCustomIdentifire' },
+      ],
+      firstDefaultIdentifire: false,
+      secondDefaultIdentifire: true,
+    };
+    const expectedResult = [
+      'secondDefaultIdentifire',
+      'firstCustomIdentifire',
+      'secondCustomIdentifire',
+    ];
+    const result = normalize({ identifiers });
+
+    expect(JSON.parse(result)).toEqual(expect.objectContaining({ prefPatronIdentifier: expectedResult.join(',') }));
+  });
+
+  it('should correctly normalize `checkoutTimeoutDuration` field', () => {
+    const identifiers = {
+      custom: [],
+    };
+    const expectedResult = {
+      useCustomFieldsAsIdentifiers: '24',
+    };
+    const testConfig = {
+      ...expectedResult,
+      identifiers,
+    };
+    const result = normalize(testConfig);
+
+    expect(JSON.parse(result)).toEqual(expect.objectContaining(expectedResult));
+  });
+
+  it('should pass values as is', () => {
+    const identifiers = {
+      custom: [],
+    };
+    const expectedResult = {
+      audioAlertsEnabled: false,
+      audioTheme: 'testTheme',
+      checkoutTimeout: 20,
+      useCustomFieldsAsIdentifiers: true,
+    };
+    const testConfig = {
+      ...expectedResult,
+      identifiers,
+    };
+    const result = normalize(testConfig);
+
+    expect(JSON.parse(result)).toEqual(expect.objectContaining(expectedResult));
+  });
+});

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -3,4 +3,5 @@ import React from 'react';
 jest.mock('@folio/stripes/core', () => ({
   stripesConnect: jest.fn((component) => component),
   stripesShape: {},
+  withStripes: (Component) => (props) => <Component {...props} />,
 }));


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `CheckoutSettings` component in `src/settings/CheckoutSettings`.

## Refs
https://issues.folio.org/browse/UICIRC-592

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/147929101-c653c278-c784-4924-83f5-a48cf132b0a8.png)
