### PR TITLE
UICIRC-619: Add Jest/RTL tests for `LostItemFeePolicyForm` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Also support `circulation` `12.0`. Refs UICIRC-729.
 * Add RTL/Jest testing for `CheckoutSettings` component in `src/settings/CheckoutSettings`. Refs UICIRC-592.
 * Add RTL/Jest testing for `NoticePolicyDetail` component in `src/settings/NoticePolicy`. Refs UICIRC-629.
+* Add RTL/Jest testing for `LostItemFeePolicyForm` component in `src/settings/LostItemFeePolicy`. Refs UICIRC-619.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import { stripesShape } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -40,6 +40,7 @@ class LostItemFeePolicyForm extends React.Component {
     form: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -81,6 +82,9 @@ class LostItemFeePolicyForm extends React.Component {
         getState,
       },
       onCancel,
+      intl : {
+        formatMessage,
+      },
     } = this.props;
 
     const { sections } = this.state;
@@ -88,7 +92,7 @@ class LostItemFeePolicyForm extends React.Component {
     const { values } = getState();
     const policy = new LostItemFeePolicy(values);
 
-    const panelTitle = policy.id ? policy.name : <FormattedMessage id="ui-circulation.settings.lostItemFee.entryLabel" />;
+    const panelTitle = policy.id ? policy.name : formatMessage({ id: 'ui-circulation.settings.lostItemFee.entryLabel' });
     const footerPaneProps = {
       pristine,
       submitting,
@@ -97,6 +101,7 @@ class LostItemFeePolicyForm extends React.Component {
 
     return (
       <form
+        data-testid="lostItemFeePolicyForm"
         noValidate
         data-test-lost-item-fee-policy-form
         onSubmit={handleSubmit}
@@ -121,11 +126,12 @@ class LostItemFeePolicyForm extends React.Component {
                 </Col>
               </Row>
               <AccordionSet
+                data-testid="generalSectionSet"
                 onToggle={this.handleSectionToggle}
               >
                 <Accordion
                   id="lostItemFeeFormGeneralSection"
-                  label={<FormattedMessage id="ui-circulation.settings.lostItemFee.generalInformation" />}
+                  label={formatMessage({ id: 'ui-circulation.settings.lostItemFee.generalInformation' })}
                   open={sections.lostItemFeeFormGeneralSection}
                 >
                   <Metadata
@@ -152,4 +158,4 @@ class LostItemFeePolicyForm extends React.Component {
 export default stripesFinalForm({
   navigationCheck: true,
   validate: model => validateLostItemFeePolicy(transformModelBooleans(model)),
-})(LostItemFeePolicyForm);
+})(injectIntl(LostItemFeePolicyForm));

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.test.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.test.js
@@ -1,0 +1,256 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  Accordion,
+  AccordionSet,
+  ExpandAllButton,
+  Pane,
+} from '@folio/stripes/components';
+
+import LostItemFeePolicyForm from './LostItemFeePolicyForm';
+import {
+  LostItemFeeAboutSection,
+  LostItemFeeSection,
+} from './components/EditSections';
+import {
+  CancelButton,
+  FooterPane,
+  Metadata,
+} from '../components';
+import LostItemFeePolicy from '../Models/LostItemFeePolicy';
+
+jest.mock('@folio/stripes/final-form', () => jest.fn(() => (Component) => Component));
+jest.mock('./components/EditSections', () => ({
+  LostItemFeeAboutSection: jest.fn(() => null),
+  LostItemFeeSection: jest.fn(() => null),
+}));
+jest.mock('../components', () => ({
+  CancelButton: jest.fn(() => null),
+  FooterPane: jest.fn(() => null),
+  Metadata: jest.fn(() => null),
+}));
+
+AccordionSet.mockImplementation(jest.fn(({
+  children,
+  onToggle,
+  'data-testid': testId,
+}) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    data-testid={testId}
+    onClick={() => onToggle({ id: 'lostItemFeeFormGeneralSection' })}
+  >
+    {children}
+  </div>
+)));
+ExpandAllButton.mockImplementation(jest.fn(({
+  accordionStatus,
+  onToggle,
+}) => {
+  const sectionKeys = Object.keys(accordionStatus);
+  const sectionStatus = {};
+
+  sectionKeys.forEach(key => {
+    sectionStatus[key] = !accordionStatus[key];
+  });
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      onClick={() => onToggle(sectionStatus)}
+    >
+      Expand all button
+    </div>
+  );
+}));
+Pane.mockImplementation(jest.fn(({
+  children,
+  firstMenu,
+  footer,
+}) => (
+  <div>
+    {firstMenu}
+    {children}
+    {footer}
+  </div>
+)));
+
+describe('LostItemFeePolicyForm', () => {
+  const testIds = {
+    lostItemFeePolicyForm: 'lostItemFeePolicyForm',
+    generalSectionSet: 'generalSectionSet',
+  };
+  const labelIds = {
+    entryLabel: 'ui-circulation.settings.lostItemFee.entryLabel',
+    generalInformation: 'ui-circulation.settings.lostItemFee.generalInformation',
+    expandAllButton: 'Expand all button',
+  };
+  const mockedStripes = {
+    connect: jest.fn(),
+  };
+  const mockedInitialValues = {
+    id: 'testId',
+    name: 'testName',
+    description: 'testDescription',
+    metadata: {
+      createdByUserId: 'testUserId',
+      createdDate: new Date(),
+      updatedByUserId: 'testUserId',
+      updatedDate: new Date(),
+    },
+  };
+  const mockedForm = {
+    change: jest.fn(),
+    getState: jest.fn(() => ({ values: mockedInitialValues })),
+  };
+  const mockedHandleSubmit = jest.fn();
+  const mockedOnCancel = jest.fn();
+  const policyForTest = new LostItemFeePolicy(mockedInitialValues);
+  const defaultProps = {
+    stripes: mockedStripes,
+    pristine: true,
+    submitting: false,
+    initialValues: mockedInitialValues,
+    form: mockedForm,
+    handleSubmit: mockedHandleSubmit,
+    onCancel: mockedOnCancel,
+  };
+
+  beforeEach(() => {
+    render(
+      <LostItemFeePolicyForm
+        {...defaultProps}
+      />
+    );
+  });
+
+  afterEach(() => {
+    Accordion.mockClear();
+    AccordionSet.mockClear();
+    ExpandAllButton.mockClear();
+    Pane.mockClear();
+    LostItemFeeAboutSection.mockClear();
+    LostItemFeeSection.mockClear();
+    CancelButton.mockClear();
+    FooterPane.mockClear();
+    Metadata.mockClear();
+  });
+
+  it('should call "handleSubmit" on form submit', () => {
+    expect(mockedHandleSubmit).not.toHaveBeenCalled();
+
+    fireEvent.submit(screen.getByTestId(testIds.lostItemFeePolicyForm));
+
+    expect(mockedHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('should execute "CancelButton" with passed props', () => {
+    expect(CancelButton).toHaveBeenCalledWith({
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should execute "FooterPane" with passed props', () => {
+    expect(FooterPane).toHaveBeenCalledWith({
+      pristine: true,
+      submitting: false,
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should have "ExpandAllButton" in the document', () => {
+    expect(screen.getByText(labelIds.expandAllButton)).toBeInTheDocument();
+  });
+
+  it('should correctly toogle sections status on "ExpandAllButton" click', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: true,
+    }), {});
+    expect(LostItemFeeSection).toHaveBeenCalledWith(expect.objectContaining({
+      lostItemFeeSectionOpen: true,
+    }), {});
+
+    fireEvent.click(screen.getByText(labelIds.expandAllButton));
+
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: false,
+    }), {});
+    expect(LostItemFeeSection).toHaveBeenCalledWith(expect.objectContaining({
+      lostItemFeeSectionOpen: false,
+    }), {});
+  });
+
+  it('"AccordionSet" should correctly handle section status toggle', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: true,
+    }), {});
+
+    fireEvent.click(screen.getByTestId(testIds.generalSectionSet));
+
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: false,
+    }), {});
+  });
+
+  it('should execute "Accordion" with passed props', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      label: labelIds.generalInformation,
+      open: true,
+    }), {});
+  });
+
+  it('should execute "Metadata" with passed props', () => {
+    expect(Metadata).toHaveBeenCalledWith({
+      connect: mockedStripes.connect,
+      metadata: policyForTest.metadata,
+    }, {});
+  });
+
+  it('should execute "LostItemFeeAboutSection"', () => {
+    expect(LostItemFeeAboutSection).toHaveBeenCalled();
+  });
+
+  it('should execute "LostItemFeeSection" with passed props', () => {
+    expect(LostItemFeeSection).toHaveBeenCalledWith({
+      policy: policyForTest,
+      change: mockedForm.change,
+      initialValues: mockedInitialValues,
+      lostItemFeeSectionOpen: true,
+    }, {});
+  });
+
+  describe('when values for policy are passed', () => {
+    it('should execute "Pane" with correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: policyForTest.name,
+      }), {});
+    });
+  });
+
+  describe('when values for policy are not passed', () => {
+    beforeEach(() => {
+      render(
+        <LostItemFeePolicyForm
+          {...defaultProps}
+          form={{
+            change: jest.fn(),
+            getState: jest.fn(() => ({})),
+          }}
+        />
+      );
+    });
+
+    it('should execute "Pane" with correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: labelIds.entryLabel,
+      }), {});
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LostItemFeePolicyForm` component in `src/settings/LostItemFeePolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-619

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/148937789-30805f5d-1628-4066-b88e-1e75759543cc.png)
