### PR TITLE
UICIRC-758: Add Jest/RTL tests for `LostItemFeePolicySettings` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [8.0.0] (IN PROGRESS)
 
+* Add RTL/Jest testing for `LostItemFeePolicySettings` component in `settings/LostItemFeePolicy`. Refs UICIRC-758.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.js
@@ -6,7 +6,6 @@ import {
   sortBy,
 } from 'lodash';
 import {
-  FormattedMessage,
   injectIntl,
 } from 'react-intl';
 
@@ -19,6 +18,37 @@ import LostItemFeePolicy from '../Models/LostItemFeePolicy';
 import normalize from './utils/normalize';
 import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
 import withPreventDelete from '../wrappers/withPreventDelete';
+
+export const parseInitialValues = (init = {}) => {
+  const policy = { ...init };
+
+  for (const key in policy) {
+    if (isBoolean(policy[key])) {
+      policy[key] = policy[key].toString();
+    }
+  }
+
+  if (!isUndefined(init.lostItemProcessingFee)) {
+    policy.lostItemProcessingFee = parseFloat(init.lostItemProcessingFee).toFixed(2);
+  }
+
+  if (!isUndefined(init.replacementProcessingFee)) {
+    policy.replacementProcessingFee = parseFloat(init.replacementProcessingFee).toFixed(2);
+  }
+
+  if (init.chargeAmountItem) {
+    policy.chargeAmountItem = {
+      amount: init.chargeAmountItem.amount
+        ? parseFloat(init.chargeAmountItem.amount).toFixed(2)
+        : '0.00',
+      chargeType: init.chargeAmountItem.chargeType
+        ? init.chargeAmountItem.chargeType
+        : '',
+    };
+  }
+
+  return policy;
+};
 
 class LostItemFeePolicySettings extends React.Component {
   static manifest = Object.freeze({
@@ -52,37 +82,6 @@ class LostItemFeePolicySettings extends React.Component {
     }).isRequired,
   };
 
-  parseInitialValues = (init = {}) => {
-    const policy = { ...init };
-
-    for (const key in policy) {
-      if (isBoolean(policy[key])) {
-        policy[key] = policy[key].toString();
-      }
-    }
-
-    if (!isUndefined(init.lostItemProcessingFee)) {
-      policy.lostItemProcessingFee = parseFloat(init.lostItemProcessingFee).toFixed(2);
-    }
-
-    if (!isUndefined(init.replacementProcessingFee)) {
-      policy.replacementProcessingFee = parseFloat(init.replacementProcessingFee).toFixed(2);
-    }
-
-    if (init.chargeAmountItem) {
-      policy.chargeAmountItem = {
-        amount: init.chargeAmountItem.amount
-          ? parseFloat(init.chargeAmountItem.amount).toFixed(2)
-          : '0.00',
-        chargeType: init.chargeAmountItem.chargeType
-          ? init.chargeAmountItem.chargeType
-          : '',
-      };
-    }
-
-    return policy;
-  };
-
   render() {
     const {
       checkPolicy,
@@ -108,17 +107,17 @@ class LostItemFeePolicySettings extends React.Component {
         isEntryInUse={checkPolicy}
         parentMutator={mutator}
         permissions={permissions}
-        parseInitialValues={this.parseInitialValues}
+        parseInitialValues={parseInitialValues}
         parentResources={resources}
         prohibitItemDelete={{
-          close: <FormattedMessage id={this.props.closeText} />,
-          label: <FormattedMessage id={this.props.labelText} />,
-          message: <FormattedMessage id={this.props.messageText} />,
+          close: formatMessage({ id: this.props.closeText }),
+          label: formatMessage({ id: this.props.labelText }),
+          message: formatMessage({ id: this.props.messageText }),
         }}
         detailComponent={LostItemFeePolicyDetail}
         enableDetailsActionMenu
         entryFormComponent={LostItemFeePolicyForm}
-        paneTitle={<FormattedMessage id="ui-circulation.settings.lostItemFee.paneTitle" />}
+        paneTitle={formatMessage({ id: 'ui-circulation.settings.lostItemFee.paneTitle' })}
         entryLabel={formatMessage({ id: 'ui-circulation.settings.lostItemFee.entryLabel' })}
         defaultEntry={LostItemFeePolicy.defaultLostItemFeePolicy()}
         onBeforeSave={normalize}

--- a/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.test.js
+++ b/src/settings/LostItemFeePolicy/LostItemFeePolicySettings.test.js
@@ -1,0 +1,215 @@
+import React from 'react';
+import {
+  render,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { EntryManager } from '@folio/stripes/smart-components';
+
+import LostItemFeePolicySettings, {
+  parseInitialValues,
+} from './LostItemFeePolicySettings';
+import LostItemFeePolicyDetail from './LostItemFeePolicyDetail';
+import LostItemFeePolicyForm from './LostItemFeePolicyForm';
+import LostItemFeePolicy from '../Models/LostItemFeePolicy';
+
+import normalize from './utils/normalize';
+
+jest.mock('../wrappers/withPreventDelete', () => jest.fn(component => component));
+
+describe('LostItemFeePolicySettings', () => {
+  const labelIds = {
+    paneTitle: 'ui-circulation.settings.lostItemFee.paneTitle',
+    entryLabel: 'ui-circulation.settings.lostItemFee.entryLabel',
+  };
+  const mockedCheckPolicy = jest.fn();
+  const mockedCloseText = 'closeText';
+  const mockedLabelText = 'labelText';
+  const mockedMessageText = 'messageText';
+  const mockedLostItemFeePolicies = {
+    records: [
+      {
+        name: 'Zak',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Alex',
+      },
+    ],
+  };
+  const mockedMutator = {
+    lostItemFeePolicies: {
+      POST:jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  };
+  const defaultProps = {
+    checkPolicy: mockedCheckPolicy,
+    closeText: mockedCloseText,
+    labelText: mockedLabelText,
+    messageText: mockedMessageText,
+    resources: {
+      lostItemFeePolicies: mockedLostItemFeePolicies,
+    },
+    mutator: mockedMutator,
+  };
+
+  afterEach(() => {
+    EntryManager.mockClear();
+  });
+
+  it('should execute "EntryManager" with passed props', () => {
+    const expectedNameOrder = [
+      {
+        name: 'Alex',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Zak',
+      },
+    ];
+
+    render(
+      <LostItemFeePolicySettings
+        {...defaultProps}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      nameKey: 'name',
+      resourceKey: 'lostItemFeePolicies',
+      entryList: expectedNameOrder,
+      isEntryInUse: mockedCheckPolicy,
+      parentMutator: mockedMutator,
+      permissions: {
+        put: 'ui-circulation.settings.lost-item-fees-policies',
+        post: 'ui-circulation.settings.lost-item-fees-policies',
+        delete: 'ui-circulation.settings.lost-item-fees-policies',
+      },
+      parseInitialValues,
+      parentResources: defaultProps.resources,
+      prohibitItemDelete: {
+        close: mockedCloseText,
+        label: mockedLabelText,
+        message: mockedMessageText,
+      },
+      detailComponent: LostItemFeePolicyDetail,
+      enableDetailsActionMenu: true,
+      entryFormComponent: LostItemFeePolicyForm,
+      paneTitle: labelIds.paneTitle,
+      entryLabel: labelIds.entryLabel,
+      defaultEntry: LostItemFeePolicy.defaultLostItemFeePolicy(),
+      onBeforeSave: normalize,
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "records" in "lostItemFeePolicies"', () => {
+    render(
+      <LostItemFeePolicySettings
+        {...defaultProps}
+        resources={{
+          lostItemFeePolicies: {},
+        }}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "lostItemFeePolicies" in "resources"', () => {
+    render(
+      <LostItemFeePolicySettings
+        {...defaultProps}
+        resources={{}}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+});
+
+describe('parseInitialValues', () => {
+  it('should correctly process boolean values in "policy"', () => {
+    const testPolicy = {
+      booleanKey: false,
+      nonBooleanKey: null,
+    };
+    const expectedResult = {
+      booleanKey: 'false',
+      nonBooleanKey: null,
+    };
+
+    expect(parseInitialValues(testPolicy)).toEqual(expectedResult);
+  });
+
+  it('should correctly process "lostItemProcessingFee" key in "policy"', () => {
+    const testNumber = 10;
+    const testPolicy = {
+      lostItemProcessingFee: testNumber,
+    };
+    const expectedResult = {
+      lostItemProcessingFee: testNumber.toFixed(2),
+    };
+
+    expect(parseInitialValues(testPolicy)).toEqual(expectedResult);
+  });
+
+  it('should correctly process "replacementProcessingFee" key in "policy"', () => {
+    const testNumber = 10;
+    const testPolicy = {
+      replacementProcessingFee: testNumber,
+    };
+    const expectedResult = {
+      replacementProcessingFee: testNumber.toFixed(2),
+    };
+
+    expect(parseInitialValues(testPolicy)).toEqual(expectedResult);
+  });
+
+  it('should correctly process "chargeAmountItem" key in "policy" if "amount" and "chargeType" are present', () => {
+    const testNumber = 10;
+    const testType = 'testType';
+    const testPolicy = {
+      chargeAmountItem: {
+        amount: testNumber,
+        chargeType: testType,
+      },
+    };
+    const expectedResult = {
+      chargeAmountItem: {
+        amount: testNumber.toFixed(2),
+        chargeType: testType,
+      },
+    };
+
+    expect(parseInitialValues(testPolicy)).toEqual(expectedResult);
+  });
+
+  it('should correctly process "chargeAmountItem" key in "policy" if "amount" and "chargeType" are absent', () => {
+    const testPolicy = {
+      chargeAmountItem: {},
+    };
+    const expectedResult = {
+      chargeAmountItem: {
+        amount: '0.00',
+        chargeType: '',
+      },
+    };
+
+    expect(parseInitialValues(testPolicy)).toEqual(expectedResult);
+  });
+
+  it('should correctly process if policy is not passed', () => {
+    expect(parseInitialValues()).toEqual({});
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LostItemFeePolicySettings` component in `settings/LostItemFeePolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-758

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/155941490-57746a0c-913b-420d-93fd-225d439a391a.png)

