### PR TITLE
UICIRC-654: UI tests replacement with RTL/Jest for folder Anonymizing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add RTL/Jest testing for `NoticePolicySettings` component in `settings/NoticePolicy`. Refs UICIRC-759.
 * Add RTL/Jest testing for `RequestPolicySettings` component in `settings/RequestPolicy`. Refs UICIRC-761.
 * Add RTL/Jest testing for `LoanHistorySettings` component in `src/settings/LoanHistory`. Refs UICIRC-763.
+* Add RTL/Jest testing for `AnonymizingTypeSelectContainer` component in `src/settings/components/AnonymizingTypeSelect`. Refs UICIRC-654.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.js
@@ -19,7 +19,7 @@ import css from './AnonymizingTypeSelectContainer.css';
 
 class AnonymizingTypeSelectContainer extends Component {
   static propTypes = {
-    intl: PropTypes.object,
+    intl: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
     types: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -35,6 +35,7 @@ class AnonymizingTypeSelectContainer extends Component {
   renderPeriod(name, path) {
     return (
       <div
+        data-testid="period"
         data-test-period-section
         className={css.periodContainer}
       >

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.test.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.test.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import AnonymizingTypeSelect from './AnonymizingTypeSelect';
+import { Period } from '..';
+import AnonymizingTypeSelectContainer from './AnonymizingTypeSelectContainer';
+
+Field.mockImplementation(() => null);
+
+jest.mock('./AnonymizingTypeSelect', () => jest.fn(({ types }) => (
+  <div>
+    {types.map((type, index) => (
+      <div key={index}>
+        {type.label}
+      </div>
+    ))}
+  </div>
+)));
+jest.mock('..', () => ({
+  Period: jest.fn(() => null),
+}));
+
+describe('AnonymizingTypeSelectContainer', () => {
+  const labelIds = {
+    afterClose: 'ui-circulation.settings.loanHistory.afterClose',
+  };
+  const testName = 'testName';
+  const testPath = 'testPath';
+  const testTypes = [
+    {
+      value: 'immediately',
+      label: 'ui-circulation.settings.loanHistory.immediatelyAfterClose',
+    },
+    {
+      value: 'interval',
+      label: 'ui-circulation.settings.loanHistory.interval',
+    },
+  ];
+  const testDefaultProps = {
+    name: testName,
+    path: testPath,
+    types: testTypes,
+  };
+
+  afterEach(() => {
+    Field.mockClear();
+    Period.mockClear();
+    AnonymizingTypeSelect.mockClear();
+  });
+
+  describe('with default props', () => {
+    beforeEach(() => {
+      render(
+        <AnonymizingTypeSelectContainer {...testDefaultProps} />
+      );
+    });
+
+    it('should render AnonymizingTypeSelect component', () => {
+      expect(AnonymizingTypeSelect).toHaveBeenCalledWith(expect.objectContaining({
+        name: testPath,
+      }), {});
+
+      expect(Period).toHaveBeenCalledWith(expect.objectContaining({
+        inputValuePath: `${testPath}.duration`,
+        selectValuePath: `${testPath}.intervalId`,
+      }), {});
+
+      expect(within(screen.getByTestId('period')).getByText(labelIds.afterClose)).toBeVisible();
+    });
+
+    it('should render Field component', () => {
+      expect(Field).toHaveBeenCalledWith(expect.objectContaining({
+        name: `${testPath}Selected`,
+      }), {});
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `AnonymizingTypeSelectContainer` component in `src/settings/components/AnonymizingTypeSelect`.

## Refs
https://issues.folio.org/browse/UICIRC-654

## Screenshots
<img width="1271" alt="Screen Shot 2022-03-04 at 11 37 24 AM" src="https://user-images.githubusercontent.com/47976677/156728667-a631496a-405f-4941-916c-3cfe6f89f0d0.png">


