### PR TITLE
UICIRC-837: UI tests replacement with RTL/Jest for initRulesCMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Cover functions in `rule-show-hint.js` by RTL/jest tests. UICIRC-832.
 * Do not allow only space characters in the notice template body. UICIRC-783
 * Create a new permission "Settings (Circ): Can edit loan history". UICIRC-766.
+* UI tests replacement with RTL/Jest for initRulesCMM. Refs UICIRC-837.
 
 ## [7.1.0](https://github.com/folio-org/ui-circulation/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.0.3...v7.1.0)

--- a/src/settings/lib/RuleEditor/initRulesCMM.js
+++ b/src/settings/lib/RuleEditor/initRulesCMM.js
@@ -42,7 +42,7 @@ export const hooks = {
   }
 };
 
-function processToken(stream, state, parserConfig) {
+export function processToken(stream, state, parserConfig) {
   const {
     typeMapping,
     policyMapping,
@@ -133,64 +133,66 @@ function processToken(stream, state, parserConfig) {
   return null;
 }
 
-const initRulesCMM = (CodeMirror) => {
-  CodeMirror.defineMode('rulesCMM', (config, parserConfig) => {
-    const { indentUnit } = config;
+export const defineRulesCMM = (config, parserConfig) => {
+  const { indentUnit } = config;
 
-    return {
-      startState() {
-        const { completionLists, typeMapping, policyMapping } = parserConfig;
+  return {
+    startState() {
+      const { completionLists, typeMapping, policyMapping } = parserConfig;
 
-        return {
-          keyProperty: null, // current defined property or typegroup, if any.
-          rValue: false, // in a property or value?
-          indented: 0,
-          nextApplicable: { completionLists, typeMapping, policyMapping },
-          ruleLine: false,
-          context: {
-            align: null,
-          }
-        };
-      },
-
-      blankLine(state) {
-        state.comment = false;
-        state.indented = 0;
-        state.keyProperty = null;
-      },
-
-      indent(state) {
-        if (state.ruleLine) {
-          return state.indented + indentUnit;
+      return {
+        keyProperty: null, // current defined property or typegroup, if any.
+        rValue: false, // in a property or value?
+        indented: 0,
+        nextApplicable: { completionLists, typeMapping, policyMapping },
+        ruleLine: false,
+        context: {
+          align: null,
         }
+      };
+    },
 
-        if (state.rValue) {
-          return state.indented;
-        }
+    blankLine(state) {
+      state.comment = false;
+      state.indented = 0;
+      state.keyProperty = null;
+    },
 
-        return null;
-      },
-
-      eletricInput: /#.*$/,
-
-      token(stream, state) {
-        const ctx = state.context;
-
-        if (stream.eol()) {
-          state.keyProperty = null;
-        }
-
-        if (stream.sol()) {
-          if (ctx.align == null) ctx.align = false;
-
-          state.indented = stream.indentation();
-          state.startOfLine = true;
-        }
-
-        return processToken(stream, state, parserConfig);
+    indent(state) {
+      if (state.ruleLine) {
+        return state.indented + indentUnit;
       }
-    };
-  });
+
+      if (state.rValue) {
+        return state.indented;
+      }
+
+      return null;
+    },
+
+    eletricInput: /#.*$/,
+
+    token(stream, state) {
+      const ctx = state.context;
+
+      if (stream.eol()) {
+        state.keyProperty = null;
+      }
+
+      if (stream.sol()) {
+        if (ctx.align == null) ctx.align = false;
+
+        state.indented = stream.indentation();
+        state.startOfLine = true;
+      }
+
+      return processToken(stream, state, parserConfig);
+    }
+  };
+};
+
+const initRulesCMM = (CodeMirror) => {
+  CodeMirror.defineMode('rulesCMM', defineRulesCMM);
 };
 
 export default initRulesCMM;

--- a/src/settings/lib/RuleEditor/initRulesCMM.test.js
+++ b/src/settings/lib/RuleEditor/initRulesCMM.test.js
@@ -1,7 +1,15 @@
 import React from 'react';
 
-import { EDITOR_SPECIAL_SYMBOL } from '../../../constants';
-import { hooks } from './initRulesCMM';
+import {
+  EDITOR_KEYWORD,
+  EDITOR_SPECIAL_SYMBOL,
+  RULES_TYPE,
+} from '../../../constants';
+import initRulesCMM, {
+  hooks,
+  processToken,
+  defineRulesCMM,
+} from './initRulesCMM';
 
 describe('initRulesCMM', () => {
   describe('hooks', () => {
@@ -75,6 +83,586 @@ describe('initRulesCMM', () => {
         expect(hooks[EDITOR_SPECIAL_SYMBOL.NEGATION](stream)).toBe('not');
         expect(String(stream.eatWhile.mock.calls[0][0])).toBe(String(/\s/));
       });
+    });
+  });
+
+  describe('processToken', () => {
+    const commonStream = {
+      sol: () => true,
+      eatSpace: () => true,
+      skipToEnd: () => {},
+      next: () => {},
+      eatWhile: () => {},
+    };
+    const commonParserConfig = {
+      typeMapping: {},
+      policyMapping: {},
+      completionLists: {},
+      keySelector: '',
+    };
+
+    describe('when "stream.sol" returns true and "stream.eatSpace" returns true', () => {
+      const state = {};
+      const result = processToken(commonStream, state, commonParserConfig);
+
+      it('should return "null"', () => {
+        expect(result).toBeNull();
+      });
+
+      it('should modify "state"', () => {
+        expect(state.rValue).toEqual(false);
+        expect(state.keyProperty).toEqual(null);
+      });
+    });
+
+    describe('when "stream.sol" returns true and "stream.eatSpace" returns false', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        eatSpace: () => false,
+        next: () => {},
+        current: () => {},
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return "null"', () => {
+        expect(result).toBeNull();
+      });
+
+      it('should modify "state"', () => {
+        expect(state.rValue).toEqual(false);
+        expect(state.keyProperty).toEqual(null);
+      });
+    });
+
+    describe('when "stream.sol" returns false and "stream.eatSpace" returns true', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return "null"', () => {
+        expect(result).toBeNull();
+      });
+
+      it('should not modify "state"', () => {
+        const expectedResult = {};
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "stream.next" returns SLASH hook', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => EDITOR_SPECIAL_SYMBOL.SLASH,
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return correct result', () => {
+        const expectedResult = 'comment';
+
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should not modify state', () => {
+        const expectedResult = {};
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "stream.next" returns NEGATION hook', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => EDITOR_SPECIAL_SYMBOL.NEGATION,
+      };
+
+      it('should return correct result', () => {
+        const expectedResult = 'not';
+        const result = processToken(stream, state, commonParserConfig);
+
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should modify state', () => {
+        const expectedResult = {
+          ruleLine: false,
+        };
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "keywords" includes result of "stream.current"', () => {
+      const state = {};
+      const currentResult = EDITOR_KEYWORD.PRIORITY;
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => undefined,
+        current: () => currentResult,
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return correct result', () => {
+        const expectedResult = 'keyword';
+
+        expect(result).toEqual(expectedResult);
+      });
+
+      it('should modify state', () => {
+        const expectedResult = {
+          keyProperty: currentResult,
+        };
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "keywords" does not include result of "stream.current"', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => undefined,
+        current: () => 'test',
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return "null"', () => {
+        expect(result).toBeNull();
+      });
+
+      it('should not modify state', () => {
+        const expectedResult = {};
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "typeKeys" includes result of "stream.current"', () => {
+      const state = {};
+      const test = 'test';
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => undefined,
+        current: () => test,
+      };
+      const parserConfig = {
+        ...commonParserConfig,
+        typeMapping: {
+          test,
+        },
+      };
+      const result = processToken(stream, state, parserConfig);
+
+      it('should return correct result', () => {
+        expect(result).toEqual(test);
+      });
+
+      it('should modify state', () => {
+        const expectedResult = {
+          keyProperty: test,
+        };
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "LOCATION_RULES_TYPES" includes result of "stream.current"', () => {
+      const state = {};
+      const stream = {
+        ...commonStream,
+        sol: () => false,
+        eatSpace: () => false,
+        next: () => undefined,
+        current: () => RULES_TYPE.INSTITUTION,
+      };
+      const result = processToken(stream, state, commonParserConfig);
+
+      it('should return correct result', () => {
+        expect(result).toEqual(RULES_TYPE.INSTITUTION);
+      });
+
+      it('should modify state', () => {
+        const expectedResult = {
+          keyProperty: RULES_TYPE.INSTITUTION,
+        };
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "policyKeys" includes result of "stream.current"', () => {
+      const current = 'current';
+      const stream = {
+        ...commonStream,
+        eatSpace: () => false,
+        sol: () => false,
+        next: () => undefined,
+        current: () => current,
+      };
+      const parserConfig = {
+        ...commonParserConfig,
+        policyMapping: {
+          current,
+        },
+      };
+      const state = {};
+      const result = processToken(stream, state, parserConfig);
+
+      it('should return correct result', () => {
+        expect(result).toEqual(current);
+      });
+
+      it('should modify state', () => {
+        const expectedResult = {
+          keyProperty: current,
+        };
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "keyProperty" is presented', () => {
+      const current = 'current';
+
+      describe('when there are no "typeMapping" and "policyMapping" values', () => {
+        const keyProperty = 'keyProperty';
+        const stream = {
+          ...commonStream,
+          eatSpace: () => false,
+          sol: () => false,
+          next: () => undefined,
+          current: () => keyProperty,
+        };
+        const state = {
+          keyProperty,
+        };
+
+        it('should return "null"', () => {
+          expect(processToken(stream, state, commonParserConfig)).toBeNull();
+        });
+      });
+
+      describe('when "typeMapping" value is presented', () => {
+        const keyProperty = RULES_TYPE.INSTITUTION;
+        const stream = {
+          ...commonStream,
+          eatSpace: () => false,
+          sol: () => false,
+          next: () => undefined,
+          current: () => current,
+        };
+        const state = {
+          keyProperty,
+        };
+        const parseConfig = {
+          ...commonParserConfig,
+          typeMapping: {
+            [RULES_TYPE.INSTITUTION]: keyProperty,
+          },
+          completionLists: {
+            [RULES_TYPE.INSTITUTION]: [{
+              code: 'test',
+            }],
+          }
+        };
+
+        it('should return "null"', () => {
+          expect(processToken(stream, state, parseConfig)).toBeNull();
+        });
+      });
+
+      describe('when "isLocationCriteriaExists" is true', () => {
+        const keyProperty = RULES_TYPE.INSTITUTION;
+        const stream = {
+          ...commonStream,
+          eatSpace: () => false,
+          sol: () => false,
+          next: () => undefined,
+          current: () => current,
+        };
+        const state = {
+          keyProperty,
+        };
+        const parseConfig = {
+          ...commonParserConfig,
+          typeMapping: {
+            [RULES_TYPE.INSTITUTION]: keyProperty,
+          },
+          completionLists: {
+            [RULES_TYPE.INSTITUTION]: [{
+              code: current,
+            }],
+          }
+        };
+
+        it('should return selector', () => {
+          expect(processToken(stream, state, parseConfig)).toEqual(`${keyProperty}-selector`);
+        });
+      });
+
+      describe('when "keySelector" does not contain result of "stream.current"', () => {
+        const keyProperty = RULES_TYPE.INSTITUTION;
+        const stream = {
+          ...commonStream,
+          eatSpace: () => false,
+          sol: () => false,
+          next: () => undefined,
+          current: () => current,
+        };
+        const state = {
+          keyProperty,
+        };
+        const parseConfig = {
+          ...commonParserConfig,
+          typeMapping: {
+            [RULES_TYPE.INSTITUTION]: keyProperty,
+          },
+          completionLists: {
+            [RULES_TYPE.INSTITUTION]: [{
+              code: '',
+            }],
+          },
+          keySelector: current,
+        };
+
+        it('should return selector', () => {
+          expect(processToken(stream, state, parseConfig)).toEqual(`${keyProperty}-selector`);
+        });
+      });
+
+      describe('when "policyMapping" and "rValue" values are presented', () => {
+        const keyProperty = 'keyProperty';
+        const stream = {
+          ...commonStream,
+          eatSpace: () => false,
+          sol: () => false,
+          next: () => undefined,
+          current: () => current,
+        };
+        const state = {
+          keyProperty,
+          rValue: 'rValue',
+        };
+        const parseConfig = {
+          ...commonParserConfig,
+          policyMapping: {
+            keyProperty,
+          },
+        };
+        const result = processToken(stream, state, parseConfig);
+
+        it('should return "null"', () => {
+          const expectedResult = 'policy';
+
+          expect(result).toEqual(expectedResult);
+        });
+
+        it('should modify "state"', () => {
+          const expectedResult = {
+            ...state,
+            keyProperty: null,
+          };
+
+          expect(state).toEqual(expectedResult);
+        });
+      });
+    });
+  });
+
+  describe('defineRulesCMM', () => {
+    const indentUnit = 'test';
+    const config = {
+      indentUnit,
+    };
+    const completionLists = 'completionLists';
+    const typeMapping = 'typeMapping';
+    const policyMapping = 'policyMapping';
+    const parserConfig = {
+      completionLists,
+      typeMapping,
+      policyMapping,
+    };
+    const result = defineRulesCMM(config, parserConfig);
+
+    describe('startState', () => {
+      it('should return correct data', () => {
+        const expectedResult = {
+          keyProperty: null,
+          rValue: false,
+          indented: 0,
+          nextApplicable: {
+            completionLists,
+            typeMapping,
+            policyMapping,
+          },
+          ruleLine: false,
+          context: {
+            align: null,
+          }
+        };
+
+        expect(result.startState()).toEqual(expectedResult);
+      });
+    });
+
+    describe('blankLine', () => {
+      it('should modify "state"', () => {
+        const state = {};
+        const expectedResult = {
+          comment: false,
+          indented: 0,
+          keyProperty: null,
+        };
+
+        result.blankLine(state);
+
+        expect(state).toEqual(expectedResult);
+      });
+    });
+
+    describe('indent', () => {
+      describe('when "state" is empty object', () => {
+        it('should return "null"', () => {
+          expect(result.indent({})).toBeNull();
+        });
+      });
+
+      describe('when "state" contains "ruleLine"', () => {
+        it('should return correct data', () => {
+          const indented = 1;
+          const state = {
+            ruleLine: true,
+            indented,
+          };
+          expect(result.indent(state)).toEqual(indented + indentUnit);
+        });
+      });
+
+      describe('when "state" contains "rValue"', () => {
+        it('should return correct data', () => {
+          const indented = 1;
+          const state = {
+            rValue: true,
+            indented,
+          };
+          expect(result.indent(state)).toEqual(indented);
+        });
+      });
+    });
+
+    describe('token', () => {
+      const commonStream = {
+        eatSpace: () => {},
+        next: () => {},
+        eatWhile: () => {},
+        current: () => {},
+      };
+
+      describe('when "stream.eol" returns true', () => {
+        const stream = {
+          ...commonStream,
+          eol: () => true,
+          sol: () => false,
+        };
+        const state = {};
+
+        result.token(stream, state);
+
+        it('should modify "state"', () => {
+          expect(state.keyProperty).toBeNull();
+        });
+      });
+
+      describe('when "stream.sol" returns true', () => {
+        const stream = {
+          ...commonStream,
+          sol: () => true,
+          eol: () => false,
+          indentation: () => false,
+        };
+
+        it('should modify "state"', () => {
+          const state = {
+            context: {
+              align: '',
+            },
+          };
+          const expectedResult = {
+            ...state,
+            indented: false,
+            startOfLine: true,
+          };
+
+          result.token(stream, state);
+
+          expect(state).toEqual(expect.objectContaining(expectedResult));
+        });
+
+        describe('when "ctx.align" equals "null"', () => {
+          it('should modify "state"', () => {
+            const state = {
+              context: {
+                align: null,
+              },
+            };
+            const expectedResult = {
+              context: {
+                align: false,
+              },
+              indented: false,
+              startOfLine: true,
+            };
+
+            result.token(stream, state);
+
+            expect(state).toEqual(expect.objectContaining(expectedResult));
+          });
+        });
+      });
+
+      describe('when "stream.eol" and "stream.sol" return false', () => {
+        const stream = {
+          ...commonStream,
+          eol: () => false,
+          sol: () => false,
+        };
+        const state = {};
+        const expectedResult = {};
+
+        result.token(stream, state);
+
+        it('should not modify "state"', () => {
+          expect(state).toEqual(expectedResult);
+        });
+      });
+    });
+  });
+
+  describe('initRulesCMM', () => {
+    const CodeMirror = {
+      defineMode: jest.fn(),
+    };
+
+    it('should trigger "defineMode" with correct arguments', () => {
+      initRulesCMM(CodeMirror);
+
+      expect(CodeMirror.defineMode).toHaveBeenLastCalledWith('rulesCMM', expect.any(Function));
     });
   });
 });


### PR DESCRIPTION
## Purpose
Cover initRulesCMM by jest tests

## Refs
[UICIRC-837](https://issues.folio.org/browse/UICIRC-837)

## Screenshots
![image](https://user-images.githubusercontent.com/42437614/192274997-1a7fb953-d885-4693-8ae7-3a35c6a442fd.png)

## Notes
`initRulesCMM.js` file doesn't have a lot of modfifcations.
I just moved outside function defined in `CodeMirror.defineMode`.