### PR TITLE
UICIRC-772: Lost Item Policy validation error with aging only recalls…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add RTL/Jest testing for `AnonymizingTypeSelectContainer` component in `src/settings/components/AnonymizingTypeSelect`. Refs UICIRC-654.
 * Add id for Pane component. Refs UICIRC-756.
 * Fix problem with module launch. Refs UICIRC-768.
+* Lost Item Policy validation error with aging only recalls to lost. Refs UICIRC-772.
 
 ## [7.0.1](https://github.com/folio-org/ui-circulation/tree/v7.0.1) (2022-03-31)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.0...v7.0.1)

--- a/src/settings/Validation/engine/handlers.js
+++ b/src/settings/Validation/engine/handlers.js
@@ -115,8 +115,12 @@ export const hasPatronBilledAfterAgedToLostValue = (value, model) => {
 
 export const hasChargeAmountItemSystemSelected = (value, model) => {
   const chargeAmountItemSystem = get(model, 'chargeAmountItemSystem');
+  const itemAgedLostOverdueDuration = get(model, 'itemAgedLostOverdue.duration');
+  const recalledItemAgedLostOverdueDuration = get(model, 'recalledItemAgedLostOverdue.duration');
 
-  return (chargeAmountItemSystem && isNotEmpty(value)) || !chargeAmountItemSystem;
+  return !chargeAmountItemSystem
+    || isNotEmpty(itemAgedLostOverdueDuration)
+    || isNotEmpty(recalledItemAgedLostOverdueDuration);
 };
 
 export const isToBeforeFrom = (value, model, { pathToSection }) => {

--- a/src/settings/Validation/lost-item-fee-policy/lost-item-fee.js
+++ b/src/settings/Validation/lost-item-fee-policy/lost-item-fee.js
@@ -32,7 +32,10 @@ export default function (l) {
     },
     'itemAgedLostOverdue.duration': {
       rules: ['chargeAmountItemSystemSelected', 'hasPatronBilledAfterAgedToLostValue', 'hasAmount', 'isIntegerGreaterThanOrEqualToZero'],
-      shouldValidate: l.hasInterval('itemAgedLostOverdue.intervalId') || l.hasValue('patronBilledAfterAgedLost.duration') || l.hasPassedValue('chargeAmountItemSystem', true) || l.hasValue('itemAgedLostOverdue.duration'),
+      shouldValidate: l.hasInterval('itemAgedLostOverdue.intervalId')
+        || l.hasValue('patronBilledAfterAgedLost.duration')
+        || l.hasValue('itemAgedLostOverdue.duration')
+        || (l.hasPassedValue('chargeAmountItemSystem', true) && !l.hasValue('recalledItemAgedLostOverdue.duration')),
     },
     'itemAgedLostOverdue.intervalId': {
       rules: ['isNotEmptySelect'],
@@ -50,8 +53,11 @@ export default function (l) {
     // 'Recalled items aged to lost after overdue':
     // Duration field: If there is an interval selected, there must be a duration value
     'recalledItemAgedLostOverdue.duration': {
-      rules: ['hasPatronBilledAfterRecalledAgedToLostValue', 'hasAmount', 'isIntegerGreaterThanOrEqualToZero'],
-      shouldValidate: l.hasInterval('recalledItemAgedLostOverdue.intervalId') || l.hasValue('patronBilledAfterRecalledItemAgedLost.duration'),
+      rules: ['chargeAmountItemSystemSelected', 'hasPatronBilledAfterRecalledAgedToLostValue', 'hasAmount', 'isIntegerGreaterThanOrEqualToZero'],
+      shouldValidate: l.hasInterval('recalledItemAgedLostOverdue.intervalId')
+        || l.hasValue('patronBilledAfterRecalledItemAgedLost.duration')
+        || l.hasValue('recalledItemAgedLostOverdue.duration')
+        || (l.hasPassedValue('chargeAmountItemSystem', true) && !l.hasValue('itemAgedLostOverdue.duration')),
     },
     // Interval field: If there is a duration value, an interval must be selected
     'recalledItemAgedLostOverdue.intervalId': {


### PR DESCRIPTION
## Purpose
When `Charge lost item processing fee if item aged to lost by system?` field has `yes` value then
at least one of fields(`Recalled items aged to lost after overdue` or `Items aged to lost after overdue`) must have value(required).

## Approach
[hasChargeAmountItemSystemSelected validation](https://github.com/folio-org/ui-circulation/blob/df287cf74f0fdacbb29bb9918b9e83194d60a61c/src/settings/Validation/engine/handlers.js#L116-L124) now checks that `Recalled items aged to lost after overdue` or `Items aged to lost after overdue` fields have value when `Charge lost item processing fee if item aged to lost by system?` field has `yes` value.

## Screenshots
When `Charge lost item processing fee if item aged to lost by system?` field has `yes` value and

1) `Recalled items aged to lost after overdue` and `Items aged to lost after overdue` are empty:
<img width="544" alt="Screen Shot 2022-03-30 at 12 31 40 PM" src="https://user-images.githubusercontent.com/47976677/161062064-2a03f933-9a0f-435a-9f58-506f6939fbce.png">

2) `Recalled items aged to lost after overdue` or `Items aged to lost after overdue` is not empty or both of them are not empty:
<img width="581" alt="Screen Shot 2022-03-30 at 12 31 50 PM" src="https://user-images.githubusercontent.com/47976677/161062216-ae793f49-948c-4c5e-8629-dfd63f30a136.png">
<img width="623" alt="Screen Shot 2022-03-30 at 12 32 04 PM" src="https://user-images.githubusercontent.com/47976677/161062231-d14b5403-bac9-4453-b348-59ed805cced9.png">
<img width="522" alt="Screen Shot 2022-03-30 at 12 37 28 PM" src="https://user-images.githubusercontent.com/47976677/161062238-587cabf8-1725-47e3-9f7b-afe975577e9c.png">



## Refs
https://issues.folio.org/browse/UICIRC-772