### PR TITLE
UICIRC-828: UI tests replacement with RTL/Jest for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## IN PROGRESS
 
-* UI tests replacement with RTL/Jest for `src\settings\Validation\engine\handlers.js`. UICIRC-814.
+* UI tests replacement with RTL/Jest for `src/settings/Validation/engine/handlers.js`. UICIRC-814.
+* UI tests replacement with RTL/Jest for `src/settings/lib/RuleEditor/utils.js`. UICIRC-828.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/lib/RuleEditor/utils.test.js
+++ b/src/settings/lib/RuleEditor/utils.test.js
@@ -1,0 +1,25 @@
+import addIndentToEditorRules from './utils';
+
+describe('utils', () => {
+  describe('addIndentToEditorRules', () => {
+    const rule = 'some rule';
+
+    describe('when position is before', () => {
+      it('should add indent before', () => {
+        expect(addIndentToEditorRules(rule, 'before')).toBe(` ${rule}`);
+      });
+    });
+
+    describe('when position is after', () => {
+      it('should add indent after', () => {
+        expect(addIndentToEditorRules(rule, 'after')).toBe(`${rule} `);
+      });
+    });
+
+    describe('when position is not passed', () => {
+      it('should return rule', () => {
+        expect(addIndentToEditorRules(rule)).toBe(rule);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
<img width="1273" alt="Screen Shot 2022-06-30 at 11 15 54 AM" src="https://user-images.githubusercontent.com/47976677/176627975-b742c64f-e149-4d61-99c9-18ca8004a0fa.png">

UI tests replacement with RTL/Jest for `src/settings/lib/RuleEditor/utils.js`.

## Refs
https://issues.folio.org/browse/UICIRC-828

## Screenshots
