### PR TITLE
UICIRC-606: UI tests replacement with RTL/Jest for component LoanHist…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add RTL/Jest testing for `FinePolicyForm` component in `src/settings/FinePolicy`. Refs UICIRC-737.
 * Add RTL/Jest testing for `LoanPolicyForm` component in `src/settings/LoanPolicy`. Refs UICIRC-611.
 * Add RTL/Jest testing for `StaffSlipDetail` component in `src/settings/StaffSlips`. Refs UICIRC-649.
+* Add RTL/Jest testing for `LoanHistoryForm` component in `src/settings/LoanHistory`. Refs UICIRC-606.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/FinePolicy/FinePolicyForm.test.js
+++ b/src/settings/FinePolicy/FinePolicyForm.test.js
@@ -70,17 +70,6 @@ ExpandAllButton.mockImplementation(jest.fn(({
     </div>
   );
 }));
-Pane.mockImplementation(jest.fn(({
-  children,
-  firstMenu,
-  footer,
-}) => (
-  <div>
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-)));
 
 describe('FinePolicyForm', () => {
   const testIds = {

--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -37,6 +37,7 @@ class LoanHistoryForm extends Component {
     submitting: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     form: PropTypes.object.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   renderFooter = () => {
@@ -49,6 +50,7 @@ class LoanHistoryForm extends Component {
       <PaneFooter
         renderEnd={(
           <Button
+            data-testid="submitButton"
             data-test-loan-history-save-button
             type="submit"
             buttonStyle="primary paneHeaderNewButton"
@@ -67,12 +69,16 @@ class LoanHistoryForm extends Component {
       handleSubmit,
       label,
       form: { getState },
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     const { values: loanHistoryValues } = getState();
 
     return (
       <form
+        data-testid="form"
         id="loan-history-form"
         className={css.loanHistoryForm}
         noValidate
@@ -84,8 +90,12 @@ class LoanHistoryForm extends Component {
           paneTitle={label}
           footer={this.renderFooter()}
         >
-          <div data-test-closed-loans>
+          <div
+            data-testid="closedLoans"
+            data-test-closed-loans
+          >
             <Headline
+              data-testid="closedLoansHeadline"
               size="large"
               margin="xx-large"
               tag="h3"
@@ -105,23 +115,23 @@ class LoanHistoryForm extends Component {
           <br />
           <Row>
             <Col xs={12}>
-              <Field name="treatEnabled" type="checkbox">
-                {(props) => (
-                  <Checkbox
-                    checked={props.input.checked}
-                    id="treatEnabled-checkbox"
-                    label={<FormattedMessage id="ui-circulation.settings.loanHistory.treat" />}
-                    onChange={e => props.input.onChange(e)}
-                    type="checkbox"
-                  />
-                )}
-              </Field>
+              <Field
+                name="treatEnabled"
+                type="checkbox"
+                id="treatEnabled-checkbox"
+                component={Checkbox}
+                label={formatMessage({ id: 'ui-circulation.settings.loanHistory.treat' })}
+              />
             </Col>
           </Row>
           <br />
           {loanHistoryValues.treatEnabled &&
-            <div data-test-closed-loans-feefine>
+            <div
+              data-testid="loansFeefineSection"
+              data-test-closed-loans-feefine
+            >
               <Headline
+                data-testid="closedLoansFeesFinesHeadline"
                 size="large"
                 margin="xx-large"
                 tag="h3"

--- a/src/settings/LoanHistory/LoanHistoryForm.test.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.test.js
@@ -1,0 +1,254 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
+import {
+  Button,
+  Checkbox,
+  Pane,
+  PaneFooter,
+} from '@folio/stripes/components';
+import AnonymizingTypeSelectContainer from '../components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer';
+import LoanHistoryForm from './LoanHistoryForm';
+import ExceptionsList from './ExceptionsList';
+import {
+  closingTypes,
+  closedLoansRules,
+} from '../../constants';
+
+jest.mock('@folio/stripes/final-form', () => jest.fn(() => (Component) => Component));
+jest.mock('../components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer', () => jest.fn(() => null));
+jest.mock('./ExceptionsList', () => jest.fn(() => null));
+jest.mock('../../constants', () => ({
+  closingTypes: 'testClosingTypes',
+  closedLoansRules: {
+    DEFAULT: 'testDefault',
+    WITH_FEES_FINES: 'testWithFeesFines',
+  },
+}));
+
+describe('LoanHistoryForm', () => {
+  const labelIds = {
+    'buttonSave': 'stripes-core.button.save',
+    'closedLoans': 'ui-circulation.settings.loanHistory.closedLoans',
+    'anonymize': 'ui-circulation.settings.loanHistory.anonymize',
+    'treat': 'ui-circulation.settings.loanHistory.treat',
+    'closedLoansFeesFines': 'ui-circulation.settings.loanHistory.closedLoansFeesFines',
+    'anonymizeFeesFines': 'ui-circulation.settings.loanHistory.anonymizeFeesFines',
+  };
+  const testIds = {
+    form: 'form',
+    submitButton: 'submitButton',
+    closedLoans: 'closedLoans',
+    closedLoansHeadline: 'closedLoansHeadline',
+    closedLoansFeesFinesHeadline: 'closedLoansFeesFinesHeadline',
+    loansFeefineSection: 'loansFeefineSection',
+  };
+  const testHandleSubmit = jest.fn();
+  const testGetState = jest.fn(() => ({
+    values: {
+      treatEnabled: false,
+    },
+  }));
+  const testDefaultProps = {
+    handleSubmit: testHandleSubmit,
+    form: {
+      getState: testGetState,
+    },
+    pristine: false,
+    submitting: false,
+  };
+
+  const getById = (id) => within(screen.getByTestId(id));
+
+  afterEach(() => {
+    Button.mockClear();
+    Pane.mockClear();
+    PaneFooter.mockClear();
+    AnonymizingTypeSelectContainer.mockClear();
+    FieldArray.mockClear();
+    testHandleSubmit.mockClear();
+  });
+
+  describe('with default props', () => {
+    beforeEach(() => {
+      render(
+        <LoanHistoryForm {...testDefaultProps} />
+      );
+    });
+
+    it('should render form', () => {
+      const form = screen.getByTestId(testIds.form);
+
+      expect(form).toBeVisible();
+      expect(form).toHaveAttribute('noValidate', '');
+    });
+
+    it('should submit form', () => {
+      expect(testHandleSubmit).toHaveBeenCalledTimes(0);
+
+      fireEvent.submit(screen.getByTestId(testIds.form));
+
+      expect(testHandleSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render Pane component', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        defaultWidth: 'fill',
+        fluidContentWidth: true,
+        paneTitle: undefined,
+      }), {});
+    });
+
+    it('should render PaneFooter component', () => {
+      expect(PaneFooter).toHaveBeenCalled();
+    });
+
+    it('should render submit Button component', () => {
+      expect(Button).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'submit',
+        disabled: false,
+      }), {});
+    });
+
+    it('should render submit Button component label', () => {
+      expect(getById(testIds.submitButton).getByText(labelIds.buttonSave)).toBeVisible();
+    });
+
+    it('should render closed loans label', () => {
+      expect(getById(testIds.closedLoansHeadline).getByText(labelIds.closedLoans)).toBeVisible();
+    });
+
+    it('should render anonymize label', () => {
+      expect(getById(testIds.closedLoans).getByText(labelIds.anonymize)).toBeVisible();
+    });
+
+    it('should render closed loans AnonymizingTypeSelectContainer component', () => {
+      expect(AnonymizingTypeSelectContainer).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        name: closedLoansRules.DEFAULT,
+        path: closedLoansRules.DEFAULT,
+        types: closingTypes,
+      }), {});
+    });
+
+    it('should render treat enabled Field component', () => {
+      expect(Field).toHaveBeenCalledWith({
+        name: 'treatEnabled',
+        type: 'checkbox',
+        id: 'treatEnabled-checkbox',
+        component: Checkbox,
+        label: labelIds.treat,
+      }, {});
+    });
+
+    it('should not render loans feefine section', () => {
+      expect(screen.queryByTestId(testIds.loansFeefineSection)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when treatEnabled is true', () => {
+    beforeEach(() => {
+      render(
+        <LoanHistoryForm
+          {...testDefaultProps}
+          form={{
+            ...testDefaultProps.form,
+            getState: jest.fn(() => ({
+              values: {
+                treatEnabled: true,
+              },
+            })),
+          }}
+        />
+      );
+    });
+
+    it('should render loans feefine section', () => {
+      expect(screen.getByTestId(testIds.loansFeefineSection)).toBeVisible();
+    });
+
+    it('should render closed loans fees fines label', () => {
+      expect(getById(testIds.closedLoansFeesFinesHeadline).getByText(labelIds.closedLoansFeesFines)).toBeVisible();
+    });
+
+    it('should render anonymize fees fines label', () => {
+      expect(getById(testIds.loansFeefineSection).getByText(labelIds.anonymizeFeesFines)).toBeVisible();
+    });
+
+    it('should render closed loans fees fines AnonymizingTypeSelectContainer component', () => {
+      expect(AnonymizingTypeSelectContainer).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        name: closedLoansRules.WITH_FEES_FINES,
+        path: closedLoansRules.WITH_FEES_FINES,
+        types: closingTypes,
+      }), {});
+    });
+
+    it('should render loan exceptions FieldArray component', () => {
+      expect(FieldArray).toHaveBeenCalledWith({
+        name: 'loanExceptions',
+        component: ExceptionsList,
+      }, {});
+    });
+  });
+
+  describe('when pristine is true', () => {
+    beforeEach(() => {
+      render(
+        <LoanHistoryForm
+          {...testDefaultProps}
+          pristine
+        />
+      );
+    });
+
+    it('should render submit Button component', () => {
+      expect(Button).toHaveBeenCalledWith(expect.objectContaining({
+        disabled: true,
+      }), {});
+    });
+  });
+
+  describe('when submitting is true', () => {
+    beforeEach(() => {
+      render(
+        <LoanHistoryForm
+          {...testDefaultProps}
+          submitting
+        />
+      );
+    });
+
+    it('should render submit Button component', () => {
+      expect(Button).toHaveBeenCalledWith(expect.objectContaining({
+        disabled: true,
+      }), {});
+    });
+  });
+
+  describe('when label is passed', () => {
+    const testLabel = 'testLabel';
+
+    beforeEach(() => {
+      render(
+        <LoanHistoryForm
+          {...testDefaultProps}
+          label={testLabel}
+        />
+      );
+    });
+
+    it('should render Pane component', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: testLabel,
+      }), {});
+    });
+  });
+});

--- a/src/settings/LoanPolicy/LoanPolicyForm.test.js
+++ b/src/settings/LoanPolicy/LoanPolicyForm.test.js
@@ -97,17 +97,6 @@ ExpandAllButton.mockImplementation(jest.fn(({
     </div>
   );
 }));
-Pane.mockImplementation(jest.fn(({
-  children,
-  firstMenu,
-  footer,
-}) => (
-  <div>
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-)));
 
 describe('LoanPolicyForm', () => {
   const testIds = {

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.test.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicyForm.test.js
@@ -70,17 +70,6 @@ ExpandAllButton.mockImplementation(jest.fn(({
     </div>
   );
 }));
-Pane.mockImplementation(jest.fn(({
-  children,
-  firstMenu,
-  footer,
-}) => (
-  <div>
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-)));
 
 describe('LostItemFeePolicyForm', () => {
   const testIds = {

--- a/src/settings/NoticePolicy/NoticePolicyForm.test.js
+++ b/src/settings/NoticePolicy/NoticePolicyForm.test.js
@@ -45,19 +45,6 @@ jest.mock('./utils/get-templates', () => jest.fn((templates, categoryIds) => (
   }
 )));
 
-Pane.mockImplementation(jest.fn(({
-  paneTitle,
-  firstMenu,
-  children,
-  footer,
-}) => (
-  <div>
-    {paneTitle}
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-)));
 ExpandAllButton.mockImplementation(jest.fn(({ onToggle, ...rest }) => {
   const sections = {
     general: false,

--- a/src/settings/NoticePolicy/components/EditSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
@@ -22,10 +22,6 @@ import {
 
 const mockedCatchFunc = jest.fn();
 
-jest.mock('react-final-form-arrays', () => ({
-  FieldArray: jest.fn(() => null),
-}));
-
 describe('FeeFineNoticesSection', () => {
   const mockedPolicy = {
     data: 'mockedPolicy',

--- a/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
@@ -19,10 +19,6 @@ import {
   noticesSendEvents,
 } from '../../../../../constants';
 
-jest.mock('react-final-form-arrays', () => ({
-  FieldArray: jest.fn(() => null),
-}));
-
 jest.mock('../components', () => jest.fn(() => null));
 
 describe('LoanNoticesSection', () => {

--- a/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
@@ -5,9 +5,9 @@ import {
   within,
 } from '@testing-library/react';
 
-import { FieldArray } from 'react-final-form-arrays';
-
 import '../../../../../../test/jest/__mock__';
+
+import { FieldArray } from 'react-final-form-arrays';
 
 import NoticesList from '../components';
 import RequestNoticesSection, {
@@ -18,10 +18,6 @@ import {
   uponAndBeforeSendEvents,
   requestNoticesTriggeringEvents,
 } from '../../../../../constants';
-
-jest.mock('react-final-form-arrays', () => ({
-  FieldArray: jest.fn(() => null),
-}));
 
 jest.mock('../components', () => jest.fn(() => null));
 

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
@@ -21,9 +21,6 @@ import GeneralSection, {
 } from './GeneralSection';
 import { requestPolicyTypes } from '../../../../../constants';
 
-jest.mock('react-final-form-arrays', () => ({
-  FieldArray: jest.fn(() => null),
-}));
 jest.mock('../../../../components', () => ({
   Metadata: jest.fn(() => null),
 }));

--- a/src/settings/StaffSlips/StaffSlipForm.test.js
+++ b/src/settings/StaffSlips/StaffSlipForm.test.js
@@ -31,13 +31,6 @@ jest.mock('../components', () => ({
   FooterPane: jest.fn(() => null),
 }));
 Field.mockImplementation(jest.fn(() => null));
-Pane.mockImplementation(jest.fn(({ children, firstMenu, footer }) => (
-  <div>
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-)));
 
 describe('StaffSlipForm', () => {
   const orderOfFieldExecution = {

--- a/src/settings/TitleLevelRequests/TitleLevelRequestsForm.test.js
+++ b/src/settings/TitleLevelRequests/TitleLevelRequestsForm.test.js
@@ -27,12 +27,6 @@ import {
 
 jest.mock('./NoticeTemplates', () => jest.fn(() => null));
 jest.mock('@folio/stripes/final-form', () => jest.fn(() => (component) => component));
-Pane.mockImplementation(jest.fn(({ children, footer }) => (
-  <div>
-    {children}
-    {footer}
-  </div>
-)));
 PaneFooter.mockImplementation(jest.fn(({ renderEnd }) => (
   <div>
     {renderEnd}

--- a/test/jest/__mock__/finalFormArrayComponents.mock.js
+++ b/test/jest/__mock__/finalFormArrayComponents.mock.js
@@ -1,0 +1,3 @@
+jest.mock('react-final-form-arrays', () => ({
+  FieldArray: jest.fn(() => null),
+}));

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -4,5 +4,6 @@ import './intl.mock';
 import './stripesIcon.mock';
 import './stripesComponents.mock';
 import './finalFormComponents.mock';
+import './finalFormArrayComponents.mock';
 import './stripesSmartComponents.mock';
 import './stripesCore.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -85,9 +85,17 @@ jest.mock('@folio/stripes/components', () => ({
     <div {...rest}>{children}</div>
   )),
   Modal: jest.fn(() => null),
-  Pane: jest.fn(({ children }) => (<div>{children}</div>)),
-  PaneFooter: jest.fn(({ ref, children, ...rest }) => (
-    <div ref={ref} {...rest}>{children}</div>
+  Pane: jest.fn(({ children, footer }) => (
+    <div>
+      {children}
+      {footer}
+    </div>
+  )),
+  PaneFooter: jest.fn(({ ref, children, renderEnd, ...rest }) => (
+    <div ref={ref} {...rest}>
+      {children}
+      {renderEnd}
+    </div>
   )),
   PaneMenu: jest.fn((props) => <div>{props.children}</div>),
   Paneset: jest.fn(({ children }) => (<div>{children}</div>)),

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -85,8 +85,10 @@ jest.mock('@folio/stripes/components', () => ({
     <div {...rest}>{children}</div>
   )),
   Modal: jest.fn(() => null),
-  Pane: jest.fn(({ children, footer }) => (
+  Pane: jest.fn(({ paneTitle, firstMenu, children, footer }) => (
     <div>
+      {paneTitle}
+      {firstMenu}
       {children}
       {footer}
     </div>


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LoanHistoryForm` component in `src/settings/LoanHistory`

## Refs
https://issues.folio.org/browse/UICIRC-606

## Screenshots
<img width="1269" alt="Screen Shot 2022-01-17 at 3 50 53 PM" src="https://user-images.githubusercontent.com/47976677/149772965-ca0c878c-8b8f-4d96-974c-d0b800550baa.png">

