### PR TITLE
UICIRC-830: UI tests replacement with RTL/Jest for hooks in `src/sett…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * UI tests replacement with RTL/Jest for `src/settings/lib/RuleEditor/utils.js`. UICIRC-828.
 * Add RTL/Jest testing for `initFoldRules` in `src/settings/lib/RuleEditor`. Refs UICIRC-829.
 * UI tests replacement with RTL/Jest for `FormValidator.js` file in `Validation`. Refs UICIRC-813.
+* UI tests replacement with RTL/Jest for hooks in `src/settings/lib/RuleEditor/initRulesCMM.js`. UICIRC-830.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/lib/RuleEditor/initRulesCMM.js
+++ b/src/settings/lib/RuleEditor/initRulesCMM.js
@@ -9,7 +9,7 @@ import {
   EDITOR_SPECIAL_SYMBOL,
 } from '../../../constants';
 
-const hooks = {
+export const hooks = {
   [EDITOR_SPECIAL_SYMBOL.HASH]: (stream, state) => { // # starts a rule, followed by name of rule.
     stream.eatWhile(/[^/]/);
     state.ruleLine = true;

--- a/src/settings/lib/RuleEditor/initRulesCMM.test.js
+++ b/src/settings/lib/RuleEditor/initRulesCMM.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { EDITOR_SPECIAL_SYMBOL } from '../../../constants';
+import { hooks } from './initRulesCMM';
+
+describe('initRulesCMM', () => {
+  describe('hooks', () => {
+    describe('hash', () => {
+      it('should work correctly', () => {
+        const stream = {
+          eatWhile: jest.fn(),
+        };
+        const state = {};
+
+        expect(hooks[EDITOR_SPECIAL_SYMBOL.HASH](stream, state)).toBe('ruleName');
+        expect(state.ruleLine).toBe(true);
+        expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/[^/]/));
+      });
+    });
+
+    describe('slash', () => {
+      it('should work correctly', () => {
+        const stream = {
+          skipToEnd: jest.fn(),
+        };
+
+        expect(hooks[EDITOR_SPECIAL_SYMBOL.SLASH](stream)).toBe('comment');
+        expect(stream.skipToEnd).toHaveBeenCalled();
+      });
+    });
+
+    describe('comma', () => {
+      it('should work correctly', () => {
+        const stream = {
+          eatWhile: jest.fn(),
+        };
+
+        expect(hooks[EDITOR_SPECIAL_SYMBOL.COMMA](stream)).toBe('comma');
+        expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/\s/));
+      });
+    });
+
+    describe('plus', () => {
+      it('should work correctly', () => {
+        const stream = {
+          eatWhile: jest.fn(),
+        };
+
+        expect(hooks[EDITOR_SPECIAL_SYMBOL.PLUS](stream)).toBe('and');
+        expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/\s/));
+      });
+    });
+
+    describe('colon', () => {
+      it('should work correctly', () => {
+        const stream = {
+          eatWhile: jest.fn(),
+        };
+        const state = {};
+
+        hooks[EDITOR_SPECIAL_SYMBOL.COLON](stream, state);
+
+        expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/\s/));
+        expect(state.rValue).toBe(true);
+        expect(state.keyProperty).toBe(null);
+      });
+    });
+
+    describe('negation', () => {
+      it('should work correctly', () => {
+        const stream = {
+          eatWhile: jest.fn(),
+        };
+
+        expect(hooks[EDITOR_SPECIAL_SYMBOL.NEGATION](stream)).toBe('not');
+        expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/\s/));
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
UI tests replacement with RTL/Jest for hooks in `src/settings/lib/RuleEditor/initRulesCMM.js`

## Refs
[UICIRC-813](https://issues.folio.org/browse/UICIRC-830)