### PR TITLE
UICIRC-777: hide title level requests settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 7.0.3
+
+* Hide title level requests settings. Refs UICIRC-777.
+
 ## [7.0.2](https://github.com/folio-org/ui-circulation/tree/v7.0.2) (2022-04-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.1...v7.0.2)
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,6 @@ import PatronNotices from './settings/PatronNotices';
 import StaffSlips from './settings/StaffSlips';
 import NoticePolicySettings from './settings/NoticePolicy';
 import RequestPolicySettings from './settings/RequestPolicy';
-import TitleLevelRequests from './settings/TitleLevelRequests';
 
 class Circulation extends Component {
   static propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,6 @@ class Circulation extends Component {
       {
         label: <FormattedMessage id="ui-circulation.settings.index.request" />,
         pages: [
-
           {
             route: 'cancellation-reasons',
             label: <FormattedMessage id="ui-circulation.settings.index.requestCancellationReasons" />,
@@ -127,13 +126,6 @@ class Circulation extends Component {
             component: RequestPolicySettings,
             perm: 'ui-circulation.settings.request-policies',
           },
-          {
-            route: 'title-level-requests',
-            label: <FormattedMessage id="ui-circulation.settings.index.titleLevelRequests" />,
-            component: TitleLevelRequests,
-            perm: 'ui-circulation.settings.titleLevelRequests',
-          },
-
         ],
       },
     ];


### PR DESCRIPTION
## Purpose
For Lotus release was decided to cut out possibility of TLR settings changing.

## Refs
https://issues.folio.org/browse/UICIRC-777