### PR TITLE
UICIRC-767: With the permission "Settings (Circ): Can view loan history", hide the Save button on the Loan history pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Cover functions in `rule-show-hint.js` by RTL/jest tests. UICIRC-832.
 * Do not allow only space characters in the notice template body. UICIRC-783
 * Create a new permission "Settings (Circ): Can edit loan history". UICIRC-766.
+* With the permission "Settings (Circ): Can view loan history", hide the Save button on the Loan history pane. UICIRC-767
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/LoanHistory/LoanHistoryForm.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.js
@@ -34,6 +34,7 @@ class LoanHistoryForm extends Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
+    stripes: PropTypes.object,
     submitting: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     form: PropTypes.object.isRequired,
@@ -43,6 +44,7 @@ class LoanHistoryForm extends Component {
   renderFooter = () => {
     const {
       pristine,
+      stripes,
       submitting,
     } = this.props;
 
@@ -54,7 +56,7 @@ class LoanHistoryForm extends Component {
             data-test-loan-history-save-button
             type="submit"
             buttonStyle="primary paneHeaderNewButton"
-            disabled={pristine || submitting}
+            disabled={pristine || submitting || !stripes?.user?.perms?.['ui-circulation.settings.edit-loan-history']}
             marginBottom0
           >
             <FormattedMessage id="stripes-core.button.save" />

--- a/src/settings/LoanHistory/LoanHistoryForm.test.js
+++ b/src/settings/LoanHistory/LoanHistoryForm.test.js
@@ -64,6 +64,13 @@ describe('LoanHistoryForm', () => {
     },
     pristine: false,
     submitting: false,
+    stripes: {
+      user: {
+        perms: {
+          'ui-circulation.settings.edit-loan-history': true
+        }
+      }
+    }
   };
 
   const getById = (id) => within(screen.getByTestId(id));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UICIRC-551: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
With the permission "Settings (Circ): Can view loan history", hide the Save button on the Loan history pane
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
https://issues.folio.org/browse/UICIRC-767
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICIRC-551
-->

## Screenshots
recording on folio snapshot with diku_admin login
![chrome_gnIDbs5AR7](https://user-images.githubusercontent.com/104053200/191192193-e1122ada-c7c3-4b96-9afa-4775519e4154.gif)

recording on folio snapshot with other login that has permission "ui-circulation.settings.loan-history" ("Settings (Circ): Can view loan history") and not "ui-circulation.settings.edit-loan-history" ("Settings (Circ): Can edit loan history")
![chrome_gw0S08E80K](https://user-images.githubusercontent.com/104053200/191193361-09bebbfb-3c06-4a4a-b816-72d75068aba9.gif)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
