### PR TITLE
UICIRC-750: Add `user-settings.custom-fields.collection.get` as subpermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-lost-item-fees-policies`. Refs UICIRC-745.
 * Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-overdue-fines-policies`. Refs UICIRC-746.
 * Permission errors with `ui-circulation.settings.notice-templates`. Refs UICIRC-744.
+* Add `user-settings.custom-fields.collection.get` as subpermission for `ui-circulation.settings.other-settings`. Refs UICIRC-746.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
         "permissionName": "ui-circulation.settings.other-settings",
         "displayName": "Settings (Circ): Can create, edit and remove other settings",
         "subPermissions": [
+          "user-settings.custom-fields.collection.get",
           "configuration.all",
           "settings.circulation.enabled"
         ],


### PR DESCRIPTION
## Purpose
Add `user-settings.custom-fields.collection.get` as subpermission for `ui-circulation.settings.other-settings`

## Refs
https://issues.folio.org/browse/UICIRC-750