### PR TITLE
UICIRC-732: Also support circulation 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add RTL/Jest testing for `LoanHistoryForm` component in `src/settings/LoanHistory`. Refs UICIRC-606.
 * Add RTL/Jest testing for `FinePolicyDetail` component in `src/settings/FinePolicy`. Refs UICIRC-738.
 * Add RTL/Jest testing for `FixedDueDateScheduleManager` component in `src/settings/FixedDueDateSchedule`. Refs UICIRC-600.
+* Also support `circulation` `13.0`. Refs UICIRC-732.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "@folio/stripes-template-editor"
     ],
     "okapiInterfaces": {
-      "circulation": "9.0 10.0 11.0 12.0",
+      "circulation": "9.0 10.0 11.0 12.0 13.0",
       "configuration": "2.0",
       "fixed-due-date-schedules-storage": "2.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
## Purpose
Support okapi interfaces `circulation` `13.0`

## Approach
* Title level requests changes affect ui-requests (UIREQ) without breaking change for this module.
* Was changed API associated with request queue.

## Refs
https://issues.folio.org/browse/UICIRC-732