### PR TITLE
UICIRC-812: add RTL/Jest tests for `patron-notice-template` and `requ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Cover `RequestPolicy` by RTL/jest tests. Refs UICIRC-801.
 * Add RTL/Jest testing for `RulesForm` component in `src/settings/lib/RuleEditor`. Refs UICIRC-825.
 * Add RTL/Jest testing for `src/settings/Models/LostItemFeePolicy` folder. Refs UICIRC-799.
+* Add RTL/Jest testing for `patron-notice-template` and `request-policy` components in `src/settings/Validation`. Refs UICIRC-812.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/constants/Validation/patron-notice-template.js
+++ b/src/constants/Validation/patron-notice-template.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+export const PATRON_NOTICE_PATH = {
+  CATEGORY: 'category',
+  LOCALIZED_TEMPLATES_EN_HEADER: 'localizedTemplates.en.header',
+  LOCALIZED_TEMPLATES_EN_BODY: 'localizedTemplates.en.body',
+};

--- a/src/settings/Validation/patron-notice-template/patron-notice-template.js
+++ b/src/settings/Validation/patron-notice-template/patron-notice-template.js
@@ -4,24 +4,25 @@ import {
   RULES,
   GENERAL_NAME_FIELD_VALIDATION_PROPS,
 } from '../../../constants/Validation/general';
+import { PATRON_NOTICE_PATH } from '../../../constants/Validation/patron-notice-template';
+
+export const config = {
+  ...GENERAL_NAME_FIELD_VALIDATION_PROPS,
+  [PATRON_NOTICE_PATH.CATEGORY]: {
+    rules: [RULES.IS_NOT_EMPTY_SELECT],
+    shouldValidate: true,
+  },
+  [PATRON_NOTICE_PATH.LOCALIZED_TEMPLATES_EN_HEADER]: {
+    rules: [RULES.IS_NOT_EMPTY, RULES.IS_NOT_EMPTY_WITHOUT_SPACE],
+    shouldValidate: true,
+  },
+  [PATRON_NOTICE_PATH.LOCALIZED_TEMPLATES_EN_BODY]: {
+    rules: [RULES.IS_NOT_EMPTY_EDITOR],
+    shouldValidate: true,
+  },
+};
 
 const patronNoticeTemplate = (template) => {
-  const config = {
-    ...GENERAL_NAME_FIELD_VALIDATION_PROPS,
-    'category': {
-      rules: [RULES.IS_NOT_EMPTY_SELECT],
-      shouldValidate: true,
-    },
-    'localizedTemplates.en.header': {
-      rules: [RULES.IS_NOT_EMPTY, RULES.IS_NOT_EMPTY_WITHOUT_SPACE],
-      shouldValidate: true,
-    },
-    'localizedTemplates.en.body': {
-      rules: [RULES.IS_NOT_EMPTY_EDITOR],
-      shouldValidate: true,
-    },
-  };
-
   const formValidator = new FormValidator(config);
 
   return formValidator.validate(template);

--- a/src/settings/Validation/patron-notice-template/patron-notice-template.test.js
+++ b/src/settings/Validation/patron-notice-template/patron-notice-template.test.js
@@ -1,0 +1,39 @@
+import patronNoticeTemplate, {
+  config as patronNoticeConfig,
+} from './patron-notice-template';
+import { PATRON_NOTICE_PATH } from '../../../constants/Validation/patron-notice-template';
+
+jest.mock('../engine/FormValidator', () => (class {
+  constructor(config) {
+    this.config = config;
+  }
+
+  validate(policy) {
+    return {
+      ...this.config,
+      passedPolicy: policy,
+      hasBeenValidate: true,
+    };
+  }
+}));
+
+describe('patronNoticeTemplate', () => {
+  it('should correctly process passed policy', () => {
+    const testPolicyData = 'testPolicyData';
+    const expectedResult = {
+      ...patronNoticeConfig,
+      passedPolicy: testPolicyData,
+      hasBeenValidate: true,
+    };
+
+    expect(patronNoticeTemplate(testPolicyData)).toEqual(expectedResult);
+  });
+
+  describe('"shouldValidate"', () => {
+    Object.values(PATRON_NOTICE_PATH).forEach(path => {
+      it(`should be true for "${path}" key`, () => {
+        expect(patronNoticeConfig[path].shouldValidate).toBe(true);
+      });
+    });
+  });
+});

--- a/src/settings/Validation/request-policy/request-policy.test.js
+++ b/src/settings/Validation/request-policy/request-policy.test.js
@@ -1,0 +1,29 @@
+import { GENERAL_NAME_FIELD_VALIDATION_PROPS } from '../../../constants/Validation/general';
+import requestPolicy from './request-policy';
+
+jest.mock('../engine/FormValidator', () => (class {
+  constructor(config) {
+    this.config = config;
+  }
+
+  validate(policy) {
+    return {
+      ...this.config,
+      passedPolicy: policy,
+      hasBeenValidate: true,
+    };
+  }
+}));
+
+describe('requestPolicy', () => {
+  it('should correctly process the passed policy', () => {
+    const testPolicyData = 'testPolicyData';
+    const expectedResult = {
+      ...GENERAL_NAME_FIELD_VALIDATION_PROPS,
+      passedPolicy: testPolicyData,
+      hasBeenValidate: true,
+    };
+
+    expect(requestPolicy(testPolicyData)).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `patron-notice-template` and `request-policy` components in `src/settings/Validation`.

## Refs
https://issues.folio.org/browse/UICIRC-812

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/174805326-a1a82365-3c70-4d83-9381-d8155e2bf470.png)
![image](https://user-images.githubusercontent.com/88130496/174805371-812c4aca-aa8a-487e-82cf-d6d2aed37df0.png)