### PR TITLE
UICIRC-892 Drop react-redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-circulation
 
-## (8.0.0) IN PROGRESS
+## IN PROGRESS
 * Make consistent view of delete functionality of "Fixed due date schedules". Refs UICIRC-874.
 * Increase code coverage of "PatronNotices.js" file. Refs UICIRC-866.
 * Add "Settings (Circ): Can edit staff slips" permission. Refs UICIRC-876.
@@ -11,7 +11,6 @@
 * Add "user.preferredFirstName" as notice token in Settings. Refs UICIRC-462.
 * Add "Patron Group" as staff slip token in Settings. Refs UICIRC-791.
 * UI tests replacement with RTL/Jest for `normalize.js`. Refs UICIRC-864.
-* Upgrade `react-redux` to `v8`. Refs UICIRC-892.
 
 ## [7.2.1](https://github.com/folio-org/ui-circulation/tree/v7.2.1) (2022-11-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.2.0...v7.2.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-circulation
 
-## IN PROGRESS
+## (8.0.0) IN PROGRESS
 * Make consistent view of delete functionality of "Fixed due date schedules". Refs UICIRC-874.
 * Increase code coverage of "PatronNotices.js" file. Refs UICIRC-866.
 * Add "Settings (Circ): Can edit staff slips" permission. Refs UICIRC-876.
@@ -11,6 +11,7 @@
 * Add "user.preferredFirstName" as notice token in Settings. Refs UICIRC-462.
 * Add "Patron Group" as staff slip token in Settings. Refs UICIRC-791.
 * UI tests replacement with RTL/Jest for `normalize.js`. Refs UICIRC-864.
+* Upgrade `react-redux` to `v8`. Refs UICIRC-892.
 
 ## [7.2.1](https://github.com/folio-org/ui-circulation/tree/v7.2.1) (2022-11-29)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.2.0...v7.2.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/circulation",
-  "version": "8.0.0",
+  "version": "7.2.0",
   "description": "Circulation manager",
   "repository": "folio-org/ui-circulation",
   "publishConfig": {
@@ -353,7 +353,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.0",
-    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3"
   },
@@ -375,7 +374,6 @@
     "@folio/stripes": "^8.0.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",
-    "react-intl": "^5.7.0",
-    "react-redux": "^8.0.5"
+    "react-intl": "^5.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/circulation",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "Circulation manager",
   "repository": "folio-org/ui-circulation",
   "publishConfig": {
@@ -353,7 +353,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.0",
-    "react-redux": "~7.2.2",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3"
   },
@@ -375,6 +375,7 @@
     "@folio/stripes": "^8.0.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",
-    "react-intl": "^5.7.0"
+    "react-intl": "^5.7.0",
+    "react-redux": "^8.0.5"
   }
 }


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UICIRC-892.
- Dropping unneeded `react-redux` from this component.