### PR TITLE
UICIRC-647: Add Jest/RTL tests for `RequestPolicyForm` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Add RTL/Jest testing for `AnonymizingTypeSelectContainer` component in `src/settings/components/AnonymizingTypeSelect`. Refs UICIRC-654.
 * Add id for Pane component. Refs UICIRC-756.
 * Fix problem with module launch. Refs UICIRC-768.
+* Cover LoansSection component by RTL/jest tests. Refs UICIRC-613.
+* Add RTL/Jest testing for `RequestPolicyForm` component in `src/settings/RequestPolicy`. Refs UICIRC-647.
 
 ## [7.0.2](https://github.com/folio-org/ui-circulation/tree/v7.0.2) (2022-04-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.1...v7.0.2)
@@ -22,7 +24,6 @@
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.0...v7.0.1)
 
 * Add the possibility to select only active templates. Refs UICIRC-771.
-* Cover LoansSection component by RTL/jest tests. Refs UICIRC-613.
 
 ## [7.0.0](https://github.com/folio-org/ui-circulation/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v6.0.1...v7.0.0)

--- a/src/settings/RequestPolicy/RequestPolicyForm.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import {
   find,
   memoize,
@@ -36,6 +36,7 @@ class RequestPolicyForm extends React.Component {
     submitting: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -72,28 +73,31 @@ class RequestPolicyForm extends React.Component {
           'X-Okapi-Tenant': okapi.tenant,
           'X-Okapi-Token': okapi.token,
           'Content-Type': 'application/json',
-        }
+        },
       });
   };
 
   validate = memoize(async (name) => {
-    const { initialValues } = this.props;
+    const {
+      initialValues,
+      intl: {
+        formatMessage,
+      },
+    } = this.props;
 
     let error;
-
     if (name) {
       try {
         const response = await this.getPoliciesByName(name);
         const { requestPolicies = [] } = await response.json();
         const matchedPolicy = find(requestPolicies, ['name', name]);
         if (matchedPolicy && matchedPolicy.id !== initialValues.id) {
-          error = <FormattedMessage id="ui-circulation.settings.requestPolicy.errors.nameExists" />;
+          error = formatMessage({ id: 'ui-circulation.settings.requestPolicy.errors.nameExists' });
         }
       } catch (e) {
         throw new Error(e);
       }
     }
-
     return error;
   });
 
