### PR TITLE
UICIRC-784: fix the issue when some values in `overdue fine policy` could be less than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Cover FixedDueDateScheduleForm component by RTL/jest tests. Refs UICIRC-609.
 * Add RTL/Jest testing for `PatronNoticeForm` component in `src/settings/PatronNotices`. Refs UICIRC-644.
 * Cypress issue with circulation rules form. Refs UICIRC-776.
+* User can save "Overdue fine" and "Overdue recall fine" with values less than 0. Refs UICIRC-784.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/Models/FinePolicy/FinePolicy.js
+++ b/src/settings/Models/FinePolicy/FinePolicy.js
@@ -33,6 +33,11 @@ export default class FinePolicy {
 
   hasValue(pathToValue) {
     const value = get(this, pathToValue);
+    return value > 0;
+  }
+  
+  hasNonZeroValue(pathToValue) {
+    const value = get(this, pathToValue);
 
     return !!parseFloat(value, 10);
   }

--- a/src/settings/Models/FinePolicy/FinePolicy.js
+++ b/src/settings/Models/FinePolicy/FinePolicy.js
@@ -13,7 +13,7 @@ export default class FinePolicy {
       'overdueFine': { quantity: 0, intervalId: '' },
       'maxOverdueFine': 0,
       'maxOverdueRecallFine': 0,
-      'overdueRecallFine': { quantity: 0, intervalId: '' }
+      'overdueRecallFine': { quantity: 0, intervalId: '' },
     };
   }
 
@@ -33,7 +33,8 @@ export default class FinePolicy {
 
   hasValue(pathToValue) {
     const value = get(this, pathToValue);
-    return value > 0;
+
+    return !!parseFloat(value);
   }
 
   isIntervalSelected = (pathToValue) => {

--- a/src/settings/Models/FinePolicy/FinePolicy.js
+++ b/src/settings/Models/FinePolicy/FinePolicy.js
@@ -34,7 +34,7 @@ export default class FinePolicy {
   hasValue(pathToValue) {
     const value = get(this, pathToValue);
 
-    return !!parseFloat(value);
+    return !!parseFloat(value, 10);
   }
 
   isIntervalSelected = (pathToValue) => {

--- a/src/settings/Validation/fine-policy/fines.js
+++ b/src/settings/Validation/fine-policy/fines.js
@@ -5,7 +5,7 @@ export default function (finePolicy) {
       shouldValidate: true,
     },
     'overdueFine.quantity': {
-      rules: ['hasOverdueFineInterval'],
+      rules: ['isFloatGreaterThanOrEqualToZero', 'hasOverdueFineInterval'],
       shouldValidate: finePolicy.isIntervalSelected('overdueFine.intervalId') || finePolicy.hasValue('overdueFine.quantity'),
     },
     'overdueFine.intervalId': {
@@ -13,7 +13,7 @@ export default function (finePolicy) {
       shouldValidate: finePolicy.isOverdueFine(),
     },
     'overdueRecallFine.quantity': {
-      rules: ['hasOverdueRecallFineInterval'],
+      rules: ['isFloatGreaterThanOrEqualToZero', 'hasOverdueRecallFineInterval'],
       shouldValidate: finePolicy.isIntervalSelected('overdueRecallFine.intervalId') || finePolicy.hasValue('overdueRecallFine.quantity'),
     },
     'overdueRecallFine.intervalId': {

--- a/src/settings/Validation/fine-policy/fines.js
+++ b/src/settings/Validation/fine-policy/fines.js
@@ -6,7 +6,7 @@ export default function (finePolicy) {
     },
     'overdueFine.quantity': {
       rules: ['hasOverdueFineInterval'],
-      shouldValidate: finePolicy.isIntervalSelected('overdueFine.intervalId'),
+      shouldValidate: finePolicy.isIntervalSelected('overdueFine.intervalId') || finePolicy.hasValue('overdueFine.quantity'),
     },
     'overdueFine.intervalId': {
       rules: ['isNotEmptySelect'],
@@ -14,7 +14,7 @@ export default function (finePolicy) {
     },
     'overdueRecallFine.quantity': {
       rules: ['hasOverdueRecallFineInterval'],
-      shouldValidate: finePolicy.isIntervalSelected('overdueRecallFine.intervalId'),
+      shouldValidate: finePolicy.isIntervalSelected('overdueRecallFine.intervalId') || finePolicy.hasValue('overdueRecallFine.quantity'),
     },
     'overdueRecallFine.intervalId': {
       rules: ['isNotEmptySelect'],

--- a/src/settings/Validation/fine-policy/fines.js
+++ b/src/settings/Validation/fine-policy/fines.js
@@ -6,7 +6,7 @@ export default function (finePolicy) {
     },
     'overdueFine.quantity': {
       rules: ['isFloatGreaterThanOrEqualToZero', 'hasOverdueFineInterval'],
-      shouldValidate: finePolicy.isIntervalSelected('overdueFine.intervalId') || finePolicy.hasValue('overdueFine.quantity'),
+      shouldValidate: finePolicy.isIntervalSelected('overdueFine.intervalId') || finePolicy.hasNonZeroValue('overdueFine.quantity'),
     },
     'overdueFine.intervalId': {
       rules: ['isNotEmptySelect'],
@@ -14,7 +14,7 @@ export default function (finePolicy) {
     },
     'overdueRecallFine.quantity': {
       rules: ['isFloatGreaterThanOrEqualToZero', 'hasOverdueRecallFineInterval'],
-      shouldValidate: finePolicy.isIntervalSelected('overdueRecallFine.intervalId') || finePolicy.hasValue('overdueRecallFine.quantity'),
+      shouldValidate: finePolicy.isIntervalSelected('overdueRecallFine.intervalId') || finePolicy.hasNonZeroValue('overdueRecallFine.quantity'),
     },
     'overdueRecallFine.intervalId': {
       rules: ['isNotEmptySelect'],
@@ -22,11 +22,11 @@ export default function (finePolicy) {
     },
     'maxOverdueFine': {
       rules: ['isFloatGreaterThanOrEqualToZero', 'isGreaterThanOverdueFine', 'isMaximumOverdueFineValid'],
-      shouldValidate: finePolicy.isOverdueFine() || finePolicy.hasValue('maxOverdueFine'),
+      shouldValidate: finePolicy.isOverdueFine() || finePolicy.hasNonZeroValue('maxOverdueFine'),
     },
     'maxOverdueRecallFine': {
       rules: ['isFloatGreaterThanOrEqualToZero', 'isGreaterThanOverdueRecallFine', 'isMaximumOverdueRecallFineValid'],
-      shouldValidate: finePolicy.isOverdueRecallFine() || finePolicy.hasValue('maxOverdueRecallFine'),
+      shouldValidate: finePolicy.isOverdueRecallFine() || finePolicy.hasNonZeroValue('maxOverdueRecallFine'),
     },
   };
 }


### PR DESCRIPTION
## Purpose
User must not be able to save form if "Overdue fine" or "Overdue recall fine" have values less than 0. `isFloatGreaterThanOrEqualToZero` validator must be added to these fields.

## Refs
https://issues.folio.org/browse/UICIRC-784

## Screenshots
before:
![image](https://user-images.githubusercontent.com/88130496/165926373-17e8d079-f419-4035-8bae-6fc6e9d0b6ac.png)

after:
![image](https://user-images.githubusercontent.com/88130496/165926309-b071fd73-1217-4926-892e-3fd7be878fce.png)
