### PR TITLE
UICIRC-738: UI tests replacement with RTL/Jest for FinePolicy/FinePol…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Add RTL/Jest testing for `LoanPolicyForm` component in `src/settings/LoanPolicy`. Refs UICIRC-611.
 * Add RTL/Jest testing for `StaffSlipDetail` component in `src/settings/StaffSlips`. Refs UICIRC-649.
 * Add RTL/Jest testing for `LoanHistoryForm` component in `src/settings/LoanHistory`. Refs UICIRC-606.
+* Add RTL/Jest testing for `FinePolicyDetail` component in `src/settings/FinePolicy`. Refs UICIRC-738.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/FinePolicy/FinePolicyDetail.js
+++ b/src/settings/FinePolicy/FinePolicyDetail.js
@@ -29,6 +29,7 @@ class FinePolicyDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
     stripes: stripesShape.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -63,18 +64,21 @@ class FinePolicyDetail extends React.Component {
     return get(policy, pathToValue);
   };
 
-  getCheckboxValue = (seletedValue) => {
-    return seletedValue
+  getCheckboxValue = (selectedValue) => {
+    return selectedValue
       ? <FormattedMessage id="ui-circulation.settings.finePolicy.yes" />
       : <FormattedMessage id="ui-circulation.settings.finePolicy.no" />;
   };
 
   render() {
     const {
-      initialValues: policy = {},
+      initialValues: policy,
       stripes: {
         connect,
-      }
+      },
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     const { sections } = this.state;
@@ -97,7 +101,7 @@ class FinePolicyDetail extends React.Component {
         >
           <Accordion
             id="generalFeePolicy"
-            label={<FormattedMessage id="ui-circulation.settings.finePolicy.generalInformation" />}
+            label={formatMessage({ id: 'ui-circulation.settings.finePolicy.generalInformation' })}
             open={sections.generalFeePolicy}
           >
             <Metadata

--- a/src/settings/FinePolicy/FinePolicyDetail.test.js
+++ b/src/settings/FinePolicy/FinePolicyDetail.test.js
@@ -1,0 +1,293 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  Accordion,
+  AccordionSet,
+  ExpandAllButton,
+} from '@folio/stripes/components';
+
+import buildStripes from '../../../test/jest/__mock__/stripes.mock';
+
+import {
+  FinesSection,
+  OverdueAboutSection,
+} from './components/ViewSections';
+import { Metadata } from '../components';
+import FinePolicyDetail from './FinePolicyDetail';
+
+const mockFinePolicyReturnValue = {
+  metadata: 'testMetadata',
+};
+const mockTestIds = {
+  expandAllButton: 'expandAllButton',
+  accordionSet: 'accordionSet',
+  finesSection: 'finesSection',
+  overdueAboutSection: 'overdueAboutSection',
+};
+
+jest.mock('./components/ViewSections', () => ({
+  FinesSection: jest.fn(() => null),
+  OverdueAboutSection: jest.fn(() => null),
+}));
+jest.mock('../components', () => ({
+  Metadata: jest.fn(() => null),
+}));
+jest.mock('../Models/FinePolicy', () => jest.fn(() => mockFinePolicyReturnValue));
+
+ExpandAllButton.mockImplementation(({ onToggle }) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    data-testid={mockTestIds.expandAllButton}
+    onClick={() => onToggle({
+      generalFeePolicy: false,
+      viewFineSection: false,
+    })}
+  />
+));
+
+AccordionSet.mockImplementation(({ onToggle, children }) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    data-testid={mockTestIds.accordionSet}
+    onClick={() => onToggle({ id: 'generalFeePolicy' })}
+  >
+    {children}
+  </div>
+));
+
+const testStripes = buildStripes();
+
+describe('FinePolicyDetail', () => {
+  const labelIds = {
+    finePolicyGeneralInformation: 'ui-circulation.settings.finePolicy.generalInformation',
+    finePolicyYes: 'ui-circulation.settings.finePolicy.yes',
+    finePolicyNo: 'ui-circulation.settings.finePolicy.no',
+  };
+  const testDefaultProps = {
+    stripes: testStripes,
+  };
+  const accordionDefaultStatus = {
+    generalFeePolicy: true,
+    viewFineSection: true,
+  };
+
+  const getById = (id) => within(screen.getByTestId(id));
+
+  afterEach(() => {
+    Accordion.mockClear();
+    AccordionSet.mockClear();
+    ExpandAllButton.mockClear();
+    Metadata.mockClear();
+    FinesSection.mockClear();
+    OverdueAboutSection.mockClear();
+  });
+
+  describe('with default props', () => {
+    beforeEach(() => {
+      render(
+        <FinePolicyDetail {...testDefaultProps} />
+      );
+    });
+
+    it('should render ExpandAllButton component', () => {
+      expect(ExpandAllButton).toHaveBeenCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+    });
+
+    it('should render AccordionSet component', () => {
+      expect(AccordionSet).toHaveBeenCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+    });
+
+    it('should render Accordion component', () => {
+      expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'generalFeePolicy',
+        label: labelIds.finePolicyGeneralInformation,
+        open: accordionDefaultStatus.generalFeePolicy,
+      }), {});
+    });
+
+    it('should render Metadata component', () => {
+      expect(Metadata).toHaveBeenCalledWith(expect.objectContaining({
+        connect: testStripes.connect,
+        metadata: mockFinePolicyReturnValue.metadata,
+      }), {});
+    });
+
+    it('should render OverdueAboutSection component', () => {
+      expect(OverdueAboutSection).toHaveBeenCalled();
+    });
+
+    it('should render FinesSection component', () => {
+      expect(FinesSection).toHaveBeenCalledWith(expect.objectContaining({
+        policy: mockFinePolicyReturnValue,
+        fineSectionOpen: accordionDefaultStatus.viewFineSection,
+      }), {});
+    });
+  });
+
+  describe('handleExpandAll method', () => {
+    it('should expand all accordions', () => {
+      render(
+        <FinePolicyDetail {...testDefaultProps} />
+      );
+
+      expect(ExpandAllButton).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+
+      expect(AccordionSet).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+
+      expect(Accordion).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: accordionDefaultStatus.generalFeePolicy,
+        }), {}
+      );
+
+      expect(FinesSection).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fineSectionOpen: accordionDefaultStatus.viewFineSection,
+        }), {}
+      );
+
+      fireEvent.click(screen.getByTestId(mockTestIds.expandAllButton));
+
+      expect(ExpandAllButton).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: {
+          generalFeePolicy: false,
+          viewFineSection: false,
+        },
+      }), {});
+
+      expect(AccordionSet).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: {
+          generalFeePolicy: false,
+          viewFineSection: false,
+        },
+      }), {});
+
+      expect(Accordion).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: false,
+        }), {}
+      );
+
+      expect(FinesSection).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fineSectionOpen: false,
+        }), {}
+      );
+    });
+  });
+
+  describe('handleSectionToggle method', () => {
+    it('should expand accordion', () => {
+      render(
+        <FinePolicyDetail {...testDefaultProps} />
+      );
+
+      expect(ExpandAllButton).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+
+      expect(AccordionSet).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: accordionDefaultStatus,
+      }), {});
+
+      expect(Accordion).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: accordionDefaultStatus.generalFeePolicy,
+        }), {}
+      );
+
+      fireEvent.click(screen.getByTestId(mockTestIds.accordionSet));
+
+      expect(ExpandAllButton).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: {
+          ...accordionDefaultStatus,
+          generalFeePolicy: false,
+        },
+      }), {});
+
+      expect(AccordionSet).toHaveBeenLastCalledWith(expect.objectContaining({
+        accordionStatus: {
+          ...accordionDefaultStatus,
+          generalFeePolicy: false,
+        },
+      }), {});
+
+      expect(Accordion).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          open: false,
+        }), {}
+      );
+    });
+  });
+
+  describe('getCheckboxValue method', () => {
+    const createMockFinesSection = (selectedValue) => {
+      FinesSection.mockImplementationOnce(({ getCheckboxValue }) => (
+        <div data-testid={mockTestIds.finesSection}>
+          {getCheckboxValue(selectedValue)}
+        </div>
+      ));
+    };
+
+    it('should get checkbox value when selectedValue is true', () => {
+      createMockFinesSection(true);
+
+      render(
+        <FinePolicyDetail {...testDefaultProps} />
+      );
+
+      expect(getById(mockTestIds.finesSection).getByText(labelIds.finePolicyYes)).toBeVisible();
+    });
+
+    it('should get checkbox value when seletedValue is false', () => {
+      createMockFinesSection(false);
+
+      render(
+        <FinePolicyDetail {...testDefaultProps} />
+      );
+
+      expect(getById(mockTestIds.finesSection).getByText(labelIds.finePolicyNo)).toBeVisible();
+    });
+  });
+
+  describe('getValue method', () => {
+    it('should get value', () => {
+      const testValue = 'testValue';
+
+      OverdueAboutSection.mockImplementationOnce(({ getValue }) => (
+        <div data-testid={mockTestIds.overdueAboutSection}>
+          {getValue('a.b')}
+        </div>
+      ));
+
+      render(
+        <FinePolicyDetail
+          {...testDefaultProps}
+          initialValues={{
+            a: {
+              b: testValue,
+            },
+          }}
+        />
+      );
+
+      expect(getById(mockTestIds.overdueAboutSection).getByText(testValue)).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `FinePolicyDetail` component in `src/settings/FinePolicy`

## Refs
https://issues.folio.org/browse/UICIRC-738

## Screenshots
<img width="1267" alt="Screen Shot 2022-01-13 at 5 04 36 PM" src="https://user-images.githubusercontent.com/47976677/149480708-cadc59e6-664f-4380-862f-f35416a31c5b.png">

