### PR TITLE
UICIRC-630: Add Jest/RTL tests for `NoticePolicyForm` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Add RTL/Jest testing for `CheckoutSettings` component in `src/settings/CheckoutSettings`. Refs UICIRC-592.
 * Add RTL/Jest testing for `NoticePolicyDetail` component in `src/settings/NoticePolicy`. Refs UICIRC-629.
 * Add RTL/Jest testing for `LostItemFeePolicyForm` component in `src/settings/LostItemFeePolicy`. Refs UICIRC-619.
+* Add RTL/Jest testing for `NoticePolicyForm` component in `src/settings/NoticePolicy`. Refs UICIRC-630.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/NoticePolicy/NoticePolicyForm.js
+++ b/src/settings/NoticePolicy/NoticePolicyForm.js
@@ -98,6 +98,7 @@ class NoticePolicyForm extends React.Component {
 
     return (
       <form
+        data-testid="form"
         data-test-notice-policy-form
         className={css.noticePolicyForm}
         noValidate
@@ -122,6 +123,7 @@ class NoticePolicyForm extends React.Component {
               </Col>
             </Row>
             <AccordionSet
+              data-testid="accordionSet"
               accordionStatus={sections}
               onToggle={this.handleSectionToggle}
             >

--- a/src/settings/NoticePolicy/NoticePolicyForm.test.js
+++ b/src/settings/NoticePolicy/NoticePolicyForm.test.js
@@ -1,0 +1,277 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  ExpandAllButton,
+  AccordionSet,
+  Pane,
+} from '@folio/stripes/components';
+
+import NoticePolicyForm from './NoticePolicyForm';
+import {
+  GeneralSection,
+  LoanNoticesSection,
+  FeeFineNoticesSection,
+  RequestNoticesSection,
+} from './components';
+import {
+  FooterPane,
+  CancelButton,
+} from '../components';
+import { NoticePolicy } from '../Models/NoticePolicy';
+import { patronNoticeCategoryIds } from '../../constants';
+
+jest.mock('@folio/stripes/final-form', () => jest.fn(() => (component) => component));
+jest.mock('./components', () => ({
+  GeneralSection: jest.fn(() => null),
+  LoanNoticesSection: jest.fn(() => null),
+  FeeFineNoticesSection: jest.fn(() => null),
+  RequestNoticesSection: jest.fn(() => null),
+}));
+jest.mock('../components', () => ({
+  FooterPane: jest.fn(() => null),
+  CancelButton: jest.fn(() => null),
+}));
+jest.mock('./utils/get-templates', () => jest.fn((templates, categoryIds) => (
+  {
+    templates,
+    categoryIds,
+  }
+)));
+
+Pane.mockImplementation(jest.fn(({
+  paneTitle,
+  firstMenu,
+  children,
+  footer,
+}) => (
+  <div>
+    {paneTitle}
+    {firstMenu}
+    {children}
+    {footer}
+  </div>
+)));
+ExpandAllButton.mockImplementation(jest.fn(({ onToggle, ...rest }) => {
+  const sections = {
+    general: false,
+    editLoanNotices: false,
+    editRequestNotices: false,
+    editFeeFineNotices: false,
+  };
+
+  return (
+    <button
+      onClick={() => onToggle(sections)}
+      type="button"
+      {...rest}
+    >
+        Expand all button
+    </button>
+  );
+}));
+AccordionSet.mockImplementation(jest.fn(({ children, onToggle, ...rest }) => {
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      onClick={() => onToggle({ id: 'general' })}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}));
+
+describe('NoticePolicyForm', () => {
+  const testIds = {
+    form: 'form',
+    accordionSet: 'accordionSet',
+  };
+  const labelIds = {
+    createEntryLabel: 'ui-circulation.settings.noticePolicy.createEntryLabel',
+    expandAllButton: 'Expand all button',
+  };
+  const mockedValuesForPolicy = {
+    id: 'testPolicyId',
+    active: 'testPolicyActive',
+    name: 'testPolicyName',
+    description: 'testPolicyDescription',
+    metadata: 'testPolicyMetadata',
+  };
+  const mockedForm = {
+    getState: jest.fn(() => ({ values: mockedValuesForPolicy })),
+  };
+  const mockedStripes = {
+    connect: jest.fn(),
+  };
+  const mockedTemplates = ['testTemplate'];
+  const mockedParentResources = {
+    templates: {
+      records: mockedTemplates,
+    },
+  };
+  const mockedOnSave = jest.fn();
+  const mockedOnCancel = jest.fn();
+  const mockedHandleSubmit = jest.fn();
+  const mockedPolicy = new NoticePolicy(mockedValuesForPolicy);
+  const defaultProps = {
+    form: mockedForm,
+    stripes: mockedStripes,
+    pristine: true,
+    submitting: false,
+    parentResources: mockedParentResources,
+    onSave: mockedOnSave,
+    onCancel: mockedOnCancel,
+    handleSubmit: mockedHandleSubmit,
+  };
+  const componentSections = [
+    GeneralSection,
+    LoanNoticesSection,
+    RequestNoticesSection,
+    FeeFineNoticesSection,
+  ];
+  const isSectionsOpenOrClosed = (isOpen) => {
+    componentSections.forEach(section => {
+      expect(section).toHaveBeenLastCalledWith(expect.objectContaining({
+        isOpen,
+      }), {});
+    });
+  };
+
+  beforeEach(() => {
+    render(
+      <NoticePolicyForm
+        {...defaultProps}
+      />
+    );
+  });
+
+  afterEach(() => {
+    GeneralSection.mockClear();
+    LoanNoticesSection.mockClear();
+    RequestNoticesSection.mockClear();
+    FeeFineNoticesSection.mockClear();
+    CancelButton.mockClear();
+    FooterPane.mockClear();
+  });
+
+  it('should correctly handle form submit', () => {
+    expect(mockedHandleSubmit).not.toHaveBeenCalled();
+
+    fireEvent.submit(screen.getByTestId(testIds.form));
+
+    expect(mockedHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('should execute "CancelButton" with passed props', () => {
+    expect(CancelButton).toHaveBeenCalledWith({
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should execute "FooterPane" with passed props', () => {
+    expect(FooterPane).toHaveBeenCalledWith({
+      pristine: true,
+      submitting: false,
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should have "ExpandAllButton" in the document', () => {
+    expect(screen.getByText(labelIds.expandAllButton)).toBeInTheDocument();
+  });
+
+  it('should correctly toogle sections status on "ExpandAllButton" click', () => {
+    isSectionsOpenOrClosed(true);
+
+    fireEvent.click(screen.getByText(labelIds.expandAllButton));
+
+    isSectionsOpenOrClosed(false);
+  });
+
+  it('"AccordionSet" should correctly handle section status toggle', () => {
+    expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+      isOpen: true,
+    }), {});
+
+    fireEvent.click(screen.getByTestId(testIds.accordionSet));
+
+    expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+      isOpen: false,
+    }), {});
+  });
+
+  it('should execute "GeneralSection" with passed props', () => {
+    expect(GeneralSection).toHaveBeenCalledWith({
+      isOpen: true,
+      metadata: mockedPolicy.metadata,
+      connect: mockedStripes.connect,
+      isPolicyActive: mockedPolicy.active,
+    }, {});
+  });
+
+  it('should execute "LoanNoticesSection" with passed props', () => {
+    expect(LoanNoticesSection).toHaveBeenCalledWith({
+      isOpen: true,
+      policy: mockedPolicy,
+      templates: {
+        templates: mockedTemplates,
+        categoryIds: [patronNoticeCategoryIds.LOAN],
+      },
+    }, {});
+  });
+
+  it('should execute "RequestNoticesSection" with passed props', () => {
+    expect(RequestNoticesSection).toHaveBeenCalledWith({
+      isOpen: true,
+      policy: mockedPolicy,
+      templates: {
+        templates: mockedTemplates,
+        categoryIds: [patronNoticeCategoryIds.REQUEST],
+      },
+    }, {});
+  });
+
+  it('should execute "FeeFineNoticesSection" with passed props', () => {
+    expect(FeeFineNoticesSection).toHaveBeenCalledWith({
+      isOpen: true,
+      policy: mockedPolicy,
+      templates: {
+        templates: mockedTemplates,
+        categoryIds: [
+          patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
+          patronNoticeCategoryIds.AUTOMATED_FEE_FINE_ADJUSTMENT,
+        ],
+      },
+    }, {});
+  });
+
+  describe('if values for policy are present', () => {
+    it('should render correcty pane title', () => {
+      expect(screen.getByText(mockedPolicy.name)).toBeInTheDocument();
+    });
+  });
+
+  describe('if values for policy are absent', () => {
+    beforeEach(() => {
+      render(
+        <NoticePolicyForm
+          {...defaultProps}
+          form={{
+            getState: jest.fn(() => ({})),
+          }}
+        />
+      );
+    });
+
+    it('should render correctly pane title', () => {
+      expect(screen.getByText(labelIds.createEntryLabel)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `NoticePolicyForm` component in `src/settings/NoticePolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-630

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/149146022-cf10928c-60c8-4206-a236-fe92a8d452c5.png)