### PR TITLE
UICIRC-760: Add Jest/RTL tests for `PatronNotices` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [8.0.0] (IN PROGRESS)
 
 * Add RTL/Jest testing for `LostItemFeePolicySettings` component in `settings/LostItemFeePolicy`. Refs UICIRC-758.
+* Add RTL/Jest testing for `PatronNotices` component in `settings/PatronNotices`. Refs UICIRC-760.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  injectIntl,
+} from 'react-intl';
 import {
   sortBy,
   get,
@@ -37,6 +39,7 @@ class PatronNotices extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   static manifest = Object.freeze({
@@ -83,6 +86,7 @@ class PatronNotices extends React.Component {
 
   render() {
     const [{ id: defaultCategory }] = patronNoticeCategories;
+    const { formatMessage } = this.props.intl;
 
     return (
       <EntryManager
@@ -109,13 +113,13 @@ class PatronNotices extends React.Component {
         editElement="both"
         isEntryInUse={this.isTemplateInUse}
         prohibitItemDelete={{
-          close: <FormattedMessage id="ui-circulation.settings.common.close" />,
-          label: <FormattedMessage id="ui-circulation.settings.patronNotices.denyDelete.header" />,
-          message: <FormattedMessage id="ui-circulation.settings.patronNotices.denyDelete.body" />,
+          close: formatMessage({ id: 'ui-circulation.settings.common.close' }),
+          label: formatMessage({ id: 'ui-circulation.settings.patronNotices.denyDelete.header' }),
+          message: formatMessage({ id: 'ui-circulation.settings.patronNotices.denyDelete.body' }),
         }}
       />
     );
   }
 }
 
-export default stripesConnect(PatronNotices);
+export default stripesConnect(injectIntl(PatronNotices));

--- a/src/settings/PatronNotices/PatronNotices.test.js
+++ b/src/settings/PatronNotices/PatronNotices.test.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import {
+  render,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { EntryManager } from '@folio/stripes/smart-components';
+
+import PatronNotices from './PatronNotices';
+import PatronNoticeDetail from './PatronNoticeDetail';
+import PatronNoticeForm from './PatronNoticeForm';
+
+import {
+  patronNoticeCategories,
+} from '../../constants';
+
+describe('PatronNotices', () => {
+  const labelIds = {
+    close: 'ui-circulation.settings.common.close',
+    header: 'ui-circulation.settings.patronNotices.denyDelete.header',
+    body: 'ui-circulation.settings.patronNotices.denyDelete.body',
+  };
+  const mockedLabel = 'testLabel';
+  const mockedEntries = {
+    records: [
+      {
+        name: 'Zak',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Alex',
+      },
+    ],
+  };
+  const mockedPatronNoticePolicies = {
+    entries: {
+      records: [{
+        test: 'testPatronNoticePoliciesData',
+      }],
+    },
+  };
+  const mockedMutator = {
+    entries: {
+      POST: jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  };
+  const defaultProps = {
+    label: mockedLabel,
+    resources: {
+      entries: mockedEntries,
+      patronNoticePolicies: mockedPatronNoticePolicies,
+    },
+    mutator: mockedMutator,
+  };
+
+  afterEach(() => {
+    EntryManager.mockClear();
+  });
+
+  it('"EntryManager" should be executed with correct props', () => {
+    const expectedNameOrder = [
+      {
+        name: 'Alex',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Zak',
+      },
+    ];
+
+    render(
+      <PatronNotices
+        {...defaultProps}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      parentMutator: mockedMutator,
+      entryList: expectedNameOrder,
+      detailComponent: PatronNoticeDetail,
+      paneTitle: mockedLabel,
+      entryLabel: mockedLabel,
+      entryFormComponent: PatronNoticeForm,
+      defaultEntry: {
+        active: true,
+        outputFormats: ['text/html'],
+        templateResolver: 'mustache',
+        category: patronNoticeCategories[0].id,
+      },
+      nameKey: 'name',
+      permissions: {
+        put: 'ui-circulation.settings.notice-templates',
+        post: 'ui-circulation.settings.notice-templates',
+        delete: 'ui-circulation.settings.notice-templates',
+      },
+      enableDetailsActionMenu: true,
+      editElement: 'both',
+      prohibitItemDelete: {
+        close: labelIds.close,
+        label: labelIds.header,
+        message: labelIds.body,
+      },
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "records" in "entries"', () => {
+    render(
+      <PatronNotices
+        {...defaultProps}
+        resources={{
+          ...defaultProps.resources,
+          entries: {},
+        }}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "entries" in "resources"', () => {
+    render(
+      <PatronNotices
+        {...defaultProps}
+        resources={{
+          patronNoticePolicies: mockedPatronNoticePolicies,
+        }}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `PatronNotices` component in `settings/PatronNotices`.

## Refs
https://issues.folio.org/browse/UICIRC-760

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/155699044-ef292998-9329-4b08-9432-6cf7b2c436c8.png)