### PR TITLE
UICIRC-752 adjust Lost Item Fee Policy setting name

### DIFF
--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -432,7 +432,7 @@
   "settings.lostItemFee.chargeAmountItemPatron": "Charge lost item processing fee if item declared lost by patron",
   "settings.lostItemFee.chargeAmountItemSystem": "Charge lost item processing fee if item aged to lost by system",
   "settings.lostItemFee.lostItemNotChargeFeesFine": "For lost items not charged a fee/fine, close the loan after",
-  "settings.lostItemFee.returnedLostItemProcessingFee": "If lost item returned, remove lost item processing fee",
+  "settings.lostItemFee.returnedLostItemProcessingFee": "If lost item returned or renewed, remove lost item processing fee",
   "settings.lostItemFee.replacedLostItemProcessingFee": "If lost item replaced, remove lost item processing fee",
   "settings.lostItemFee.replacementProcessFee": "Replacement processing fee",
   "settings.lostItemFee.replacementAllowed": "Replacement allowed",


### PR DESCRIPTION
## Purpose

UIU-1994 Change setting name for 'If lost item returned, remove lost item processing fee' in Lost Item Fee Policy

## Refs

https://issues.folio.org/browse/UIU-1994

## Screenshots

![image](https://user-images.githubusercontent.com/57374564/149422520-eaf928b2-a8cf-41aa-a71a-05bc743d66a2.png)

Replaces #851