### PR TITLE
UICIRC-715: Unable to delete fixed due date schedule with permission …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * User can save "Overdue fine" and "Overdue recall fine" with values less than 0. Refs UICIRC-784.
 * Lost item processing fee can be saved with a value less than 0. Refs UICIRC-779.
 * Fix tests fails. Refs UICIRC-816.
+* Unable to delete fixed due date schedule with permission `ui-circulation.settings.fixed-due-date-schedules`. Refs UICIRC-715.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
@@ -9,10 +9,7 @@ import {
   memoize,
 } from 'lodash';
 
-import {
-  stripesShape,
-  IfPermission,
-} from '@folio/stripes/core';
+import { stripesShape } from '@folio/stripes/core';
 import {
   Accordion,
   AccordionSet,
@@ -174,17 +171,15 @@ class FixedDueDateScheduleForm extends React.Component {
             <FormattedMessage id="ui-circulation.settings.fDDSform.cancel" />
           </Button>
           {edit && (
-            <IfPermission perm="ui-circulation.settings.circulation-rules">
-              <Button
-                id="clickable-delete-item"
-                buttonStyle="danger mega"
-                disabled={confirmDelete}
-                marginBottom0
-                onClick={this.beginDelete}
-              >
-                <FormattedMessage id="stripes-core.button.delete" />
-              </Button>
-            </IfPermission>
+            <Button
+              id="clickable-delete-item"
+              buttonStyle="danger mega"
+              disabled={confirmDelete}
+              marginBottom0
+              onClick={this.beginDelete}
+            >
+              <FormattedMessage id="stripes-core.button.delete" />
+            </Button>
           )}
           <Button
             id="clickable-save-fixedDueDateSchedule"


### PR DESCRIPTION
## Purpose
Unable to delete fixed due date schedule with permission `ui-circulation.settings.fixed-due-date-schedules`

## Approach
We able to see schedule settings only if `ui-circulation.settings.fixed-due-date-schedules` permission already assignet to user. So we just need to remove additional check for `ui-circulation.settings.circulation-rules` permission.

## Refs
https://issues.folio.org/browse/UICIRC-715