### PR TITLE
UICIRC-714: Fix problem with `ui-circulation.settings.circulation-rules` permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Add `circulation.loans.collection.get` as subpermission for `ui-circulation.settings.view-overdue-fines-policies`. Refs UICIRC-746.
 * Permission errors with `ui-circulation.settings.notice-templates`. Refs UICIRC-744.
 * Add `user-settings.custom-fields.collection.get` as subpermission for `ui-circulation.settings.other-settings`. Refs UICIRC-746.
+* Add `overdue-fines-policies.collection.get` and `lost-item-fees-policies.collection.get` as subpermissions for `ui-circulation.settings.circulation-rules`. Refs UICIRC-714.
 
 ## [6.0.0](https://github.com/folio-org/ui-circulation/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v5.1.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -148,7 +148,9 @@
           "inventory-storage.location-units.institutions.collection.get",
           "inventory-storage.location-units.campuses.collection.get",
           "inventory-storage.location-units.libraries.collection.get",
-          "inventory-storage.locations.collection.get"
+          "inventory-storage.locations.collection.get",
+          "overdue-fines-policies.collection.get",
+          "lost-item-fees-policies.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add `overdue-fines-policies.collection.get` and `lost-item-fees-policies.collection.get` as subpermissions for `ui-circulation.settings.circulation-rules`.

## Refs
https://issues.folio.org/browse/UICIRC-714