### PR TITLE
UICIRC-826: Add RTL/Jest testing for  component in `src/settings/lib/RuleEditor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Create common helper, cover it by RTL/jest tests. UICIRC-803.
 * Cover `LoanPolicy` folder in `Models` by RTL/jest tests. Refs UICIRC-798.
 * Add RTL/Jest testing for `LoanHistoryModel` in `src/settings/Models`. Refs UICIRC-802.
+* Add RTL/Jest testing for `RulesField` component in `src/settings/lib/RuleEditor`. Refs UICIRC-826.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/lib/RuleEditor/RulesField.test.js
+++ b/src/settings/lib/RuleEditor/RulesField.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../../../test/jest/__mock__';
+
+import RulesEditor from './RulesEditor';
+import RulesField from './RulesField';
+
+jest.mock('./RulesEditor', () => jest.fn(() => null));
+
+describe('RulesField', () => {
+  const testInput = {
+    value: 'testValue',
+    onChange: jest.fn(),
+  };
+  const testOtherProp = 'testValue';
+  const testDefaultProps = {
+    input: testInput,
+    testOtherProp,
+  };
+
+  afterEach(() => {
+    RulesEditor.mockClear();
+  });
+
+  describe('with default props', () => {
+    beforeEach(() => {
+      render(
+        <RulesField {...testDefaultProps} />
+      );
+    });
+
+    it('should render RulesEditor component', () => {
+      expect(RulesEditor).toHaveBeenCalledWith({
+        code: testInput.value,
+        onChange: testInput.onChange,
+        testOtherProp,
+      }, {});
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `RulesField` component in `src/settings/lib/RuleEditor`.

## Refs
https://issues.folio.org/browse/UICIRC-826

## Screenshots
<img width="1268" alt="Screen Shot 2022-06-20 at 2 37 02 PM" src="https://user-images.githubusercontent.com/47976677/174593575-46e48a15-366a-4deb-b2d4-c1b0855f883e.png">
