### PR TITLE
UICIRC-802: Add RTL/Jest tests for `LoanHistoryModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Adjust `configuration.all` permission set. Refs UICIRC-697.
 * Create common helper, cover it by RTL/jest tests. UICIRC-803.
 * Cover `LoanPolicy` folder in `Models` by RTL/jest tests. Refs UICIRC-798.
+* Add RTL/Jest testing for `LoanHistoryModel` in `src/settings/Models`. Refs UICIRC-802.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/Models/LoanHistoryModel.test.js
+++ b/src/settings/Models/LoanHistoryModel.test.js
@@ -1,0 +1,129 @@
+import LoanHistory from './LoanHistoryModel';
+import {
+  closedLoansRules,
+  closingTypesMap,
+} from '../../constants';
+
+describe('LoanHistory', () => {
+  it('should return correct default data', () => {
+    expect(LoanHistory.defaultLoanHistory()).toEqual({});
+  });
+
+  it('should have correct values when nothing was passed', () => {
+    const loanHistory = new LoanHistory();
+
+    expect(loanHistory).toEqual(expect.objectContaining({
+      closingType: undefined,
+      loan: {
+        duration: undefined,
+        intervalId: undefined,
+      },
+      feeFine: {
+        duration: undefined,
+        intervalId: undefined,
+      },
+      loanExceptions: [],
+      treatEnabled: false,
+    }));
+  });
+
+  it('should have correct values when data was passed', () => {
+    const testData = {
+      closingType: 'testClosingType',
+      loan: {
+        duration: 'testLoanDuration',
+        intervalId: 'testLoanIntervalId',
+      },
+      feeFine: {
+        duration: 'testFeeFineDuration',
+        intervalId: 'testFeeFineIntervalId',
+      },
+      loanExceptions: ['testException'],
+      treatEnabled: true,
+    };
+    const loanHistory = new LoanHistory(testData);
+
+    expect(loanHistory).toEqual(expect.objectContaining(testData));
+  });
+
+  describe('isClosingTypeIntervalSelected', () => {
+    const testIntevalKey = 'testIntervalKey';
+    const testNonIntevalKey = 'testNonIntervalKey';
+    const testData = {
+      closingType: {
+        [testIntevalKey]: closingTypesMap.INTERVAL,
+        [testNonIntevalKey]: closingTypesMap.NEVER,
+      },
+    };
+    const loanHistory = new LoanHistory(testData);
+
+    it(`should return true when "closingType" by key contains value equal to "${closingTypesMap.INTERVAL}"`, () => {
+      expect(loanHistory.isClosingTypeIntervalSelected(testIntevalKey)).toBe(true);
+    });
+
+    it(`should return false when "closingType" by key contains value that not equal to "${closingTypesMap.INTERVAL}"`, () => {
+      expect(loanHistory.isClosingTypeIntervalSelected(testNonIntevalKey)).toBe(false);
+    });
+
+    it('should return false when "closingType" by key do not contains any value', () => {
+      expect(loanHistory.isClosingTypeIntervalSelected('unexistedKey')).toBe(false);
+    });
+  });
+
+  describe('isAnyClosingTypeSelected', () => {
+    describe('when "treatEnabled" is true', () => {
+      const testDefaultKey = closedLoansRules.DEFAULT;
+      const testNonDefaultKey = closedLoansRules.WITH_FEES_FINES;
+      const testData = {
+        closingType: {
+          [testDefaultKey]: 'testValue',
+          [testNonDefaultKey]: 'testValue',
+        },
+        treatEnabled: true,
+      };
+      const loanHistory = new LoanHistory(testData);
+
+      it(`should return false when "${closedLoansRules.DEFAULT}" is passed and it is present in loanHistory`, () => {
+        expect(loanHistory.isAnyClosingTypeSelected(testDefaultKey)).toBe(false);
+      });
+
+      it(`should return false when passed value is not "${closedLoansRules.DEFAULT}" but it present in loanHistory`, () => {
+        expect(loanHistory.isAnyClosingTypeSelected(testNonDefaultKey)).toBe(false);
+      });
+
+      it('should return true when there is no passed value in loanHistory', () => {
+        expect(loanHistory.isAnyClosingTypeSelected('nonExistedValue')).toBe(true);
+      });
+    });
+
+    describe('when "treatEnabled" is false', () => {
+      describe(`when "${closedLoansRules.DEFAULT}" is present in loanHistory`, () => {
+        const testData = {
+          closingType: {
+            [closedLoansRules.DEFAULT]: 'testValue',
+          },
+        };
+        const loanHistory = new LoanHistory(testData);
+
+        it(`should return false when "${closedLoansRules.DEFAULT}" is passed`, () => {
+          expect(loanHistory.isAnyClosingTypeSelected(closedLoansRules.DEFAULT)).toBe(false);
+        });
+
+        it('should return false when there is no passed value in loanHistory', () => {
+          expect(loanHistory.isAnyClosingTypeSelected('nonExistedValue')).toBe(false);
+        });
+      });
+
+      describe(`when there is no "${closedLoansRules.DEFAULT}" in loanHistory`, () => {
+        const testData = {
+          closingType: {},
+        };
+        const loanHistory = new LoanHistory(testData);
+
+        it(`should return true when "${closedLoansRules.DEFAULT}" is passed`, () => {
+          expect(loanHistory.isAnyClosingTypeSelected(closedLoansRules.DEFAULT)).toBe(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `LoanHistoryModel` in `src/settings/Models`.

## Refs
https://issues.folio.org/browse/UICIRC-802

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/174619261-71c35a87-6528-4ab0-a9b4-5ad0b317a88d.png)
