### PR TITLE
UICIRC-735: 'Preview of patron notice template' title is broken. 'Pre…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Add RTL/Jest testing for `FixedDueDateScheduleManager` component in `src/settings/FixedDueDateSchedule`. Refs UICIRC-600.
 * Also support `circulation` `13.0`. Refs UICIRC-732.
 * Date format in preview should change depending on localization in `Staff slips`. Refs UICIRC-734.
+* `Preview of patron notice template` title is broken. `Preview of staff slips` title is broken. Refs UICIRC-735.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/src/settings/PatronNotices/PatronNoticeDetail.js
+++ b/src/settings/PatronNotices/PatronNoticeDetail.js
@@ -159,8 +159,7 @@ class PatronNoticeDetail extends React.Component {
           header={
             formatMessage({
               id: 'ui-circulation.settings.patronNotices.view.previewHeader',
-              values: { name: notice.name },
-            })
+            }, { name: notice.name })
           }
           previewTemplate={emailTemplate}
           previewFormat={tokensReducer(tokens)}

--- a/src/settings/StaffSlips/StaffSlipDetail.js
+++ b/src/settings/StaffSlips/StaffSlipDetail.js
@@ -120,8 +120,7 @@ class StaffSlipDetail extends React.Component {
           header={
             formatMessage({
               id: 'ui-circulation.settings.staffSlips.view.previewLabel',
-              values: { name: staffSlip.name },
-            })
+            }, { name: staffSlip.name })
           }
           previewTemplate={staffSlip.template}
           previewFormat={tokensReducer(tokens)}


### PR DESCRIPTION
## Purpose
`Preview of patron notice template` title is broken. `Preview of staff slips` title is broken.

## Refs
https://issues.folio.org/browse/UICIRC-735
