### PR TITLE
UICIRC-746: Add `circulation.loans.collection.get` subpermisson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,11 @@
 * Permission errors with `ui-circulation.settings.notice-policies`. Refs UICIRC-717.
 * Add setting to enable and disable wildcard barcode lookup. Refs UICIRC-712.
 * Remove "Requests" from list of circulation apps to enable perform wildcard lookup of items by barcode in Circulation settings. Refs UICIRC-754.
-<<<<<<< HEAD
 * Permission errors with `ui-circulation.settings.view-loan-policies`. Refs UICIRC-747.
 * Permission errors with `ui-circulation.settings.loan-history`. Refs UICIRC-748.
 * Permission errors with `ui-circulation.settings.request-policies`. Refs UICIRC-742.
-=======
 * Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-lost-item-fees-policies`. Refs UICIRC-745.
->>>>>>> a15832e (UICIRC-745: Add `circulation.loans.collection.get` as subpermisson)
+* Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-overdue-fines-policies`. Refs UICIRC-746.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
         "permissionName": "ui-circulation.settings.view-overdue-fines-policies",
         "displayName": "Settings (Circ): Can view overdue fine policies",
         "subPermissions": [
+          "circulation.loans.collection.get",
           "overdue-fines-policies.collection.get",
           "overdue-fines-policies.item.get",
           "users.collection.get",


### PR DESCRIPTION
## Purpose
Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-overdue-fines-policies`.

## Refs
https://issues.folio.org/browse/UICIRC-746