### PR TITLE
UICIRC-745: Add `circulation.loans.collection.get` as subpermisson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,13 @@
 * Permission errors with `ui-circulation.settings.notice-policies`. Refs UICIRC-717.
 * Add setting to enable and disable wildcard barcode lookup. Refs UICIRC-712.
 * Remove "Requests" from list of circulation apps to enable perform wildcard lookup of items by barcode in Circulation settings. Refs UICIRC-754.
+<<<<<<< HEAD
 * Permission errors with `ui-circulation.settings.view-loan-policies`. Refs UICIRC-747.
 * Permission errors with `ui-circulation.settings.loan-history`. Refs UICIRC-748.
 * Permission errors with `ui-circulation.settings.request-policies`. Refs UICIRC-742.
+=======
+* Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-lost-item-fees-policies`. Refs UICIRC-745.
+>>>>>>> a15832e (UICIRC-745: Add `circulation.loans.collection.get` as subpermisson)
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
         "permissionName": "ui-circulation.settings.view-lost-item-fees-policies",
         "displayName": "Settings (Circ): Can view lost item fee policies",
         "subPermissions": [
+          "circulation.loans.collection.get",
           "lost-item-fees-policies.collection.get",
           "lost-item-fees-policies.item.get",
           "users.collection.get",
@@ -297,7 +298,6 @@
     "test:jest": "jest --ci --coverage --colors",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-circulation ./translations/ui-circulation/compiled"
-
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.13.0",


### PR DESCRIPTION
## Purpose
Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-lost-item-fees-policies`.

## Refs
https://issues.folio.org/browse/UICIRC-745