### PR TITLE
UICIRC-839: Components are incorrectly imported directly from stripes-* packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add RTL/Jest testing for `initFoldRules` in `src/settings/lib/RuleEditor`. Refs UICIRC-829.
 * UI tests replacement with RTL/Jest for `FormValidator.js` file in `Validation`. Refs UICIRC-813.
 * UI tests replacement with RTL/Jest for hooks in `src/settings/lib/RuleEditor/initRulesCMM.js`. UICIRC-830.
+* Correctly import components from @folio/stripes/* packages. UICIRC-839.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/TitleLevelRequests/TitleLevelRequests.js
+++ b/src/settings/TitleLevelRequests/TitleLevelRequests.js
@@ -5,7 +5,7 @@ import { injectIntl } from 'react-intl';
 import { ConfigManager } from '@folio/stripes/smart-components';
 import {
   withStripes,
-} from '@folio/stripes-core';
+} from '@folio/stripes/core';
 
 import TitleLevelRequestsForm from './TitleLevelRequestsForm';
 import {

--- a/src/settings/TitleLevelRequests/TitleLevelRequests.test.js
+++ b/src/settings/TitleLevelRequests/TitleLevelRequests.test.js
@@ -17,7 +17,7 @@ import {
   CONFIG_NAMES,
 } from '../../constants';
 
-jest.mock('@folio/stripes-core', () => ({
+jest.mock('@folio/stripes/core', () => ({
   withStripes: jest.fn((component) => component),
 }));
 


### PR DESCRIPTION
## Purpose
Components are incorrectly imported directly from stripes-* packages

## Refs
https://issues.folio.org/browse/UICIRC-839

## Screenshots
We have imports "@folio/stripes-" but all of them associated with tests or '@folio/stripes-template-editor'
![UICIRC-839](https://user-images.githubusercontent.com/24813219/179731755-3db79b64-d2f7-4a6b-98cb-d434c3a52c18.JPG)

