### PR TITLE
UICIRC-717: Permission errors with ui-circulation.settings.notice-pol…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * `Preview of patron notice template` title is broken. `Preview of staff slips` title is broken. Refs UICIRC-735.
 * Add RTL/Jest testing for `LostItemFeePolicyDetail` component in `src\settings\LostItemFeePolicy`. Refs UICIRC-621.
 * Add RTL/Jest testing for `FinePolicySettings` component in `src/settings/FinePolicy`. Refs UICIRC-593.
+* Permission errors with `ui-circulation.settings.notice-policies`. Refs UICIRC-717.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "permissionName": "ui-circulation.settings.notice-policies",
         "displayName": "Settings (Circ): Can create, edit and remove notice policies",
         "subPermissions": [
+          "circulation.rules.get",
           "circulation-storage.patron-notice-policies.item.post",
           "circulation-storage.patron-notice-policies.item.put",
           "circulation-storage.patron-notice-policies.item.delete",


### PR DESCRIPTION
## Purpose
Permission errors with `ui-circulation.settings.notice-policies`

## Refs
https://issues.folio.org/browse/UICIRC-717
