### PR TITLE
UICIRC-876: Permission "Can create, edit and remove staff slips" : Cannot edit Description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
           "circulation-storage.staff-slips.item.get",
           "settings.circulation.enabled"
         ],
-        "visible": true
+        "visible": false
       },
       {
         "permissionName": "ui-circulation.settings.staff-slips",


### PR DESCRIPTION
## Purpose
Make "ui-circulation.settings.edit-staff-slips" permission not visible for users.
This permission is necessary only as a sub-permission.
In future we could make it available in the list of all visible user permissions but now we do not need it (confirmed by Julie Bickle). 

## Refs
[Tiket - UICIRC-876](https://issues.folio.org/browse/UICIRC-876)
[Related PR](https://github.com/folio-org/ui-circulation/pull/973)