### PR TITLE
UICIRC-611: Add Jest/RTL tests for `LoanPolicyForm` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add RTL/Jest testing for `LostItemFeePolicyForm` component in `src/settings/LostItemFeePolicy`. Refs UICIRC-619.
 * Add RTL/Jest testing for `NoticePolicyForm` component in `src/settings/NoticePolicy`. Refs UICIRC-630.
 * Add RTL/Jest testing for `FinePolicyForm` component in `src/settings/FinePolicy`. Refs UICIRC-737.
+* Add RTL/Jest testing for `LoanPolicyForm` component in `src/settings/LoanPolicy`. Refs UICIRC-611.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/LoanPolicy/LoanPolicyForm.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormattedMessage,
   injectIntl,
 } from 'react-intl';
 import {
@@ -124,6 +123,9 @@ class LoanPolicyForm extends React.Component {
         getState,
       },
       onCancel,
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     const { sections } = this.state;
@@ -132,7 +134,7 @@ class LoanPolicyForm extends React.Component {
     const policy = new LoanPolicy(values);
 
     const schedules = this.generateScheduleOptions();
-    const panelTitle = policy.id ? policy.name : <FormattedMessage id="ui-circulation.settings.loanPolicy.createEntryLabel" />;
+    const panelTitle = policy.id ? policy.name : formatMessage({ id: 'ui-circulation.settings.loanPolicy.createEntryLabel' });
     const footerPaneProps = {
       pristine,
       submitting,
@@ -141,6 +143,7 @@ class LoanPolicyForm extends React.Component {
 
     return (
       <form
+        data-testid="loanPolicyForm"
         noValidate
         className={css.loanPolicyForm}
         data-test-loan-policy-form
@@ -166,9 +169,10 @@ class LoanPolicyForm extends React.Component {
             </Row>
             <AccordionSet>
               <Accordion
+                data-testid="mainAccordion"
                 id="generalLoanPolicyForm"
                 open={sections.generalLoanPolicyForm}
-                label={<FormattedMessage id="ui-circulation.settings.loanPolicy.generalInformation" />}
+                label={formatMessage({ id: 'ui-circulation.settings.loanPolicy.generalInformation' })}
                 onToggle={this.handleSectionToggle}
               >
                 <Metadata
@@ -177,16 +181,19 @@ class LoanPolicyForm extends React.Component {
                 />
                 <AboutSection />
                 <LoansSection
+                  data-testid="loanSection"
                   policy={policy}
                   schedules={schedules}
                   change={change}
                 />
                 <RenewalsSection
+                  data-testid="renewalsSection"
                   policy={policy}
                   schedules={schedules}
                   change={change}
                 />
                 <RequestManagementSection
+                  data-testid="requestManagementSection"
                   policy={policy}
                   holdsSectionOpen={sections.holdsSection}
                   recallsSectionOpen={sections.recallsSection}

--- a/src/settings/LoanPolicy/LoanPolicyForm.test.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.test.js
@@ -1,0 +1,365 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  Accordion,
+  ExpandAllButton,
+  Pane,
+} from '@folio/stripes/components';
+
+import LoanPolicyForm from './LoanPolicyForm';
+import {
+  AboutSection,
+  LoansSection,
+  RenewalsSection,
+  RequestManagementSection,
+} from './components/EditSections';
+import {
+  CancelButton,
+  FooterPane,
+  Metadata,
+} from '../components';
+import LoanPolicy from '../Models/LoanPolicy';
+
+jest.mock('@folio/stripes/final-form', () => jest.fn(() => (Component) => Component));
+jest.mock('./components/EditSections', () => ({
+  AboutSection: jest.fn(() => null),
+  LoansSection: jest.fn(({
+    'data-testid': testId,
+    schedules,
+  }) => (
+    <div data-testid={testId}>
+      {schedules}
+    </div>
+  )),
+  RenewalsSection: jest.fn(({
+    'data-testid': testId,
+    schedules,
+  }) => (
+    <div data-testid={testId}>
+      {schedules}
+    </div>
+  )),
+  RequestManagementSection: jest.fn(({
+    'data-testid': testId,
+    accordionOnToggle,
+  }) => (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      data-testid={testId}
+      onClick={() => accordionOnToggle({ id: 'recallsSection' })}
+    />
+  )),
+}));
+jest.mock('../components', () => ({
+  CancelButton: jest.fn(() => null),
+  FooterPane: jest.fn(() => null),
+  Metadata: jest.fn(() => null),
+}));
+
+Accordion.mockImplementation(jest.fn(({
+  'data-testid': testId,
+  children,
+  onToggle,
+}) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    data-testid={testId}
+    onClick={() => onToggle({ id: 'generalLoanPolicyForm' })}
+  >
+    {children}
+  </div>
+)));
+ExpandAllButton.mockImplementation(jest.fn(({
+  accordionStatus,
+  onToggle,
+}) => {
+  const sectionKeys = Object.keys(accordionStatus);
+  const sectionStatus = {};
+
+  sectionKeys.forEach(key => {
+    sectionStatus[key] = !accordionStatus[key];
+  });
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      onClick={() => onToggle(sectionStatus)}
+    >
+      Expand all button
+    </div>
+  );
+}));
+Pane.mockImplementation(jest.fn(({
+  children,
+  firstMenu,
+  footer,
+}) => (
+  <div>
+    {firstMenu}
+    {children}
+    {footer}
+  </div>
+)));
+
+describe('LoanPolicyForm', () => {
+  const testIds = {
+    loanPolicyForm: 'loanPolicyForm',
+    mainAccordion: 'mainAccordion',
+    loanSection: 'loanSection',
+    renewalsSection: 'renewalsSection',
+    requestManagementSection: 'requestManagementSection',
+  };
+  const labelIds = {
+    selectSchedule: 'ui-circulation.settings.loanPolicy.selectSchedule',
+    createEntryLabel: 'ui-circulation.settings.loanPolicy.createEntryLabel',
+    generalInformation: 'ui-circulation.settings.loanPolicy.generalInformation',
+    expandAllButton: 'Expand all button',
+  };
+  const mockedInitialValues = {
+    id: 'testId',
+    name: 'testName',
+    description: 'testDescription',
+    metadata: {
+      createdByUserId: 'testUserId',
+      createdDate: new Date(),
+      updatedByUserId: 'testUserId',
+      updatedDate: new Date(),
+    },
+  };
+  const mockedForm = {
+    change: jest.fn(),
+    getState: jest.fn(() => ({ values: mockedInitialValues })),
+  };
+  const mockedStripes = {
+    connect: jest.fn(),
+  };
+  const mockedParentResources = {
+    fixedDueDateSchedules: {
+      records:[
+        {
+          id: 'secondTestId',
+          name: 'secondTestName',
+        },
+        {
+          id: 'firstTestId',
+          name: 'firstTestName',
+        },
+      ],
+    },
+  };
+  const mockedHandleSubmit = jest.fn();
+  const mockedOnSave = jest.fn();
+  const mockedOnCancel = jest.fn();
+  const defaultProps = {
+    form: mockedForm,
+    stripes: mockedStripes,
+    pristine: true,
+    submitting: false,
+    parentResources: mockedParentResources,
+    initialValues: mockedInitialValues,
+    handleSubmit: mockedHandleSubmit,
+    onSave: mockedOnSave,
+    onCancel: mockedOnCancel,
+  };
+  const policyForTest = new LoanPolicy(mockedInitialValues);
+
+  beforeEach(() => {
+    render(
+      <LoanPolicyForm
+        {...defaultProps}
+      />
+    );
+  });
+
+  afterEach(() => {
+    Accordion.mockClear();
+    ExpandAllButton.mockClear();
+    Pane.mockClear();
+    AboutSection.mockClear();
+    LoansSection.mockClear();
+    RenewalsSection.mockClear();
+    RequestManagementSection.mockClear();
+    CancelButton.mockClear();
+    FooterPane.mockClear();
+    Metadata.mockClear();
+  });
+
+  it('should call "handleSubmit" on form submit', () => {
+    expect(mockedHandleSubmit).not.toHaveBeenCalled();
+
+    fireEvent.submit(screen.getByTestId(testIds.loanPolicyForm));
+
+    expect(mockedHandleSubmit).toHaveBeenCalled();
+  });
+
+  it('should execute "CancelButton" with passed props', () => {
+    expect(CancelButton).toHaveBeenCalledWith({
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should execute "FooterPane" with passed props', () => {
+    expect(FooterPane).toHaveBeenCalledWith({
+      pristine: true,
+      submitting: false,
+      onCancel: mockedOnCancel,
+    }, {});
+  });
+
+  it('should have "ExpandAllButton" in the document', () => {
+    expect(screen.getByText(labelIds.expandAllButton)).toBeInTheDocument();
+  });
+
+  it('should correctly toggle sections status on "ExpandAllButton" click', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: true,
+    }), {});
+    expect(RequestManagementSection).toHaveBeenCalledWith(expect.objectContaining({
+      holdsSectionOpen: true,
+      recallsSectionOpen: true,
+    }), {});
+
+    fireEvent.click(screen.getByText(labelIds.expandAllButton));
+
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: false,
+    }), {});
+    expect(RequestManagementSection).toHaveBeenCalledWith(expect.objectContaining({
+      holdsSectionOpen: false,
+      recallsSectionOpen: false,
+    }), {});
+  });
+
+  it('"Accordion" should have correct label', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      label: labelIds.generalInformation,
+    }), {});
+  });
+
+  it('"Accordion" should correctly handle section status toggle', () => {
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: true,
+    }), {});
+
+    fireEvent.click(screen.getByTestId(testIds.mainAccordion));
+
+    expect(Accordion).toHaveBeenCalledWith(expect.objectContaining({
+      open: false,
+    }), {});
+  });
+
+  it('should execute "Metadata" with passed props', () => {
+    expect(Metadata).toHaveBeenCalledWith({
+      connect: mockedStripes.connect,
+      metadata: policyForTest.metadata,
+    }, {});
+  });
+
+  it('should execute "AboutSection"', () => {
+    expect(AboutSection).toHaveBeenCalled();
+  });
+
+  it('should execute "LoansSection" with passed props', () => {
+    expect(LoansSection).toHaveBeenCalledWith(expect.objectContaining({
+      policy: policyForTest,
+      change: mockedForm.change,
+    }), {});
+  });
+
+  it('should execute "RenewalsSection" with passed props', () => {
+    expect(RenewalsSection).toHaveBeenCalledWith(expect.objectContaining({
+      policy: policyForTest,
+      change: mockedForm.change,
+    }), {});
+  });
+
+  it('should correctly handle section toggle in "RequestManagementSection" component', () => {
+    expect(RequestManagementSection).toHaveBeenCalledWith(expect.objectContaining({
+      recallsSectionOpen: true,
+    }), {});
+
+    fireEvent.click(screen.getByTestId(testIds.requestManagementSection));
+
+    expect(RequestManagementSection).toHaveBeenCalledWith(expect.objectContaining({
+      recallsSectionOpen: false,
+    }), {});
+  });
+
+  it('should execute "RequestManagementSection" with passed props', () => {
+    expect(RequestManagementSection).toHaveBeenCalledWith(expect.objectContaining({
+      policy: policyForTest,
+      holdsSectionOpen: true,
+      change: mockedForm.change,
+      recallsSectionOpen: true,
+    }), {});
+  });
+
+  describe('when values for policy are passed', () => {
+    it('should execute "Pane" with correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: policyForTest.name,
+      }), {});
+    });
+  });
+
+  describe('when values for policy are not passed', () => {
+    beforeEach(() => {
+      render(
+        <LoanPolicyForm
+          {...defaultProps}
+          form={{
+            change: jest.fn(),
+            getState: jest.fn(() => ({})),
+          }}
+        />
+      );
+    });
+
+    it('should execute "Pane" with correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: labelIds.createEntryLabel,
+      }), {});
+    });
+  });
+
+  describe('schedules', () => {
+    const expectedOptionsResult = [
+      {
+        value: '',
+        name: labelIds.selectSchedule,
+      },
+      {
+        value: 'firstTestId',
+        name: 'firstTestName',
+      },
+      {
+        value: 'secondTestId',
+        name: 'secondTestName',
+      },
+    ];
+    const schedulesTest = (testId) => {
+      const options = within(screen.getByTestId(testId)).getAllByRole('option');
+
+      options.forEach((option, index) => {
+        expect(option).toHaveAttribute('value', expectedOptionsResult[index].value);
+        expect(within(option).getByText(expectedOptionsResult[index].name)).toBeInTheDocument();
+      });
+    };
+
+    it('should correctly sort and pass schedules in "LoansSection" component', () => {
+      schedulesTest(testIds.loanSection);
+    });
+
+    it('should correctly sort and pass schedules in "RenewalsSection" component', () => {
+      schedulesTest(testIds.renewalsSection);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LoanPolicyForm` component in `src/settings/LoanPolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-611

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/149523061-eb941054-beac-4cbd-970f-a02283c8f360.png)