### PR TITLE
UICIRC-636: Add Jest/RTL tests for `NoticeCard` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix problem with module launch. Refs UICIRC-768.
 * Cover LoansSection component by RTL/jest tests. Refs UICIRC-613.
 * Add RTL/Jest testing for `RequestPolicyForm` component in `src/settings/RequestPolicy`. Refs UICIRC-647.
+* Add RTL/Jest testing for `NoticeCard` component in `src\settings\NoticePolicy\components\EditSections\components`. Refs UICIRC-636.
 
 ## [7.0.2](https://github.com/folio-org/ui-circulation/tree/v7.0.2) (2022-04-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.1...v7.0.2)

--- a/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.js
+++ b/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.js
@@ -69,7 +69,9 @@ class NoticeCard extends React.Component {
 
   render() {
     const {
-      intl,
+      intl: {
+        formatMessage,
+      },
       notice,
       noticeIndex,
       pathToNotice,
@@ -79,7 +81,7 @@ class NoticeCard extends React.Component {
       triggeringEvents,
     } = this.props;
 
-    const blankPlaceholder = intl.formatMessage({ id: 'ui-circulation.settings.common.blankPlaceholder' });
+    const blankPlaceholder = formatMessage({ id: 'ui-circulation.settings.common.blankPlaceholder' });
     const notificationKey = getNotificationContent(notice?.sendOptions?.sendWhen);
 
     return (
@@ -123,8 +125,9 @@ class NoticeCard extends React.Component {
                   data-test-notice-card-template-id
                 >
                   <Field
+                    data-testid="templateSelect"
                     name={`${pathToNotice}.templateId`}
-                    label={<FormattedMessage id="ui-circulation.settings.noticePolicy.notices.template" />}
+                    label={formatMessage({ id: 'ui-circulation.settings.noticePolicy.notices.template' })}
                     required
                     component={Select}
                     dataOptions={templates}
@@ -144,8 +147,9 @@ class NoticeCard extends React.Component {
                   data-test-notice-card-format
                 >
                   <Field
+                    data-testid="formatSelect"
                     name={`${pathToNotice}.format`}
-                    label={<FormattedMessage id="ui-circulation.settings.noticePolicy.notices.format" />}
+                    label={formatMessage({ id:'ui-circulation.settings.noticePolicy.notices.format' })}
                     required
                     component={Select}
                     placeholder={blankPlaceholder}
@@ -159,8 +163,9 @@ class NoticeCard extends React.Component {
                   data-test-notice-card-triggering-event
                 >
                   <Field
+                    data-testid="triggeringEventSelect"
                     name={`${pathToNotice}.sendOptions.sendWhen`}
-                    label={<FormattedMessage id="ui-circulation.settings.noticePolicy.notices.triggeringEvent" />}
+                    label={formatMessage({ id:'ui-circulation.settings.noticePolicy.notices.triggeringEvent' })}
                     required
                     component={Select}
                     placeholder={blankPlaceholder}
@@ -188,6 +193,7 @@ class NoticeCard extends React.Component {
                       data-test-notice-card-send-how
                     >
                       <Field
+                        data-testid="sendSelect"
                         name={`${pathToNotice}.sendOptions.sendHow`}
                         component={Select}
                         placeholder={blankPlaceholder}
@@ -210,6 +216,7 @@ class NoticeCard extends React.Component {
                           data-test-notice-card-send-by
                         >
                           <Period
+                            data-testid="sendByPeriod"
                             inputSize={6}
                             selectSize={6}
                             inputPlaceholder={1}
@@ -241,6 +248,7 @@ class NoticeCard extends React.Component {
                           data-test-notice-card-frequency
                         >
                           <Field
+                            data-testid="frequencySelect"
                             name={`${pathToNotice}.frequency`}
                             component={Select}
                             placeholder={blankPlaceholder}
@@ -263,6 +271,7 @@ class NoticeCard extends React.Component {
                               data-test-notice-card-send-every
                             >
                               <Period
+                                data-testid="andEveryPeriod"
                                 inputSize={6}
                                 selectSize={6}
                                 inputPlaceholder={1}
@@ -284,17 +293,19 @@ class NoticeCard extends React.Component {
                   { notice.sendOptions.isLoanDueDateTimeSelected() && (
                     <>
                       <Field
+                        data-testid="longTermRadioButton"
                         name={`${pathToNotice}.realTime`}
                         component={RadioButton}
                         type="radio"
-                        label={<FormattedMessage id="ui-circulation.settings.noticePolicy.notices.send.longTerm" />}
+                        label={formatMessage({ id:'ui-circulation.settings.noticePolicy.notices.send.longTerm' })}
                         value="false"
                       />
                       <Field
+                        data-testid="shortTermRadioButton"
                         name={`${pathToNotice}.realTime`}
                         component={RadioButton}
                         type="radio"
-                        label={<FormattedMessage id="ui-circulation.settings.noticePolicy.notices.send.shortTerm" />}
+                        label={formatMessage({ id:'ui-circulation.settings.noticePolicy.notices.send.shortTerm' })}
                         value="true"
                       />
                     </>

--- a/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
@@ -1,0 +1,397 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../../../../../test/jest/__mock__';
+
+import { Field } from 'react-final-form';
+
+import {
+  IconButton,
+  MessageBanner,
+  Select,
+  RadioButton,
+} from '@folio/stripes/components';
+
+import NoticeCard from './NoticeCard';
+import Period from '../../../../../components/Period';
+
+import {
+  noticesFormats,
+  noticesFrequency,
+  noticesIntervalPeriods,
+} from '../../../../../../constants';
+
+import { componentPropsCheck } from '../../../../../../../test/jest/helpers';
+
+jest.mock('../../../../../utils/options-generator', () => jest.fn((func, data) => data));
+jest.mock('../../../../utils/notice-description', () => jest.fn(data => data));
+jest.mock('../../../../../components/Period', () => jest.fn(({ 'data-testid': testId }) => (
+  <div data-testid={testId} />
+)));
+
+IconButton.mockImplementation(({ icon, onClick }) => (
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  <div
+    onClick={onClick}
+  >
+    {`iconButton-${icon}`}
+  </div>
+));
+Field.mockImplementation(({ 'data-testid': testId, label }) => (
+  <div data-testid={testId}>
+    {label}
+  </div>
+));
+
+describe('NoticeCard', () => {
+  const labelIds = {
+    blankPlaceholder: 'ui-circulation.settings.common.blankPlaceholder',
+    countableNotice: 'ui-circulation.settings.noticePolicy.countableNotice',
+    template: 'ui-circulation.settings.noticePolicy.notices.template',
+    via: 'ui-circulation.settings.noticePolicy.notices.via',
+    format: 'ui-circulation.settings.noticePolicy.notices.format',
+    triggeringEvent: 'ui-circulation.settings.noticePolicy.notices.triggeringEvent',
+    send: 'ui-circulation.settings.noticePolicy.notices.send',
+    by: 'ui-circulation.settings.noticePolicy.notices.by',
+    frequency: 'ui-circulation.settings.noticePolicy.notices.frequency',
+    andEvery: 'ui-circulation.settings.noticePolicy.notices.andEvery',
+    longTerm: 'ui-circulation.settings.noticePolicy.notices.send.longTerm',
+    shortTerm: 'ui-circulation.settings.noticePolicy.notices.send.shortTerm',
+    deleteButton: 'iconButton-trash',
+    testNotificationKeyId: 'testNotificationKeyId',
+  };
+  const testIds = {
+    templateSelect: 'templateSelect',
+    formatSelect: 'formatSelect',
+    triggeringEventSelect: 'triggeringEventSelect',
+    sendSelect: 'sendSelect',
+    sendByPeriod: 'sendByPeriod',
+    frequencySelect: 'frequencySelect',
+    andEveryPeriod: 'andEveryPeriod',
+    longTermRadioButton: 'longTermRadioButton',
+    shortTermRadioButton: 'shortTermRadioButton',
+  };
+  const sendOptions = {
+    sendWhen: labelIds.testNotificationKeyId,
+    isSendOptionsAvailable: jest.fn(() => true),
+    isBeforeOrAfter: jest.fn(() => true),
+    isFrequencyAvailable: jest.fn(() => true),
+    isLoanDueDateTimeSelected: jest.fn(() => true),
+  };
+  const notice = {
+    sendOptions,
+    isRecurring: jest.fn(() => true),
+  };
+  const noticeIndex = 1;
+  const pathToNotice = 'pathToNotice';
+  const sendEvents = [{
+    value: 'testSendEventsValue',
+    label: 'testSendEventsLabel',
+  }];
+  const sendEventTriggeringIds = [
+    'firstEventId',
+    'secondEventId',
+  ];
+  const templates = [{
+    value: 'testTemplatesValue',
+    label: 'testTemplatesLabel',
+  }];
+  const triggeringEvents = [{
+    value: 'testTriggeringEventsValue',
+    label: 'testTriggeringEventsLabel',
+  }];
+  const onRemoveNotice = jest.fn();
+  const defaultProps = {
+    notice,
+    noticeIndex,
+    pathToNotice,
+    sendEvents,
+    sendEventTriggeringIds,
+    templates,
+    triggeringEvents,
+    onRemoveNotice,
+  };
+
+  afterEach(() => {
+    onRemoveNotice.mockClear();
+    Field.mockClear();
+    MessageBanner.mockClear();
+  });
+
+  describe('when "notice" methods returns true', () => {
+    beforeEach(() => {
+      render(
+        <NoticeCard
+          {...defaultProps}
+        />
+      );
+    });
+
+    it('should render heading', () => {
+      expect(screen.getByText(labelIds.countableNotice)).toBeVisible();
+    });
+
+    it('should render button for notice deleting', () => {
+      expect(screen.getByText(labelIds.deleteButton));
+    });
+
+    it('should execute correct method on delete button click', () => {
+      expect(onRemoveNotice).not.toBeCalled();
+
+      fireEvent.click(screen.getByText(labelIds.deleteButton));
+
+      expect(onRemoveNotice).toBeCalledWith(noticeIndex);
+    });
+
+    it('should render templateSelect "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.templateSelect, {
+        name: `${pathToNotice}.templateId`,
+        label: labelIds.template,
+        required: true,
+        component: Select,
+        dataOptions: templates,
+        placeholder: labelIds.blankPlaceholder,
+      });
+    });
+
+    it('should render "via"', () => {
+      expect(screen.getByText(labelIds.via)).toBeVisible();
+    });
+
+    it('should render formatSelect "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.formatSelect, {
+        name: `${pathToNotice}.format`,
+        label: labelIds.format,
+        required: true,
+        component: Select,
+        placeholder: labelIds.blankPlaceholder,
+        children: noticesFormats,
+      });
+    });
+
+    it('should render triggeringEventSelect "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.triggeringEventSelect, {
+        name: `${pathToNotice}.sendOptions.sendWhen`,
+        label: labelIds.triggeringEvent,
+        required: true,
+        component: Select,
+        placeholder: labelIds.blankPlaceholder,
+        children: triggeringEvents,
+      });
+    });
+
+    it('should render "Send" section label', () => {
+      expect(screen.getByText(labelIds.send)).toBeVisible();
+    });
+
+    it('should render sendSelect "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.sendSelect, {
+        name: `${pathToNotice}.sendOptions.sendHow`,
+        component: Select,
+        placeholder: labelIds.blankPlaceholder,
+        children: sendEvents,
+      });
+    });
+
+    it('should render "by" delimiter', () => {
+      expect(screen.getByText(labelIds.by)).toBeVisible();
+    });
+
+    it('should render sendByPeriod "Period" with correct props', () => {
+      componentPropsCheck(Period, testIds.sendByPeriod, {
+        inputSize: 6,
+        selectSize: 6,
+        inputPlaceholder: 1,
+        selectPlaceholder: labelIds.blankPlaceholder,
+        inputValuePath: `${pathToNotice}.sendOptions.sendBy.duration`,
+        selectValuePath: `${pathToNotice}.sendOptions.sendBy.intervalId`,
+        intervalPeriods: noticesIntervalPeriods,
+      });
+    });
+
+    it('should render "frequency" label', () => {
+      expect(screen.getByText(labelIds.frequency)).toBeVisible();
+    });
+
+    it('should render frequencySelect "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.frequencySelect, {
+        name: `${pathToNotice}.frequency`,
+        component: Select,
+        placeholder: labelIds.blankPlaceholder,
+        children: noticesFrequency,
+      });
+    });
+
+    it('should render "andEvery" delimiter', () => {
+      expect(screen.getByText(labelIds.andEvery)).toBeVisible();
+    });
+
+    it('should render andEveryPeriod "Period" with correct props', () => {
+      componentPropsCheck(Period, testIds.andEveryPeriod, {
+        inputSize: 6,
+        selectSize: 6,
+        inputPlaceholder: 1,
+        selectPlaceholder: labelIds.blankPlaceholder,
+        inputValuePath: `${pathToNotice}.sendOptions.sendEvery.duration`,
+        selectValuePath: `${pathToNotice}.sendOptions.sendEvery.intervalId`,
+        intervalPeriods: noticesIntervalPeriods,
+      });
+    });
+
+    it('should render longTermRadioButton "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.longTermRadioButton, {
+        name: `${pathToNotice}.realTime`,
+        component: RadioButton,
+        type: 'radio',
+        label: labelIds.longTerm,
+        value: 'false',
+      });
+    });
+
+    it('should render shortTermRadioButton "Field" with correct props', () => {
+      componentPropsCheck(Field, testIds.shortTermRadioButton, {
+        name: `${pathToNotice}.realTime`,
+        component: RadioButton,
+        type: 'radio',
+        label: labelIds.shortTerm,
+        value: 'true',
+      });
+    });
+
+    it('should render warning message when "notificationKey" is present', () => {
+      expect(MessageBanner).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'warning',
+      }), {});
+      expect(screen.getByText(labelIds.testNotificationKeyId)).toBeVisible();
+    });
+  });
+
+  describe('when some "notice" methods or values returns false', () => {
+    const renderComponent = (newNotice) => {
+      render(
+        <NoticeCard
+          {...defaultProps}
+          notice={newNotice}
+        />
+      );
+    };
+    const createNewNotice = (key, value) => ({
+      ...notice,
+      sendOptions: {
+        ...sendOptions,
+        [key]: value || jest.fn(() => false),
+      },
+    });
+
+    describe('when "isSendOptionsAvailable" returns false', () => {
+      beforeEach(() => {
+        renderComponent(createNewNotice('isSendOptionsAvailable'));
+      });
+
+      it('should not render "sendSelect" section with label', () => {
+        expect(screen.queryByText(labelIds.send)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(testIds.sendSelect)).not.toBeInTheDocument();
+      });
+
+      it('should not render "by" delimiter', () => {
+        expect(screen.queryByText(labelIds.by)).not.toBeInTheDocument();
+      });
+
+      it('should not render "sendByPeriod" Period', () => {
+        expect(screen.queryByTestId(testIds.sendByPeriod)).not.toBeInTheDocument();
+      });
+
+      it('should not render "frequencySelect" section with label', () => {
+        expect(screen.queryByText(labelIds.frequency)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(testIds.frequencySelect)).not.toBeInTheDocument();
+      });
+
+      it('should not render "and every" delimiter', () => {
+        expect(screen.queryByText(labelIds.andEvery)).not.toBeInTheDocument();
+      });
+
+      it('should not render "andEveryPeriod" Period', () => {
+        expect(screen.queryByTestId(testIds.andEveryPeriod)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when "isBeforeOrAfter" returns false', () => {
+      beforeEach(() => {
+        renderComponent(createNewNotice('isBeforeOrAfter'));
+      });
+
+      it('should not render "by" delimiter', () => {
+        expect(screen.queryByText(labelIds.by)).not.toBeInTheDocument();
+      });
+
+      it('should not render "sendByPeriod" Period', () => {
+        expect(screen.queryByTestId(testIds.sendByPeriod)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when "isFrequencyAvailable" returns false', () => {
+      beforeEach(() => {
+        renderComponent(createNewNotice('isFrequencyAvailable'));
+      });
+
+      it('should not render "frequencySelect" section with label', () => {
+        expect(screen.queryByText(labelIds.frequency)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(testIds.frequencySelect)).not.toBeInTheDocument();
+      });
+
+      it('should not render "and every" delimiter', () => {
+        expect(screen.queryByText(labelIds.andEvery)).not.toBeInTheDocument();
+      });
+
+      it('should not render "andEveryPeriod" Period', () => {
+        expect(screen.queryByTestId(testIds.andEveryPeriod)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when "isLoanDueDateTimeSelected" returns false', () => {
+      beforeEach(() => {
+        renderComponent(createNewNotice('isLoanDueDateTimeSelected'));
+      });
+
+      it('should not render longTermRadioButton "Field"', () => {
+        expect(screen.queryByTestId(testIds.longTermRadioButton)).not.toBeInTheDocument();
+      });
+
+      it('should not render shortTermRadioButton "Field"', () => {
+        expect(screen.queryByTestId(testIds.shortTermRadioButton)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when notice have empty "sendWhen" value', () => {
+      it('should not render "MessageBanner"', () => {
+        renderComponent(createNewNotice('sendWhen', []));
+
+        expect(MessageBanner).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when "isRecurring" return false', () => {
+      const newNotice = {
+        ...notice,
+        isRecurring: jest.fn(() => false),
+      };
+
+      beforeEach(() => {
+        renderComponent(newNotice);
+      });
+
+      it('should not render "and every" delimiter', () => {
+        expect(screen.queryByText(labelIds.andEvery)).not.toBeInTheDocument();
+      });
+
+      it('should not render "andEveryPeriod" Period', () => {
+        expect(screen.queryByTestId(testIds.andEveryPeriod)).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
@@ -41,11 +41,6 @@ IconButton.mockImplementation(({ icon, onClick }) => (
     {`iconButton-${icon}`}
   </div>
 ));
-Field.mockImplementation(({ 'data-testid': testId, label }) => (
-  <div data-testid={testId}>
-    {label}
-  </div>
-));
 
 describe('NoticeCard', () => {
   const labelIds = {

--- a/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/components/NoticeCard/NoticeCard.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   render,
   screen,
-  within,
   fireEvent,
 } from '@testing-library/react';
 

--- a/test/jest/__mock__/finalFormComponents.mock.js
+++ b/test/jest/__mock__/finalFormComponents.mock.js
@@ -4,11 +4,15 @@ jest.mock('react-final-form', () => ({
   Field: jest.fn(({
     label,
     component,
+    'data-testid': testId,
     children,
     dataOptions,
     ...rest
   }) => (
-    <div {...rest}>
+    <div
+      data-testid={testId}
+      {...rest}
+    >
       {label}
       {component()}
     </div>

--- a/test/jest/helpers/index.js
+++ b/test/jest/helpers/index.js
@@ -1,0 +1,2 @@
+export * from './utils';
+export { default as translationsProperties } from './translationProperties';

--- a/test/jest/helpers/utils.js
+++ b/test/jest/helpers/utils.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+export const componentPropsCheck = (Component, testId, expectedProps, partialCompare = false) => {
+  const propertiesForCompare = Component.mock.calls
+    .reverse()
+    .find(item => item[0]['data-testid'] === testId);
+
+  if (partialCompare) {
+    expect(propertiesForCompare[0]).toStrictEqual(expect.objectContaining(expectedProps));
+  } else {
+    expect(propertiesForCompare[0]).toStrictEqual({
+      ...expectedProps,
+      'data-testid': testId,
+    });
+  }
+};

--- a/test/jest/helpers/utils.js
+++ b/test/jest/helpers/utils.js
@@ -4,12 +4,12 @@ export const componentPropsCheck = (Component, testId, expectedProps, partialCom
     .reverse()
     .find(item => item[0]['data-testid'] === testId);
 
-  if (partialCompare) {
-    expect(propertiesForCompare[0]).toStrictEqual(expect.objectContaining(expectedProps));
-  } else {
-    expect(propertiesForCompare[0]).toStrictEqual({
+  const resultExpectedProps = partialCompare
+    ? expect.objectContaining(expectedProps)
+    : {
       ...expectedProps,
       'data-testid': testId,
-    });
-  }
+    };
+
+  expect(propertiesForCompare[0]).toStrictEqual(resultExpectedProps);
 };


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `NoticeCard` component in `src\settings\NoticePolicy\components\EditSections\components`.

## Refs
https://issues.folio.org/browse/UICIRC-636

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/161963473-e983f817-8a6e-4c4a-8939-7f99711d17cd.png)