### PR TITLE
UICIRC-748: Permission errors with ui-circulation.settings.loan-history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Add setting to enable and disable wildcard barcode lookup. Refs UICIRC-712.
 * Remove "Requests" from list of circulation apps to enable perform wildcard lookup of items by barcode in Circulation settings. Refs UICIRC-754.
 * Permission errors with `ui-circulation.settings.view-loan-policies`. Refs UICIRC-747.
+* Permission errors with `ui-circulation.settings.loan-history`. Refs UICIRC-748.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "permissionName": "ui-circulation.settings.loan-history",
         "displayName": "Settings (Circ): Can view loan history",
         "subPermissions": [
+          "configuration.entries.collection.get",
           "settings.circulation.enabled",
           "payments.collection.get"
         ],


### PR DESCRIPTION
## Purpose
Permission errors with `ui-circulation.settings.loan-history`

## Refs
https://issues.folio.org/browse/UICIRC-748
