### PR TITLE
UICIRC-759: Add Jest/RTL tests for `NoticePolicySettings` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add RTL/Jest testing for `LostItemFeePolicySettings` component in `settings/LostItemFeePolicy`. Refs UICIRC-758.
 * Add RTL/Jest testing for `PatronNotices` component in `settings/PatronNotices`. Refs UICIRC-760.
 * Add RTL/Jest testing for `StaffSlipManager` component in `src/settings/StaffSlips`. Refs UICIRC-762.
+* Add RTL/Jest testing for `LoanPolicySettings` component in `src/settings/LoanPolicy`. Refs UICIRC-757.
+* Add RTL/Jest testing for `NoticePolicySettings` component in `settings/NoticePolicy`. Refs UICIRC-759.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)
@@ -57,7 +59,6 @@
 * Permission errors with `ui-circulation.settings.notice-templates`. Refs UICIRC-744.
 * Add `user-settings.custom-fields.collection.get` as subpermission for `ui-circulation.settings.other-settings`. Refs UICIRC-750.
 * Add `overdue-fines-policies.collection.get` and `lost-item-fees-policies.collection.get` as subpermissions for `ui-circulation.settings.circulation-rules`. Refs UICIRC-714.
-* Add RTL/Jest testing for `LoanPolicySettings` component in `src/settings/LoanPolicy`. Refs UICIRC-757.
 
 ## [6.0.1] (https://github.com/folio-org/ui-circulation/tree/v6.0.1) (2021-11-23)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.0...v6.0.1)

--- a/src/settings/NoticePolicy/NoticePolicySettings.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.js
@@ -7,7 +7,6 @@ import {
   sortBy,
 } from 'lodash';
 import {
-  FormattedMessage,
   injectIntl,
 } from 'react-intl';
 
@@ -20,6 +19,16 @@ import normalize from './utils/normalize';
 import { NoticePolicy } from '../Models/NoticePolicy';
 
 import { MAX_UNPAGED_RESOURCE_COUNT } from '../../constants';
