### PR TITLE
UICIRC-697: refactor psets away from backend ".all" permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Replace babel-eslint with @babel/eslint-parser. Refs UICIRC-780.
 * No validation for spacebar when create Patron notice template. Refs UICIRC-782.
 * Fix eslint error. Refs UICIRC-820.
+* Adjust `configuration.all` permission set. Refs UICIRC-697.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/package.json
+++ b/package.json
@@ -217,7 +217,8 @@
           "configuration.entries.collection.get",
           "configuration.entries.item.get",
           "configuration.entries.item.post",
-          "configuration.entries.item.put"
+          "configuration.entries.item.put",
+          "configuration.entries.item.delete"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -213,8 +213,11 @@
         "displayName": "Settings (Circ): Can create, edit and remove other settings",
         "subPermissions": [
           "user-settings.custom-fields.collection.get",
-          "configuration.all",
-          "settings.circulation.enabled"
+          "settings.circulation.enabled",
+          "configuration.entries.collection.get",
+          "configuration.entries.item.get",
+          "configuration.entries.item.post",
+          "configuration.entries.item.put"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Adjust `configuration.all` permission set

## Refs
[UICIRC-697](https://issues.folio.org/browse/UICIRC-697)