### PR TITLE
UICIRC-776: Cypress issue with circulation rules form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add RTL/Jest testing for `NoticeCard` component in `src\settings\NoticePolicy\components\EditSections\components`. Refs UICIRC-636.
 * Cover FixedDueDateScheduleForm component by RTL/jest tests. Refs UICIRC-609.
 * Add RTL/Jest testing for `PatronNoticeForm` component in `src/settings/PatronNotices`. Refs UICIRC-644.
+* Cypress issue with circulation rules form. Refs UICIRC-776.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/lib/RuleEditor/RulesEditor.css
+++ b/src/settings/lib/RuleEditor/RulesEditor.css
@@ -1,16 +1,22 @@
 .codeMirrorFullScreen {
-  height: 100%;
-  width: 100%;
   position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
 }
 
 .codeMirrorFullScreen :global .CodeMirror {
-  height: 85%;
-  width: 98%;
+  height: 100%;
 }
 
 .circulationRulesForm {
   height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.circulationRulesFormBody {
+  flex-grow: 1;
+  position: relative;
 }

--- a/src/settings/lib/RuleEditor/RulesForm.js
+++ b/src/settings/lib/RuleEditor/RulesForm.js
@@ -77,7 +77,7 @@ class RulesForm extends React.Component {
             </Button>
           </Col>
         </Row>
-        <Row>
+        <Row className={styles.circulationRulesFormBody}>
           <Col>
             <Field
               component={RulesField}


### PR DESCRIPTION
## Purpose
Cypress issue with **circulation rules form**. When we are trying to interact with form it jumps and cover "save" button.

## Approach
**DOM** element with class `codeMirrorFullScreen` which contains **circulation rules form** has `position: absolute;` style.  And row which contains this **DOM** element must have `position: relative;` but it does not. If we add `position: relative;` to this row in this case **DOM** element with class `codeMirrorFullScreen` which contains **circulation rules form** will be positioned relative to this row.

## Refs
https://issues.folio.org/browse/UICIRC-776

## Screenshots
Before:
<img width="1278" alt="Screen Shot 2022-04-14 at 12 50 56 PM" src="https://user-images.githubusercontent.com/47976677/163360801-8a1ac5af-6a5d-4597-b481-7d46b66ea97f.png">
<img width="1273" alt="Screen Shot 2022-04-14 at 1 32 54 PM" src="https://user-images.githubusercontent.com/47976677/163371864-0d90e9d0-43bf-4c12-bf66-b2f886800202.png">


After:
<img width="1278" alt="Screen Shot 2022-04-14 at 12 51 10 PM" src="https://user-images.githubusercontent.com/47976677/163360772-d6344769-e480-4a48-acfd-c23870756a25.png">
<img width="1276" alt="Screen Shot 2022-04-14 at 1 33 04 PM" src="https://user-images.githubusercontent.com/47976677/163371826-96055ab8-c069-4117-b878-7dbef626d43f.png">
