### PR TITLE
UICIRC-763: UI tests replacement with RTL/Jest for component LoanHist…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add RTL/Jest testing for `LoanPolicySettings` component in `src/settings/LoanPolicy`. Refs UICIRC-757.
 * Add RTL/Jest testing for `NoticePolicySettings` component in `settings/NoticePolicy`. Refs UICIRC-759.
 * Add RTL/Jest testing for `RequestPolicySettings` component in `settings/RequestPolicy`. Refs UICIRC-761.
+* Add RTL/Jest testing for `LoanHistorySettings` component in `src/settings/LoanHistory`. Refs UICIRC-763.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)

--- a/src/settings/LoanHistory/LoanHistorySettings.js
+++ b/src/settings/LoanHistory/LoanHistorySettings.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import {
   head,
   isEmpty,
@@ -15,9 +16,51 @@ import { ConfigManager } from '@folio/stripes/smart-components';
 import normalize from './utils/normalize';
 import LoanHistoryForm from './LoanHistoryForm';
 
+export const getInitialValues = (settings) => {
+  let config;
+  const value = isEmpty(settings) ? '' : head(settings).value;
+  const defaultConfig = {
+    closingType: {
+      loan: null,
+      feeFine: null,
+      loanExceptions: [],
+    },
+    loan: {},
+    feeFine: {},
+    loanExceptions: [],
+    treatEnabled: false,
+  };
+
+  try {
+    config = { ...defaultConfig, ...JSON.parse(value) };
+  } catch (e) {
+    config = defaultConfig;
+  }
+
+  return { ...config };
+};
+
+export const normalizeData = (value) => {
+  const { closingType, loan, feeFine, loanExceptions, treatEnabled } = normalize(value);
+  const loanHistorySettings = {
+    closingType: cloneDeep(closingType),
+    loan,
+    feeFine,
+    loanExceptions,
+    treatEnabled
+  };
+
+  loanHistorySettings.closingType.feeFine = treatEnabled
+    ? loanHistorySettings.closingType.feeFine
+    : null;
+
+  return JSON.stringify(loanHistorySettings);
+};
+
 class LoanHistorySettings extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -26,60 +69,25 @@ class LoanHistorySettings extends React.Component {
     this.configManager = props.stripes.connect(ConfigManager);
   }
 
-  getInitialValues(settings) {
-    let config;
-    const value = isEmpty(settings) ? '' : head(settings).value;
-    const defaultConfig = {
-      closingType: {
-        loan: null,
-        feeFine: null,
-        loanExceptions: [],
-      },
-      loan: {},
-      feeFine: {},
-      loanExceptions: [],
-      treatEnabled: false,
-    };
-
-    try {
-      config = { ...defaultConfig, ...JSON.parse(value) };
-    } catch (e) {
-      config = defaultConfig;
-    }
-
-    return { ...config };
-  }
-
-  normalizeData = (value) => {
-    const { closingType, loan, feeFine, loanExceptions, treatEnabled } = normalize(value);
-    const loanHistorySettings = {
-      closingType: cloneDeep(closingType),
-      loan,
-      feeFine,
-      loanExceptions,
-      treatEnabled
-    };
-
-    loanHistorySettings.closingType.feeFine = treatEnabled
-      ? loanHistorySettings.closingType.feeFine
-      : null;
-
-    return JSON.stringify(loanHistorySettings);
-  }
-
   render() {
+    const {
+      intl: {
+        formatMessage,
+      },
+    } = this.props;
+
     return (
       <this.configManager
-        label={<FormattedMessage id="ui-circulation.settings.index.loanHistory" />}
+        label={formatMessage({ id: 'ui-circulation.settings.index.loanHistory' })}
         moduleName="LOAN_HISTORY"
         configName="loan_history"
         configFormComponent={LoanHistoryForm}
         stripes={this.props.stripes}
-        getInitialValues={this.getInitialValues}
-        onBeforeSave={this.normalizeData}
+        getInitialValues={getInitialValues}
+        onBeforeSave={normalizeData}
       />
     );
   }
 }
 
-export default withStripes(LoanHistorySettings);
+export default injectIntl(withStripes(LoanHistorySettings));

--- a/src/settings/LoanHistory/LoanHistorySettings.test.js
+++ b/src/settings/LoanHistory/LoanHistorySettings.test.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { ConfigManager } from '@folio/stripes/smart-components';
+
+import LoanHistorySettings, {
+  getInitialValues,
+  normalizeData,
+} from './LoanHistorySettings';
+import LoanHistoryForm from './LoanHistoryForm';
+
+jest.mock('./LoanHistoryForm', () => jest.fn(() => null));
+
+describe('LoanHistorySettings', () => {
+  const labelIds = {
+    loanHistory: 'ui-circulation.settings.index.loanHistory',
+  };
+
+  const testStripes = {
+    connect: jest.fn((Component) => Component),
+  };
+
+  const testDefaultProps = {
+    stripes: testStripes,
+  };
+
+  afterEach(() => {
+    ConfigManager.mockClear();
+  });
+
+  describe('with default props', () => {
+    it('should render "EntryManager" component', () => {
+      render(
+        <LoanHistorySettings {...testDefaultProps} />
+      );
+
+      expect(ConfigManager).toHaveBeenCalledWith(expect.objectContaining({
+        label: labelIds.loanHistory,
+        moduleName: 'LOAN_HISTORY',
+        configName: 'loan_history',
+        configFormComponent: LoanHistoryForm,
+        stripes: testStripes,
+        getInitialValues,
+        onBeforeSave: normalizeData,
+      }), {});
+    });
+  });
+
+  describe('getInitialValues method', () => {
+    const defaultConfig = {
+      closingType: {
+        loan: null,
+        feeFine: null,
+        loanExceptions: [],
+      },
+      loan: {},
+      feeFine: {},
+      loanExceptions: [],
+      treatEnabled: false,
+    };
+
+    it('should get initial values when settings are not passed', () => {
+      expect(getInitialValues()).toEqual(defaultConfig);
+    });
+
+    it('should get initial values when settings are passed and settings are empty object', () => {
+      expect(getInitialValues({})).toEqual(defaultConfig);
+    });
+
+    it('should get initial values when settings are passed and settings are not empty object', () => {
+      const value = {
+        a: 'a',
+        b: 'b',
+      };
+      const expectedResult = {
+        ...defaultConfig,
+        ...value,
+      };
+
+      expect(getInitialValues([{ value: JSON.stringify(value) }])).toEqual(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LoanHistorySettings` component in `src/settings/LoanHistory`.

## Refs
https://issues.folio.org/browse/UICIRC-763

## Screenshots
<img width="1271" alt="Screen Shot 2022-03-02 at 4 42 14 PM" src="https://user-images.githubusercontent.com/47976677/156373325-2cd2ea37-442c-45d1-b3fb-f4a31ef0e0cd.png">