@@ -105,6 +109,9 @@ class RequestPolicyForm extends React.Component {
       submitting,
       handleSubmit,
       onCancel,
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     const { sections } = this.state;
@@ -114,7 +121,7 @@ class RequestPolicyForm extends React.Component {
 
     const panelTitle = policy.id
       ? policy.name
-      : <FormattedMessage id="ui-circulation.settings.requestPolicy.createEntryLabel" />;
+      : formatMessage({ id: 'ui-circulation.settings.requestPolicy.createEntryLabel' });
 
     const footerPaneProps = {
       pristine,
@@ -124,6 +131,7 @@ class RequestPolicyForm extends React.Component {
 
     return (
       <form
+        data-testid="form"
         noValidate
         className={css.requestPolicyForm}
         data-test-request-policy-form
@@ -169,4 +177,4 @@ class RequestPolicyForm extends React.Component {
 export default stripesFinalForm({
   navigationCheck: true,
   validate: validateRequestPolicy,
-})(RequestPolicyForm);
+})(injectIntl(RequestPolicyForm));

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -132,7 +132,7 @@ describe('RequestPolicyForm', () => {
       }, {});
     });
 
-    it('"CancelButton" should be executed with correct props', () => {
+    it('"FooterPane" should be executed with correct props', () => {
       expect(FooterPane).toHaveBeenCalledWith({
         pristine: true,
         submitting: false,

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -30,17 +30,6 @@ jest.mock('../components', () => ({
   FooterPane: jest.fn(() => null),
 }));
 
-Pane.mockImplementation(({
-  children,
-  firstMenu,
-  footer,
-}) => (
-  <div>
-    {firstMenu}
-    {children}
-    {footer}
-  </div>
-));
 ExpandAllButton.mockImplementation(({ onToggle }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div onClick={() => onToggle({ generalRequestPolicyForm: false })}>

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -1,0 +1,309 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  AccordionSet,
+  ExpandAllButton,
+  Pane,
+} from '@folio/stripes/components';
+
+import RequestPolicyForm from './RequestPolicyForm';
+import { GeneralSection } from './components';
+import {
+  CancelButton,
+  FooterPane,
+} from '../components';
+import RequestPolicy from '../Models/RequestPolicy';
+
+jest.mock('@folio/stripes/final-form', () => jest.fn(() => (component) => component));
+jest.mock('./components', () => ({
+  GeneralSection: jest.fn(() => null),
+}));
+jest.mock('../components', () => ({
+  CancelButton: jest.fn(() => null),
+  FooterPane: jest.fn(() => null),
+}));
+
+Pane.mockImplementation(({
+  children,
+  firstMenu,
+  footer,
+}) => (
+  <div>
+    {firstMenu}
+    {children}
+    {footer}
+  </div>
+));
+ExpandAllButton.mockImplementation(({ onToggle }) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div onClick={() => onToggle({ generalRequestPolicyForm: false })}>
+    ExpandAllButton
+  </div>
+));
+AccordionSet.mockImplementation(({
+  children,
+  onToggle,
+}) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    data-testid="accordionSet"
+    onClick={() => onToggle({ id: 'generalRequestPolicyForm' })}
+  >
+    {children}
+  </div>
+));
+
+describe('RequestPolicyForm', () => {
+  const labelIds = {
+    createEntryLabel: 'ui-circulation.settings.requestPolicy.createEntryLabel',
+    nameExists: 'ui-circulation.settings.requestPolicy.errors.nameExists',
+    expandAllButton: 'ExpandAllButton',
+  };
+  const testIds = {
+    form: 'form',
+    accordionSet: 'accordionSet',
+  };
+  const okapi = {
+    url: 'url',
+    tenant: 'tenant',
+    token: 'token',
+  };
+  const stripes = {
+    connect: jest.fn(),
+  };
+  const onCancel = jest.fn();
+  const handleSubmit = jest.fn();
+  const defaultProps = {
+    okapi,
+    pristine: true,
+    stripes,
+    submitting: false,
+    onCancel,
+    handleSubmit,
+  };
+
+  afterEach(() => {
+    Pane.mockClear();
+    CancelButton.mockClear();
+    FooterPane.mockClear();
+    GeneralSection.mockClear();
+    ExpandAllButton.mockClear();
+    AccordionSet.mockClear();
+  });
+
+  describe('with default props', () => {
+    const form = {
+      getState: jest.fn(() => ({})),
+    };
+
+    beforeEach(() => {
+      render(
+        <RequestPolicyForm
+          {...defaultProps}
+          form={form}
+        />
+      );
+    });
+
+    it('on form submit correct method should be executed', () => {
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      fireEvent.submit(screen.getByTestId(testIds.form));
+
+      expect(handleSubmit).toHaveBeenCalled();
+    });
+
+    it('"Pane" component should have correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: labelIds.createEntryLabel,
+      }), {});
+    });
+
+    it('"CancelButton" should be executed with correct props', () => {
+      expect(CancelButton).toHaveBeenCalledWith({
+        onCancel,
+      }, {});
+    });
+
+    it('"CancelButton" should be executed with correct props', () => {
+      expect(FooterPane).toHaveBeenCalledWith({
+        pristine: true,
+        submitting: false,
+        onCancel,
+      }, {});
+    });
+
+    it('should have "ExpandAllButton" in the document', () => {
+      expect(screen.getByText(labelIds.expandAllButton)).toBeInTheDocument();
+    });
+
+    it('should correctly change sections status on "ExpandAllButton" click', () => {
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        isOpen: true,
+      }), {});
+
+      fireEvent.click(screen.getByText(labelIds.expandAllButton));
+
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        isOpen: false,
+      }), {});
+    });
+
+    it('should correctly change sections status on "AccordionSet" toggle', () => {
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        isOpen: true,
+      }), {});
+
+      fireEvent.click(screen.getByTestId(testIds.accordionSet));
+
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        isOpen: false,
+      }), {});
+    });
+
+    it('"GeneralSection" should be executed with correct props', () => {
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        metadata: {},
+        connect: stripes.connect,
+      }), {});
+    });
+  });
+
+  describe('when data for policy is passed in initialValues', () => {
+    const name = 'policyName';
+    const initialValues = {
+      id: 'policyId',
+      name,
+      metadata: {
+        createdByUserId: 'createUserId',
+        createdDate: 'createDate',
+        updatedByUserId: 'updateUserId',
+        updatedDate: 'updateDate',
+      },
+    };
+    const form = {
+      getState: jest.fn(() => ({ values: initialValues })),
+    };
+
+    const testPolicy = new RequestPolicy(initialValues);
+
+    beforeEach(() => {
+      render(
+        <RequestPolicyForm
+          {...defaultProps}
+          initialValues={initialValues}
+          form={form}
+        />
+      );
+    });
+
+    it('"Pane" component should have correct title', () => {
+      expect(Pane).toHaveBeenCalledWith(expect.objectContaining({
+        paneTitle: testPolicy.name,
+      }), {});
+    });
+
+    it('"GeneralSection" should be executed with correct metadata prop', () => {
+      expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
+        metadata: testPolicy.metadata,
+      }), {});
+    });
+
+    describe('validation check', () => {
+      const catchFunction = jest.fn();
+
+      beforeAll(() => {
+        GeneralSection.mockImplementation(({ validateName }) => {
+          const dummyMethod = async () => {
+            catchFunction(await validateName(name));
+          };
+
+          dummyMethod();
+
+          return null;
+        });
+      });
+
+      afterAll(() => {
+        global.fetch.mockRestore();
+      });
+
+      describe('when policy with passed name is already exists', () => {
+        beforeAll(() => {
+          global.fetch = jest.fn(() => {
+            return Promise.resolve({
+              json: () => Promise.resolve({
+                requestPolicies: [
+                  {
+                    name: testPolicy.name,
+                    id: 'someTestId',
+                  },
+                ],
+              }),
+            });
+          });
+        });
+
+        afterEach(() => {
+          catchFunction.mockClear();
+        });
+
+        it('should execute "fetch" with correct props', () => {
+          expect(fetch).toBeCalledWith(`${okapi.url}/request-policy-storage/request-policies?query=(name=="${name}")`, {
+            headers: {
+              'X-Okapi-Tenant': okapi.tenant,
+              'X-Okapi-Token': okapi.token,
+              'Content-Type': 'application/json',
+            },
+          });
+        });
+
+        it('the corresponding error should appear', () => {
+          expect(catchFunction).toHaveBeenCalledWith(labelIds.nameExists);
+        });
+      });
+
+      describe('when trying to edit existing policy', () => {
+        beforeAll(() => {
+          global.fetch = jest.fn(() => {
+            return Promise.resolve({
+              json: () => Promise.resolve({
+                requestPolicies: [
+                  {
+                    name: testPolicy.name,
+                    id: testPolicy.id,
+                  },
+                ],
+              }),
+            });
+          });
+        });
+
+        it('should not be any errors', () => {
+          expect(catchFunction).toHaveBeenCalledWith(undefined);
+        });
+      });
+
+      describe('when trying to create new policy', () => {
+        beforeAll(() => {
+          global.fetch = jest.fn(() => {
+            return Promise.resolve({
+              json: () => Promise.resolve({}),
+            });
+          });
+        });
+
+        it('should not be any errors', () => {
+          expect(catchFunction).toHaveBeenCalledWith(undefined);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `RequestPolicyForm` component in `src/settings/RequestPolicy`.

## Refs
https://issues.folio.org/browse/UICIRC-647

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/161220478-8b6f6645-9b5d-4873-b73a-4fa4127e2a61.png)