### PR TITLE
UICIRC-757: UI tests replacement with RTL/Jest for component LoanPoli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Permission errors with `ui-circulation.settings.notice-templates`. Refs UICIRC-744.
 * Add `user-settings.custom-fields.collection.get` as subpermission for `ui-circulation.settings.other-settings`. Refs UICIRC-750.
 * Add `overdue-fines-policies.collection.get` and `lost-item-fees-policies.collection.get` as subpermissions for `ui-circulation.settings.circulation-rules`. Refs UICIRC-714.
+* Add RTL/Jest testing for `LoanPolicySettings` component in `src/settings/LoanPolicy`. Refs UICIRC-757.
 
 ## [6.0.1] (https://github.com/folio-org/ui-circulation/tree/v6.0.1) (2021-11-23)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.0...v6.0.1)

--- a/src/settings/LoanPolicy/LoanPolicySettings.js
+++ b/src/settings/LoanPolicy/LoanPolicySettings.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { sortBy } from 'lodash';
-import {
-  FormattedMessage,
-  injectIntl,
-} from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import { EntryManager } from '@folio/stripes/smart-components';
 import { stripesConnect } from '@folio/stripes/core';
@@ -42,7 +39,7 @@ class LoanPolicySettings extends React.Component {
   static propTypes = {
     checkPolicy: PropTypes.func.isRequired,
     closeText: PropTypes.string.isRequired,
-    intl: PropTypes.object,
+    intl: PropTypes.object.isRequired,
     labelText: PropTypes.string.isRequired,
     messageText: PropTypes.string.isRequired,
     location: PropTypes.object.isRequired,
@@ -95,14 +92,14 @@ class LoanPolicySettings extends React.Component {
         permissions={permissions}
         parentResources={resources}
         prohibitItemDelete={{
-          close: <FormattedMessage id={this.props.closeText} />,
-          label: <FormattedMessage id={this.props.labelText} />,
-          message: <FormattedMessage id={this.props.messageText} />,
+          close: formatMessage({ id: this.props.closeText }),
+          label: formatMessage({ id: this.props.labelText }),
+          message: formatMessage({ id: this.props.messageText }),
         }}
         detailComponent={LoanPolicyDetail}
         enableDetailsActionMenu
         entryFormComponent={LoanPolicyForm}
-        paneTitle={<FormattedMessage id="ui-circulation.settings.loanPolicy.paneTitle" />}
+        paneTitle={formatMessage({ id: 'ui-circulation.settings.loanPolicy.paneTitle' })}
         entryLabel={formatMessage({ id: 'ui-circulation.settings.loanPolicy.entryLabel' })}
         defaultEntry={LoanPolicy.defaultLoanPolicy()}
         onBeforeSave={normalize}

--- a/src/settings/LoanPolicy/LoanPolicySettings.test.js
+++ b/src/settings/LoanPolicy/LoanPolicySettings.test.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  render,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { EntryManager } from '@folio/stripes/smart-components';
+
+import LoanPolicyDetail from './LoanPolicyDetail';
+import LoanPolicyForm from './LoanPolicyForm';
+import { normalize } from './utils/normalize';
+import LoanPolicySettings from './LoanPolicySettings';
+
+const mockDefaultLoanPolicyReturnValue = 'mockDefaultLoanPolicyReturnValue';
+
+jest.mock('./LoanPolicyDetail', () => jest.fn(() => null));
+jest.mock('./LoanPolicyForm', () => jest.fn(() => null));
+jest.mock('../Models/LoanPolicy', () => ({
+  defaultLoanPolicy: jest.fn(() => mockDefaultLoanPolicyReturnValue),
+}));
+jest.mock('./utils/normalize', () => jest.fn(() => null));
+jest.mock('../wrappers/withPreventDelete', () => jest.fn((component) => component));
+jest.mock('../../constants', () => ({
+  MAX_UNPAGED_RESOURCE_COUNT: 1,
+}));
+
+describe('LoanPolicySettings', () => {
+  const labelIds = {
+    paneTitle: 'ui-circulation.settings.loanPolicy.paneTitle',
+    entryLabel: 'ui-circulation.settings.loanPolicy.entryLabel',
+  };
+  const testMutator = {
+    loanPolicies: {
+      POST: jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+    fixedDueDateSchedules: {
+      POST: jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  };
+  const testResources = {
+    loanPolicies: {
+      records: [{
+        name: 'Pasha',
+      }, {
+        name: 'Zelda',
+      }, {
+        name: 'Alex',
+      }],
+    },
+    fixedDueDateSchedules: {},
+  };
+  const testCheckPolicy = jest.fn();
+  const testCloseText = 'testCloseText';
+  const testLabelText = 'testLabelText';
+  const testMessageText = 'testMessageText';
+  const testDefaultProps = {
+    checkPolicy: testCheckPolicy,
+    closeText: testCloseText,
+    labelText: testLabelText,
+    messageText: testMessageText,
+    resources: testResources,
+    mutator: testMutator,
+  };
+
+  afterEach(() => {
+    EntryManager.mockClear();
+  });
+
+  describe('with default props', () => {
+    it('should render "EntryManager" component', () => {
+      render(
+        <LoanPolicySettings {...testDefaultProps} />
+      );
+
+      const expectedEntryList = [{
+        name: 'Alex',
+      }, {
+        name: 'Pasha',
+      }, {
+        name: 'Zelda',
+      }];
+
+      expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+        nameKey: 'name',
+        resourceKey: 'loanPolicies',
+        entryList: expectedEntryList,
+        isEntryInUse: testCheckPolicy,
+        parentMutator: testMutator,
+        permissions: {
+          put: 'ui-circulation.settings.loan-policies',
+          post: 'ui-circulation.settings.loan-policies',
+          delete: 'ui-circulation.settings.loan-policies',
+        },
+        parentResources: testResources,
+        prohibitItemDelete: {
+          close: testCloseText,
+          label: testLabelText,
+          message: testMessageText,
+        },
+        detailComponent: LoanPolicyDetail,
+        enableDetailsActionMenu: true,
+        entryFormComponent: LoanPolicyForm,
+        paneTitle: labelIds.paneTitle,
+        entryLabel: labelIds.entryLabel,
+        defaultEntry: mockDefaultLoanPolicyReturnValue,
+        onBeforeSave: normalize,
+      }), {});
+    });
+
+    it('should render "EntryManager" component when loanPolicies resource is not passed', () => {
+      const { loanPolicies, ...restResources } = testResources;
+      render(
+        <LoanPolicySettings
+          {...testDefaultProps}
+          resources={restResources}
+        />
+      );
+
+      const expectedEntryList = [];
+
+      expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+        entryList: expectedEntryList,
+      }), {});
+    });
+
+    it('should render "EntryManager" component when loanPolicies resource has no records', () => {
+      render(
+        <LoanPolicySettings
+          {...testDefaultProps}
+          resources={{
+            ...testResources,
+            loanPolicies: {},
+          }}
+        />
+      );
+
+      const expectedEntryList = [];
+
+      expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+        entryList: expectedEntryList,
+      }), {});
+    });
+  });
+});

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -1,7 +1,14 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/core', () => ({
-  stripesConnect: jest.fn((component) => component),
+  stripesConnect: (Component) => (props) => (
+    <Component
+      {...props}
+      stripes={{
+        logger: () => {},
+      }}
+    />
+  ),
   stripesShape: {},
   withStripes: (Component) => (props) => <Component {...props} />,
 }));


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LoanPolicySettings` component in `src/settings/LoanPolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-757

## Screenshots
<img width="1269" alt="Screen Shot 2022-02-28 at 4 56 45 PM" src="https://user-images.githubusercontent.com/47976677/155996462-b853cfb3-0031-4f7b-8836-d69d90069b82.png">

