### PR TITLE
UICIRC-829: add RTL/Jest tests for `initFoldRules` in `src/settings/lib/RuleEditor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * UI tests replacement with RTL/Jest for `src/settings/Validation/engine/handlers.js`. UICIRC-814.
 * UI tests replacement with RTL/Jest for `src/settings/lib/RuleEditor/utils.js`. UICIRC-828.
+* Add RTL/Jest testing for `initFoldRules` in `src/settings/lib/RuleEditor`. Refs UICIRC-829.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)
@@ -50,7 +51,7 @@
 * Add RTL/Jest testing for `patron-notice-template` and `request-policy` components in `src/settings/Validation`. Refs UICIRC-812.
 * UI tests replacement with RTL/Jest for `NoticePolicy` folder in `Models`. UICIRC-800.
 * Add RTL/Jest testing for `src/settings/Validation/loan-history` folder. Refs UICIRC-808.
-* Add RTL/Jest testing for `src/settings/Validation/fixed-due-date-schedule` folder. Refs UICIRC-808.
+* Add RTL/Jest testing for `src/settings/Validation/fixed-due-date-schedule` folder. Refs UICIRC-807.
 
 ## [7.0.3](https://github.com/folio-org/ui-circulation/tree/v7.0.3) (2022-04-11)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.2...v7.0.3)

--- a/src/settings/lib/RuleEditor/initFoldRules.test.js
+++ b/src/settings/lib/RuleEditor/initFoldRules.test.js
@@ -1,0 +1,59 @@
+import initFoldRules from './initFoldRules';
+
+describe('initFoldRules', () => {
+  let result;
+  const mockedLinesData = [
+    'firstTestLine',
+    '#secondTestLine',
+    'thirdTestLine',
+    'fourthTestLine',
+    '#fifthTestLine',
+    '#sixthTestLine',
+  ];
+  const cm = {
+    getLine: (lineNumber) => mockedLinesData[lineNumber],
+    lastLine: () => mockedLinesData.length - 1,
+  };
+  const CodeMirror = (start) => ({
+    registerHelper: (fold, rules, calback) => { result = calback(cm, start); },
+    Pos: (position, lineLength) => ({ position, lineLength }),
+  });
+
+  describe('when text do not starts from "#" symbol', () => {
+    it('should return undefined', () => {
+      initFoldRules(CodeMirror({ line: 0 }));
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when text starts from "#"', () => {
+    describe('when data contatins few more lines without # after passed line', () => {
+      it('should correctly process passed data', () => {
+        const line = 1;
+        const expectedResult = {
+          from: {
+            position: line,
+            lineLength: mockedLinesData[line].length,
+          },
+          to: {
+            position: 3,
+            lineLength: mockedLinesData[3].length,
+          },
+        };
+
+        initFoldRules(CodeMirror({ line }));
+
+        expect(result).toEqual(expectedResult);
+      });
+    });
+
+    describe('when the next string after passed one starts from #', () => {
+      it('should return undefined', () => {
+        initFoldRules(CodeMirror({ line: 4 }));
+
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add RTL/Jest testing for `initFoldRules` in `src/settings/lib/RuleEditor`.

## Refs
https://issues.folio.org/browse/UICIRC-829

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/176436100-e5ed1274-95c5-4c79-bd72-b32647657cd3.png)