### PR TITLE
Fix problem with validate unique name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-circulation
 
+## IN PROGRESS
+* Fix problem with saving Notice template. UICIRC-870.
+* Fix problem with saving Due date schedules. UICIRC-872.
+* Fix problem with saving Request policy. UICIRC-873.
+
 ## [7.2.0](https://github.com/folio-org/ui-circulation/tree/v7.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.1.0...v7.2.0)
 

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   render,
+  screen,
   fireEvent,
   waitFor,
 } from '@testing-library/react';
@@ -50,7 +51,9 @@ AccordionSet.mockImplementation(({
 ));
 
 const name = 'test-name';
-
+const testIds = {
+  form: 'fixedDueDateScheduleForm',
+};
 const messageIds = {
   about: 'ui-circulation.settings.fDDSform.about',
   editLabel: 'ui-circulation.settings.fDDS.editLabel',
@@ -96,6 +99,9 @@ const defaultProps = {
   handleSubmit: jest.fn(),
   stripes,
   okapi,
+  location: {
+    search: '',
+  },
 };
 
 describe('FixedDueDateScheduleForm', () => {
@@ -313,6 +319,9 @@ describe('FixedDueDateScheduleForm', () => {
       ...defaultProps,
       pristine: false,
       initialValues,
+      location: {
+        search: 'edit',
+      },
     };
 
     beforeEach(() => {
@@ -519,6 +528,23 @@ describe('FixedDueDateScheduleForm', () => {
       it('"fetch" should not be called if "name" is not provided', () => {
         expect(fetch).not.toBeCalledWith();
       });
+    });
+  });
+
+  describe('Edit layer without data', () => {
+    const props = {
+      ...defaultProps,
+      location: {
+        search: 'edit',
+      },
+    };
+
+    beforeEach(() => {
+      render(<FixedDueDateScheduleForm {...props} />);
+    });
+
+    it('should not return view', () => {
+      expect(screen.queryByTestId(testIds.form)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/settings/PatronNotices/PatronNoticeForm.test.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.test.js
@@ -54,6 +54,7 @@ jest.mock('../../constants', () => ({
 
 describe('PatronNoticeForm', () => {
   const testIds = {
+    form: 'patronNoticeForm',
     patronNoticePaneset: 'patronNoticePaneset',
     patronNoticeTemplatePane: 'patronNoticeTemplatePane',
     patronNoticeCancelButton: 'patronNoticeCancelButton',
@@ -106,6 +107,9 @@ describe('PatronNoticeForm', () => {
     handleSubmit: testHandleSubmit,
     onCancel: testOnCancel,
     okapi: testOkapi,
+    location: {
+      search: '',
+    },
   };
 
   afterEach(() => {
@@ -271,6 +275,9 @@ describe('PatronNoticeForm', () => {
         <PatronNoticeForm
           {...defaultTestProps}
           initialValues={initialValues}
+          location={{
+            search: 'edit',
+          }}
         />
       );
     });
@@ -289,6 +296,23 @@ describe('PatronNoticeForm', () => {
 
     it('should not render patron notices predefined warning label', () => {
       expect(screen.queryByText(labelIds.patronNoticesPredefinedWarning)).toBeVisible();
+    });
+  });
+
+  describe('Edit layer without data', () => {
+    const props = {
+      ...defaultTestProps,
+      location: {
+        search: 'edit',
+      },
+    };
+
+    beforeEach(() => {
+      render(<PatronNoticeForm {...props} />);
+    });
+
+    it('should not return view', () => {
+      expect(screen.queryByTestId(testIds.form)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -75,6 +75,9 @@ describe('RequestPolicyForm', () => {
     submitting: false,
     onCancel,
     handleSubmit,
+    location: {
+      search: '',
+    },
   };
 
   afterEach(() => {
@@ -188,6 +191,9 @@ describe('RequestPolicyForm', () => {
           {...defaultProps}
           initialValues={initialValues}
           form={form}
+          location={{
+            search: 'edit',
+          }}
         />
       );
     });
@@ -254,7 +260,11 @@ describe('RequestPolicyForm', () => {
         });
 
         it('the corresponding error should appear', () => {
-          expect(catchFunction).toHaveBeenCalledWith(labelIds.nameExists);
+          expect(catchFunction.mock.calls[0][0]).toEqual(expect.objectContaining({
+            props: {
+              id: labelIds.nameExists,
+            },
+          }));
         });
       });
 
@@ -292,6 +302,26 @@ describe('RequestPolicyForm', () => {
           expect(catchFunction).toHaveBeenCalledWith(undefined);
         });
       });
+    });
+  });
+
+  describe('Edit layer without data', () => {
+    const form = {
+      getState: jest.fn(() => ({})),
+    };
+    const props = {
+      ...defaultProps,
+      location: {
+        search: 'edit',
+      },
+    };
+
+    beforeEach(() => {
+      render(<RequestPolicyForm {...props} form={form} />);
+    });
+
+    it('should not return view', () => {
+      expect(screen.queryByTestId(testIds.form)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/settings/utils/utils.js
+++ b/src/settings/utils/utils.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import {
+  find,
+  get,
+} from 'lodash';
+
+export const LAYERS = {
+  EDIT: 'edit',
+};
+
+export const validateUniqueNameById = async ({
+  currentName,
+  previousId,
+  getByName,
+  selector,
+  errorKey,
+}) => {
+  let error;
+
+  if (currentName) {
+    try {
+      const response = await getByName(currentName);
+      const responseData = await response.json();
+      const data = get(responseData, selector, []);
+      const matched = find(data, (item) => {
+        return item.name.toLowerCase() === currentName.toLowerCase();
+      });
+
+      if (matched && matched.id !== previousId) {
+        error = <FormattedMessage id={`ui-circulation.${errorKey}`} />;
+      }
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  return error;
+};
+
+export const isEditLayer = (layer = '') => (layer.includes(LAYERS.EDIT));

--- a/src/settings/utils/utils.test.js
+++ b/src/settings/utils/utils.test.js
@@ -1,0 +1,86 @@
+import {
+  LAYERS,
+  isEditLayer,
+  validateUniqueNameById,
+} from './utils';
+
+describe('utils', () => {
+  describe('isEditLayer', () => {
+    it('should return true if layer is edit', () => {
+      expect(isEditLayer(LAYERS.EDIT)).toBe(true);
+    });
+
+    it('should return false if layer is not edit', () => {
+      expect(isEditLayer('any')).toBe(false);
+    });
+
+    it('should return false if layer is not provided', () => {
+      expect(isEditLayer()).toBe(false);
+    });
+  });
+
+  describe('validateUniqueNameById', () => {
+    const currentName = 'currentName';
+    const previousId = 'previousId';
+    const getByName = jest.fn(() => {
+      return Promise.resolve({
+        json: () => Promise.resolve({}),
+      });
+    });
+    const selector = 'selector';
+    const errorKey = 'errorKey';
+    const props = {
+      currentName,
+      previousId,
+      getByName,
+      selector,
+      errorKey,
+    };
+
+    it('should call getByName with currentName', () => {
+      validateUniqueNameById(props);
+
+      expect(getByName).toHaveBeenCalledWith(currentName);
+    });
+
+    it('should not return error', async () => {
+      const getByNameMock = jest.fn(() => {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            [selector]: [{
+              id: previousId,
+              name: currentName,
+            }],
+          }),
+        });
+      });
+
+      expect(await validateUniqueNameById({
+        ...props,
+        getByName: getByNameMock,
+      })).toBeUndefined();
+    });
+
+    it('should return error', async () => {
+      const getByNameMock = jest.fn(() => {
+        return Promise.resolve({
+          json: () => Promise.resolve({
+            [selector]: [{
+              id: 'notPreviousId',
+              name: currentName,
+            }],
+          }),
+        });
+      });
+
+      expect(await validateUniqueNameById({
+        ...props,
+        getByName: getByNameMock,
+      })).toEqual(expect.objectContaining({
+        props: {
+          id: 'ui-circulation.errorKey',
+        },
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Fix problem with validate unique name for:
- Patron notice templates
- Request policies
- Fixed due date schedules

## Approach
We should not render component until all necessary data will be loaded on layer edit.
Moved validate name by id to utilities and reuse it in all places.

## Refs
https://issues.folio.org/browse/UICIRC-870
https://issues.folio.org/browse/UICIRC-872
https://issues.folio.org/browse/UICIRC-873