### PR TITLE
UICIRC-832: UI tests replacement with RTL/Jest for rules-show-hint (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Correctly import components from @folio/stripes/* packages. UICIRC-839.
 * Change setting "Loan history" setting to "Loan anonymization". UICIRC-685
 * Split `rule-show-hint.js` into a few files and cover new files by RTL/Jest test. Refs UICIRC-823.
+* Cover functions in `rule-show-hint.js` by RTL/jest tests. UICIRC-832.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/lib/RuleEditor/rules-show-hint.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.js
@@ -880,4 +880,5 @@ export default {
   parseOptions,
   resolveAutoHints,
   getFromList,
+  defaultOptions,
 };

--- a/src/settings/lib/RuleEditor/rules-show-hint.test.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.test.js
@@ -62,7 +62,7 @@ describe('rulesShowHint', () => {
           listSelections: () => [1, 2],
         };
 
-        expect(fakeCodeMirror.showHintValue(initialOptions)).toBe(undefined);
+        expect(fakeCodeMirror.showHintValue(initialOptions)).toBeUndefined();
       });
     });
 
@@ -73,7 +73,7 @@ describe('rulesShowHint', () => {
           somethingSelected: () => true,
         };
 
-        expect(fakeCodeMirror.showHintValue(initialOptions)).toBe(undefined);
+        expect(fakeCodeMirror.showHintValue(initialOptions)).toBeUndefined();
       });
     });
 
@@ -99,7 +99,7 @@ describe('rulesShowHint', () => {
           },
         };
 
-        expect(fakeCodeMirror.showHintValue(options)).toBe(undefined);
+        expect(fakeCodeMirror.showHintValue(options)).toBeUndefined();
       });
 
       it('should trigger "close"', () => {
@@ -146,7 +146,7 @@ describe('rulesShowHint', () => {
           state: {},
         };
 
-        expect(fakeCodeMirror.showHintValue(rulesShowHint.defaultOptions)).toBe(undefined);
+        expect(fakeCodeMirror.showHintValue(rulesShowHint.defaultOptions)).toBeUndefined();
       });
     });
   });
@@ -192,55 +192,6 @@ describe('rulesShowHint', () => {
   });
 
   describe('resolveAutoHints', () => {
-    describe('when "getHelpers" returns empty array', () => {
-      const cm = {
-        getHelpers: () => [],
-        getCursor: () => [],
-      };
-
-      it('should return undefined', () => {
-        const getHelper = jest.fn(() => '');
-
-        expect(rulesShowHint.resolveAutoHints({
-          ...cm,
-          getHelper,
-        })).toBe(noop);
-      });
-
-      it('should trigger "fromList" from returned function', () => {
-        const fromListSpy = jest.spyOn(CodeMirror.hint, 'fromList');
-        const words = 'test';
-        const getHelper = jest.fn(() => words);
-        const codeMirror = {};
-        const returnedFunction = rulesShowHint.resolveAutoHints({
-          ...cm,
-          getHelper,
-        });
-
-        returnedFunction(codeMirror);
-
-        expect(fromListSpy).toHaveBeenCalledWith(codeMirror, { words });
-      });
-
-      it('should trigger "anyword" from returned function', () => {
-        const anyword = jest.fn();
-        const getHelper = jest.fn(() => '');
-        const codeMirror = {};
-        const options = {};
-
-        CodeMirror.hint.anyword = anyword;
-
-        const returnedFunction = rulesShowHint.resolveAutoHints({
-          ...cm,
-          getHelper,
-        });
-
-        returnedFunction(codeMirror, options);
-
-        expect(anyword).toHaveBeenCalledWith(codeMirror, options);
-      });
-    });
-
     describe('when "getHelpers" returns array with data', () => {
       const helpers = ['helper'];
       const applicableHelpers = [];
@@ -287,6 +238,55 @@ describe('rulesShowHint', () => {
         returnedFunction(codeMirror, () => {}, options);
 
         expect(fetchHintsSpy).toHaveBeenCalledWith(appHelper[helperIndex], codeMirror, options, expect.any(Function));
+      });
+    });
+
+    describe('when "getHelpers" returns empty array', () => {
+      const cm = {
+        getHelpers: () => [],
+        getCursor: () => [],
+      };
+
+      it('should return noop', () => {
+        const getHelper = jest.fn(() => '');
+
+        expect(rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        })).toBe(noop);
+      });
+
+      it('should trigger "fromList" from returned function', () => {
+        const fromListSpy = jest.spyOn(CodeMirror.hint, 'fromList');
+        const words = 'test';
+        const getHelper = jest.fn(() => words);
+        const codeMirror = {};
+        const returnedFunction = rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        });
+
+        returnedFunction(codeMirror);
+
+        expect(fromListSpy).toHaveBeenCalledWith(codeMirror, { words });
+      });
+
+      it('should trigger "anyword" from returned function', () => {
+        const anyword = jest.fn();
+        const getHelper = jest.fn(() => '');
+        const codeMirror = {};
+        const options = {};
+
+        CodeMirror.hint.anyword = anyword;
+
+        const returnedFunction = rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        });
+
+        returnedFunction(codeMirror, options);
+
+        expect(anyword).toHaveBeenCalledWith(codeMirror, options);
       });
     });
   });
@@ -350,7 +350,7 @@ describe('rulesShowHint', () => {
 
     describe('when there are no founded words', () => {
       it('should return undefined', () => {
-        expect(rulesShowHint.getFromList(commonCm, options)).toBe(undefined);
+        expect(rulesShowHint.getFromList(commonCm, options)).toBeUndefined();
       });
     });
   });

--- a/src/settings/lib/RuleEditor/rules-show-hint.test.js
+++ b/src/settings/lib/RuleEditor/rules-show-hint.test.js
@@ -1,0 +1,357 @@
+import CodeMirror from 'codemirror';
+import { noop } from 'lodash';
+
+import rulesShowHint from './rules-show-hint';
+import * as utils from './utils';
+
+jest.mock('codemirror', () => ({
+  hint: {
+    auto: {
+      resolve: jest.fn(),
+    },
+    fromList: jest.fn(),
+    anyword: null,
+  },
+  registerHelper: jest.fn(),
+  defineExtension: jest.fn(),
+  defineOption: jest.fn(),
+  signal: jest.fn(),
+  Pos: jest.fn(),
+  commands: {},
+}));
+jest.mock('./utils', () => ({
+  showHint: jest.fn(),
+  getText: jest.fn(),
+  addIndentToEditorRules: jest.fn(),
+  fetchHints: jest.fn(),
+  isChildTextInputField: jest.fn(),
+  createContainer: jest.fn(),
+  createHeader: jest.fn(),
+  isAnyItem: jest.fn(),
+  getApplicableHelpers: jest.fn(),
+}));
+
+describe('rulesShowHint', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('showHintValue', () => {
+    const initialOptions = {
+      hint: {},
+    };
+    const commonCodeMirrorMocks = {
+      getCursor: () => {},
+      listSelections: () => [],
+      on: () => {},
+      getLine: () => 1,
+      getSelection: () => [],
+      showHintValue: rulesShowHint.showHintValue,
+      options: {
+        hintOptions: {},
+      },
+      startPos: {
+        line: 1,
+      },
+    };
+
+    describe('when "selections.length" more than 1', () => {
+      it('should return undefined', () => {
+        const fakeCodeMirror = {
+          ...commonCodeMirrorMocks,
+          listSelections: () => [1, 2],
+        };
+
+        expect(fakeCodeMirror.showHintValue(initialOptions)).toBe(undefined);
+      });
+    });
+
+    describe('when there is no "supportsSelection"', () => {
+      it('should return undefined', () => {
+        const fakeCodeMirror = {
+          ...commonCodeMirrorMocks,
+          somethingSelected: () => true,
+        };
+
+        expect(fakeCodeMirror.showHintValue(initialOptions)).toBe(undefined);
+      });
+    });
+
+    describe('when "supportsSelection" exists', () => {
+      it('should return undefined', () => {
+        const fakeCodeMirror = {
+          ...commonCodeMirrorMocks,
+          listSelections: () => [
+            {
+              head: {
+                line: 'test',
+              },
+              anchor: {
+                line: 'test_2',
+              },
+            }
+          ],
+          somethingSelected: () => true,
+        };
+        const options = {
+          hint: {
+            supportsSelection: true,
+          },
+        };
+
+        expect(fakeCodeMirror.showHintValue(options)).toBe(undefined);
+      });
+
+      it('should trigger "close"', () => {
+        const line = 'test';
+        const close = jest.fn();
+        const fakeCodeMirror = {
+          ...commonCodeMirrorMocks,
+          listSelections: () => [
+            {
+              head: {
+                line,
+              },
+              anchor: {
+                line,
+              },
+            }
+          ],
+          getCursor: () => ({ line }),
+          somethingSelected: () => true,
+          state: {
+            completionActive: {
+              close,
+            },
+          },
+        };
+        const options = {
+          hint: {
+            supportsSelection: true,
+          },
+        };
+
+        fakeCodeMirror.showHintValue(options);
+
+        expect(close).toHaveBeenCalled();
+      });
+    });
+
+    describe('when there is no "hint" and "somethingSelected" returns false', () => {
+      it('should return undefined', () => {
+        const fakeCodeMirror = {
+          ...commonCodeMirrorMocks,
+          getCursor: () => ({ line: 'test' }),
+          somethingSelected: () => false,
+          state: {},
+        };
+
+        expect(fakeCodeMirror.showHintValue(rulesShowHint.defaultOptions)).toBe(undefined);
+      });
+    });
+  });
+
+  describe('parseOptions', () => {
+    const hintOptions = {
+      test: 'test',
+    };
+    const options = {
+      test_2: 'test_2',
+    };
+    const cm = {
+      options: {
+        hintOptions,
+      },
+    };
+    const pos = {};
+
+    describe('when "parsedOptions.hint.resolve" exists', () => {
+      it('should trigger "resolve" with correct arguments', () => {
+        const resolve = jest.fn();
+
+        CodeMirror.hint.auto.resolve.mockImplementationOnce(resolve);
+        rulesShowHint.parseOptions(cm, pos, options);
+
+        expect(resolve).toHaveBeenCalledWith(cm, pos);
+      });
+
+      it('should return options', () => {
+        const resolveResult = 'test_result';
+        const expectedResult = {
+          ...hintOptions,
+          ...options,
+          ...rulesShowHint.defaultOptions,
+          hint: resolveResult,
+        };
+
+        CodeMirror.hint.auto.resolve.mockImplementationOnce(() => resolveResult);
+
+        expect(rulesShowHint.parseOptions(cm, pos, options)).toEqual(expectedResult);
+      });
+    });
+  });
+
+  describe('resolveAutoHints', () => {
+    describe('when "getHelpers" returns empty array', () => {
+      const cm = {
+        getHelpers: () => [],
+        getCursor: () => [],
+      };
+
+      it('should return undefined', () => {
+        const getHelper = jest.fn(() => '');
+
+        expect(rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        })).toBe(noop);
+      });
+
+      it('should trigger "fromList" from returned function', () => {
+        const fromListSpy = jest.spyOn(CodeMirror.hint, 'fromList');
+        const words = 'test';
+        const getHelper = jest.fn(() => words);
+        const codeMirror = {};
+        const returnedFunction = rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        });
+
+        returnedFunction(codeMirror);
+
+        expect(fromListSpy).toHaveBeenCalledWith(codeMirror, { words });
+      });
+
+      it('should trigger "anyword" from returned function', () => {
+        const anyword = jest.fn();
+        const getHelper = jest.fn(() => '');
+        const codeMirror = {};
+        const options = {};
+
+        CodeMirror.hint.anyword = anyword;
+
+        const returnedFunction = rulesShowHint.resolveAutoHints({
+          ...cm,
+          getHelper,
+        });
+
+        returnedFunction(codeMirror, options);
+
+        expect(anyword).toHaveBeenCalledWith(codeMirror, options);
+      });
+    });
+
+    describe('when "getHelpers" returns array with data', () => {
+      const helpers = ['helper'];
+      const applicableHelpers = [];
+      const cm = {
+        getHelpers: () => helpers,
+      };
+      const options = {};
+      const codeMirror = {};
+      const returnedFunction = rulesShowHint.resolveAutoHints(cm);
+
+      it('should return function which has additional properties', () => {
+        const expectedProperties = {
+          async: true,
+          supportsSelection: true,
+        };
+
+        expect(returnedFunction).toEqual(expect.objectContaining(expectedProperties));
+      });
+
+      it('should trigger "getApplicableHelpers" from returned function', () => {
+        const getApplicableHelpersSpy = jest.spyOn(utils, 'getApplicableHelpers')
+          .mockReturnValueOnce(applicableHelpers);
+
+        returnedFunction(codeMirror, () => {}, options);
+
+        expect(getApplicableHelpersSpy).toHaveBeenCalledWith(codeMirror, helpers);
+      });
+
+      it('should trigger "callback" with null', () => {
+        const callback = jest.fn();
+
+        utils.getApplicableHelpers.mockReturnValueOnce(applicableHelpers);
+        returnedFunction(codeMirror, callback, options);
+
+        expect(callback).toHaveBeenCalledWith(null);
+      });
+
+      it('should trigger "fetchHints"', () => {
+        const fetchHintsSpy = jest.spyOn(utils, 'fetchHints').mockImplementationOnce((helper, codeM, opt, callback) => callback());
+        const appHelper = [{}];
+        const helperIndex = 0;
+
+        utils.getApplicableHelpers.mockReturnValueOnce(appHelper);
+        returnedFunction(codeMirror, () => {}, options);
+
+        expect(fetchHintsSpy).toHaveBeenCalledWith(appHelper[helperIndex], codeMirror, options, expect.any(Function));
+      });
+    });
+  });
+
+  describe('getFromList', () => {
+    const line = 1;
+    const to = 5;
+    const from = 8;
+    const string = 'string';
+    const commonCm = {
+      getCursor: () => ({
+        line,
+      }),
+      getTokenAt: () => ({
+        end: 1,
+        start: 2,
+        string,
+      }),
+    };
+    const options = {
+      words: [],
+    };
+
+    describe('when there are founded words', () => {
+      it('should use "CodeMirror.Pos" data for returned object', () => {
+        const words = [string];
+        const expectedResult = {
+          list: words,
+          from,
+          to,
+        };
+
+        CodeMirror.Pos
+          .mockReturnValueOnce(to)
+          .mockReturnValueOnce(from);
+
+        expect(rulesShowHint.getFromList(commonCm, { words })).toEqual(expectedResult);
+      });
+
+      it('should return "from" and "to" properties which are equal', () => {
+        const words = [''];
+        const cm = {
+          ...commonCm,
+          getTokenAt: () => ({
+            end: 1,
+            start: 2,
+          }),
+        };
+        const expectedResult = {
+          list: words,
+          from: to,
+          to,
+        };
+
+        CodeMirror.Pos
+          .mockReturnValueOnce(to);
+
+        expect(rulesShowHint.getFromList(cm, { words })).toEqual(expectedResult);
+      });
+    });
+
+    describe('when there are no founded words', () => {
+      it('should return undefined', () => {
+        expect(rulesShowHint.getFromList(commonCm, options)).toBe(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Cover functions in `rules-show-hint.js` by jest tests

## Refs
[UICIRC-832](https://issues.folio.org/browse/UICIRC-832)