+
+export const parseInitialValues = (entity) => {
+  const policy = cloneDeep(entity);
+
+  forEach(policy?.loanNotices || [], (loanNotice) => {
+    loanNotice.realTime = loanNotice.realTime.toString();
+  });
+
+  return policy;
+};
 
 class NoticePolicySettings extends React.Component {
   static manifest = Object.freeze({
@@ -73,16 +82,6 @@ class NoticePolicySettings extends React.Component {
     return circulationRules.rulesAsText.includes(policyId);
   };
 
-  parseInitialValues = (entity) => {
-    const policy = cloneDeep(entity);
-
-    forEach(policy?.loanNotices || [], (loanNotice) => {
-      loanNotice.realTime = loanNotice.realTime.toString();
-    });
-
-    return policy;
-  };
-
   render() {
     const {
       resources,
@@ -112,16 +111,16 @@ class NoticePolicySettings extends React.Component {
         parentResources={resources}
         detailComponent={NoticePolicyDetail}
         entryFormComponent={NoticePolicyForm}
-        paneTitle={<FormattedMessage id="ui-circulation.settings.noticePolicy.paneTitle" />}
+        paneTitle={formatMessage({ id: 'ui-circulation.settings.noticePolicy.paneTitle' })}
         entryLabel={formatMessage({ id: 'ui-circulation.settings.noticePolicy.entryLabel' })}
         defaultEntry={NoticePolicy.defaultNoticePolicy()}
         isEntryInUse={this.isPolicyInUse}
         prohibitItemDelete={{
-          close: <FormattedMessage id="ui-circulation.settings.common.close" />,
-          label: <FormattedMessage id="ui-circulation.settings.noticePolicy.denyDelete.header" />,
-          message: <FormattedMessage id="ui-circulation.settings.noticePolicy.denyDelete.body" />,
+          close: formatMessage({ id: 'ui-circulation.settings.common.close' }),
+          label: formatMessage({ id: 'ui-circulation.settings.noticePolicy.denyDelete.header' }),
+          message: formatMessage({ id: 'ui-circulation.settings.noticePolicy.denyDelete.body' }),
         }}
-        parseInitialValues={this.parseInitialValues}
+        parseInitialValues={parseInitialValues}
         onBeforeSave={normalize}
       />
     );

--- a/src/settings/NoticePolicy/NoticePolicySettings.test.js
+++ b/src/settings/NoticePolicy/NoticePolicySettings.test.js
@@ -1,0 +1,201 @@
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { EntryManager } from '@folio/stripes/smart-components';
+
+import NoticePolicySettings, {
+  parseInitialValues,
+} from './NoticePolicySettings';
+import NoticePolicyDetail from './NoticePolicyDetail';
+import NoticePolicyForm from './NoticePolicyForm';
+import { NoticePolicy } from '../Models/NoticePolicy';
+import normalize from './utils/normalize';
+
+describe('NoticePolicySettings', () => {
+  const testIds = {
+    isPolicyInUse: 'isPolicyInUse',
+  };
+  const labelIds = {
+    paneTitle: 'ui-circulation.settings.noticePolicy.paneTitle',
+    entryLabel: 'ui-circulation.settings.noticePolicy.entryLabel',
+    close: 'ui-circulation.settings.common.close',
+    header: 'ui-circulation.settings.noticePolicy.denyDelete.header',
+    body: 'ui-circulation.settings.noticePolicy.denyDelete.body',
+  };
+  const mockedPatronNoticePolicies = {
+    records: [
+      {
+        name: 'Zak',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Alex',
+      },
+    ],
+  };
+  const mockedCirculationRules = {
+    records: [{
+      rulesAsText: testIds.isPolicyInUse,
+    }],
+  };
+  const mockedMutator = {
+    patronNoticePolicies: {
+      POST:jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  };
+  const defaultProps = {
+    resources: {
+      patronNoticePolicies: mockedPatronNoticePolicies,
+      circulationRules: mockedCirculationRules,
+    },
+    mutator: mockedMutator,
+  };
+
+  afterEach(() => {
+    EntryManager.mockClear();
+  });
+
+  it('should execute "EntryManager" with passed props', () => {
+    const sortedEntyList = [
+      {
+        name: 'Alex',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Zak',
+      },
+    ];
+
+    render(
+      <NoticePolicySettings
+        {...defaultProps}
+      />
+    );
+
+    expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+      nameKey: 'name',
+      resourceKey: 'patronNoticePolicies',
+      entryList: sortedEntyList,
+      parentMutator: mockedMutator,
+      enableDetailsActionMenu: true,
+      permissions: {
+        put: 'ui-circulation.settings.notice-policies',
+        post: 'ui-circulation.settings.notice-policies',
+        delete: 'ui-circulation.settings.notice-policies',
+      },
+      parentResources: defaultProps.resources,
+      detailComponent: NoticePolicyDetail,
+      entryFormComponent: NoticePolicyForm,
+      paneTitle: labelIds.paneTitle,
+      entryLabel: labelIds.entryLabel,
+      defaultEntry: NoticePolicy.defaultNoticePolicy(),
+      prohibitItemDelete: {
+        close: labelIds.close,
+        label: labelIds.header,
+        message: labelIds.body,
+      },
+      parseInitialValues,
+      onBeforeSave: normalize,
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "records" in "patronNoticePolicies"', () => {
+    render(
+      <NoticePolicySettings
+        {...defaultProps}
+        resources={{
+          ...defaultProps.resources,
+          patronNoticePolicies: {},
+        }}
+      />
+    );
+
+    expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "patronNoticePolicies" in "resources"', () => {
+    render(
+      <NoticePolicySettings
+        {...defaultProps}
+        resources={{
+          circulationRules: mockedCirculationRules,
+        }}
+      />
+    );
+
+    expect(EntryManager).toHaveBeenCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  describe('isPolicyInUse', () => {
+    beforeEach(() => {
+      EntryManager.mockImplementationOnce(({ isEntryInUse }) => {
+        return isEntryInUse(testIds.isPolicyInUse)
+          ? <div data-testid="isPolicyInUse" />
+          : null;
+      });
+    });
+
+    it('should correctly process "isPolicyInUse" method when policy is included', () => {
+      render(
+        <NoticePolicySettings
+          {...defaultProps}
+        />
+      );
+
+      expect(screen.getByTestId(testIds.isPolicyInUse)).toBeInTheDocument();
+    });
+
+    it('should correctly process "isPolicyInUse" method when policy is not included', () => {
+      render(
+        <NoticePolicySettings
+          {...defaultProps}
+          resources={{
+            circulationRules: {},
+          }}
+        />
+      );
+
+      expect(screen.queryByTestId(testIds.isPolicyInUse)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('parseInitialValues', () => {
+  it('should correctly process passed policy', () => {
+    const policyForTest = {
+      loanNotices: [
+        { realTime: 42 },
+        { realTime: 99 },
+        { realTime: 1000 },
+      ],
+    };
+    const expectedResult = {
+      loanNotices: [
+        { realTime: '42' },
+        { realTime: '99' },
+        { realTime: '1000' },
+      ],
+    };
+
+    expect(parseInitialValues(policyForTest)).toEqual(expectedResult);
+  });
+
+  it('should correctly process passed policy if no "loanNotices" in it', () => {
+    expect(parseInitialValues({})).toEqual({});
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `NoticePolicySettings` component in `settings/NoticePolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-759

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/156123149-987c69ce-07f9-4c5b-b7b8-f3abeef84a2b.png)
