### PR TITLE
UICIRC-912: Use camel case notation for all data-testid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change history for ui-circulation
 
 ## IN PROGRESS
+
 * Add metadata information to view of Staff Slips (Settings > Circulation > Staff Slips). Refs UICIRC-855.
 * Implement General information accordion. Refs UICIRC-909
 * Implement Template content accordion. Refs UICIRC-910
 * Add "item.loanType" as notice token in Settings. Refs UICIRC-852
+* Use camel case notation for all data-testid. Refs UICIRC-912.
 
 ## [8.0.0](https://github.com/folio-org/ui-circulation/tree/v8.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.2.1...v8.0.0)

--- a/src/settings/FinePolicy/FinePolicySettings.test.js
+++ b/src/settings/FinePolicy/FinePolicySettings.test.js
@@ -27,6 +27,7 @@ describe('FinePolicySettings', () => {
   const labelIds = {
     paneTitle: 'ui-circulation.settings.finePolicy.paneTitle',
     entryLabel: 'ui-circulation.settings.finePolicy.entryLabel',
+    overdueFinesPolicies: 'ui-circulation.settings.overdue-fines-policies',
   };
   const testMutator = {
     finePolicies: {
@@ -74,9 +75,9 @@ describe('FinePolicySettings', () => {
           },
           parseInitialValues,
           permissions: {
-            delete: 'ui-circulation.settings.overdue-fines-policies',
-            post: 'ui-circulation.settings.overdue-fines-policies',
-            put: 'ui-circulation.settings.overdue-fines-policies',
+            delete: labelIds.overdueFinesPolicies,
+            post: labelIds.overdueFinesPolicies,
+            put: labelIds.overdueFinesPolicies,
           },
           resourceKey: 'finePolicies',
           resources: {

--- a/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
+++ b/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
@@ -12,7 +12,7 @@ import {
 const OverdueAboutSection = () => (
   <div
     data-test-fine-policy-form-about-section
-    data-testid="OverdueAboutSection"
+    data-testid="overdueAboutSection"
   >
     <Row>
       <Col xs={3} data-test-about-section-policy-name>

--- a/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.test.js
+++ b/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.test.js
@@ -9,8 +9,15 @@ import '../../../../../../test/jest/__mock__';
 
 import OverdueAboutSection from './OverdueAboutSection';
 
-const labelIdForNameField = 'ui-circulation.settings.finePolicy.overdueFinePolicyName';
-const labelIdForDescriptionField = 'ui-circulation.settings.finePolicy.description';
+const labelIds = {
+  labelIdForNameField: 'ui-circulation.settings.finePolicy.overdueFinePolicyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.finePolicy.description',
+};
+const testIds = {
+  overdueAboutSection: 'overdueAboutSection',
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+};
 
 describe('OverdueAboutSection', () => {
   beforeEach(() => {
@@ -20,21 +27,21 @@ describe('OverdueAboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(screen.getByTestId('OverdueAboutSection')).toBeTruthy();
+    expect(screen.getByTestId(testIds.overdueAboutSection)).toBeTruthy();
   });
 
   it('should render "name" field with the correct props', () => {
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('id', 'input-policy-name');
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('name', 'name');
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('required');
-    expect(getItemByTestId('nameTestId').getByRole('textbox')).toBeTruthy();
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeTruthy();
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('id', 'input-policy-name');
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('name', 'name');
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('required');
+    expect(getItemByTestId(testIds.nameTestId).getByRole('textbox')).toBeTruthy();
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeTruthy();
   });
 
   it('should render "description" field with the correct props', () => {
-    expect(screen.getByTestId('descriptionTestId')).toHaveAttribute('id', 'description');
-    expect(screen.getByTestId('descriptionTestId')).toHaveAttribute('name', 'description');
-    expect(getItemByTestId('descriptionTestId').getByRole('textbox')).toBeTruthy();
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeTruthy();
+    expect(screen.getByTestId(testIds.descriptionTestId)).toHaveAttribute('id', 'description');
+    expect(screen.getByTestId(testIds.descriptionTestId)).toHaveAttribute('name', 'description');
+    expect(getItemByTestId(testIds.descriptionTestId).getByRole('textbox')).toBeTruthy();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeTruthy();
   });
 });

--- a/src/settings/FinePolicy/components/EditSections/RangeSection/OverdueFinesSection.test.js
+++ b/src/settings/FinePolicy/components/EditSections/RangeSection/OverdueFinesSection.test.js
@@ -19,10 +19,17 @@ import OverdueFinesSection, {
 
 Field.mockImplementation(jest.fn(() => null));
 
+const testIds = {
+  finePolicyLabelTestId: 'finePolicyLabelTestId',
+  quantityDurationLabelTestId: 'quantityDurationLabelTestId',
+};
+const labelIds = {
+  quantityLabelId: 'ui-circulation.settings.circulationRules.overdueFine.quantity',
+  perLabelId: 'ui-circulation.settings.finePolicy.per',
+  periodLabelId: 'ui-circulation.settings.circulationRules.overdueFine.period',
+};
+
 describe('OverdueFinesSection', () => {
-  const quantityLabelId = 'ui-circulation.settings.circulationRules.overdueFine.quantity';
-  const perLabelId = 'ui-circulation.settings.finePolicy.per';
-  const periodLabelId = 'ui-circulation.settings.circulationRules.overdueFine.period';
   const fieldsMap = {
     quantityField: 1,
     periodField: 2,
@@ -47,12 +54,12 @@ describe('OverdueFinesSection', () => {
   });
 
   it('should render component main label', () => {
-    expect(getById('quantityDurationLabelTestId').getByText('testLabel')).toBeVisible();
+    expect(getById(testIds.quantityDurationLabelTestId).getByText('testLabel')).toBeVisible();
   });
 
   it('should use correct props for "Field" in "overdue fine quantity" section', () => {
     const expectedResult = {
-      'aria-label': quantityLabelId,
+      'aria-label': labelIds.quantityLabelId,
       name: 'testName',
       type: 'number',
       hasClearIcon: false,
@@ -65,12 +72,12 @@ describe('OverdueFinesSection', () => {
   });
 
   it('should render secondary label', () => {
-    expect(getById('finePolicyLabelTestId').getByText(perLabelId)).toBeVisible();
+    expect(getById(testIds.finePolicyLabelTestId).getByText(labelIds.perLabelId)).toBeVisible();
   });
 
   it('should use correct props for "Field" in "overdue fine period" section', () => {
     const expectedResult = {
-      'aria-label': periodLabelId,
+      'aria-label': labelIds.periodLabelId,
       children: ['testIntervalPeriod'],
       name: 'testPeriod',
       component: Select,

--- a/src/settings/FinePolicy/components/EditSections/RangeSection/OverdueFinesSectionColumn.test.js
+++ b/src/settings/FinePolicy/components/EditSections/RangeSection/OverdueFinesSectionColumn.test.js
@@ -20,6 +20,17 @@ import OverdueFinesSectionColumn, {
 
 Field.mockImplementation(jest.fn(() => null));
 
+const testIds = {
+  mainLabelTestId: 'mainLabelTestId',
+};
+const labelIds = {
+  quantityLabelId: 'ui-circulation.settings.finePolicy.quantity',
+  selectLabelId: 'ui-circulation.settings.finePolicy.select',
+  finePolicyYes: 'ui-circulation.settings.finePolicy.yes',
+  finePolicyNo: 'ui-circulation.settings.finePolicy.no',
+
+};
+
 describe('OverdueFinesSectionColumn', () => {
   const getById = (id) => within(screen.getByTestId(id));
 
@@ -28,8 +39,6 @@ describe('OverdueFinesSectionColumn', () => {
   });
 
   describe('when component is "TextField"', () => {
-    const quantityLabelId = 'ui-circulation.settings.finePolicy.quantity';
-
     beforeEach(() => {
       render(
         <OverdueFinesSectionColumn
@@ -42,12 +51,12 @@ describe('OverdueFinesSectionColumn', () => {
     });
 
     it('should render main label', () => {
-      expect(getById('mainLabelTestId').getByText('firstTestLabel')).toBeVisible();
+      expect(getById(testIds.mainLabelTestId).getByText('firstTestLabel')).toBeVisible();
     });
 
     it('should execute "Field" with correct props', () => {
       const expectedProps = {
-        'aria-label': quantityLabelId,
+        'aria-label': labelIds.quantityLabelId,
         name: 'firstTestName',
         type: 'number',
         hasClearIcon: false,
@@ -61,8 +70,6 @@ describe('OverdueFinesSectionColumn', () => {
   });
 
   describe('when component is "Select"', () => {
-    const selectLabelId = 'ui-circulation.settings.finePolicy.select';
-
     beforeEach(() => {
       render(
         <OverdueFinesSectionColumn
@@ -75,22 +82,22 @@ describe('OverdueFinesSectionColumn', () => {
     });
 
     it('should render main label', () => {
-      expect(getById('mainLabelTestId').getByText('firstTestLabel')).toBeVisible();
+      expect(getById(testIds.mainLabelTestId).getByText('firstTestLabel')).toBeVisible();
     });
 
     it('should execute "Field" with correct props', () => {
       const expectedProps = {
-        'aria-label': selectLabelId,
+        'aria-label': labelIds.selectLabelId,
         name: 'secondTestName',
         component: Select,
         dataOptions: [
           {
             value: true,
-            label: 'ui-circulation.settings.finePolicy.yes',
+            label: labelIds.finePolicyYes,
           },
           {
             value: false,
-            label: 'ui-circulation.settings.finePolicy.no',
+            label: labelIds.finePolicyNo,
           },
         ],
       };

--- a/src/settings/FinePolicy/components/ViewSections/FinesSection/FinesSection.test.js
+++ b/src/settings/FinePolicy/components/ViewSections/FinesSection/FinesSection.test.js
@@ -14,17 +14,30 @@ import FinesSection, {
   getFormatedValue,
 } from './FinesSection';
 
+const testIds = {
+  viewFineSectionTestId: 'viewFineSectionTestId',
+  sectionOverdue: 'sectionOverdue',
+  sectionCountClosed: 'sectionCountClosed',
+  sectionMaxOverdue: 'sectionMaxOverdue',
+  sectionForgiveOverdue: 'sectionForgiveOverdue',
+  sectionOverdueRecall: 'sectionOverdueRecall',
+  sectionGracePeriod: 'sectionGracePeriod',
+  sectionMaxOverdueRecall: 'sectionMaxOverdueRecall',
+};
+const labelIds = {
+  overdueFineIdTitle: 'ui-circulation.settings.finePolicy.overdueFineTitle',
+  overdueFineId: 'ui-circulation.settings.finePolicy.overdueFine',
+  countClosedDHMId: 'ui-circulation.settings.finePolicy.countClosedDHM',
+  maximumOverdueFineId: 'ui-circulation.settings.finePolicy.maximumOverdueFine',
+  forgiveOverdueFineId: 'ui-circulation.settings.finePolicy.forgiveOverdueFine',
+  overdueRecallFineId: 'ui-circulation.settings.finePolicy.overdueRecallFine',
+  ignoreGracePeriodsRecallsId: 'ui-circulation.settings.finePolicy.ignoreGracePeriodsRecalls',
+  maximumRecallOverdueFineId: 'ui-circulation.settings.finePolicy.maximumRecallOverdueFine',
+  perPeriodId: 'ui-circulation.settings.finePolicy.perPeriod',
+};
+
 describe('FinesSection', () => {
   const getElementByTestId = (id) => within(screen.getByTestId(id));
-  const overdueFineIdTitle = 'ui-circulation.settings.finePolicy.overdueFineTitle';
-  const overdueFineId = 'ui-circulation.settings.finePolicy.overdueFine';
-  const countClosedDHMId = 'ui-circulation.settings.finePolicy.countClosedDHM';
-  const maximumOverdueFineId = 'ui-circulation.settings.finePolicy.maximumOverdueFine';
-  const forgiveOverdueFineId = 'ui-circulation.settings.finePolicy.forgiveOverdueFine';
-  const overdueRecallFineId = 'ui-circulation.settings.finePolicy.overdueRecallFine';
-  const ignoreGracePeriodsRecallsId = 'ui-circulation.settings.finePolicy.ignoreGracePeriodsRecalls';
-  const maximumRecallOverdueFineId = 'ui-circulation.settings.finePolicy.maximumRecallOverdueFine';
-  const perPeriodId = 'ui-circulation.settings.finePolicy.perPeriod';
   const mockedGetCheckboxValue = jest.fn(value => value);
 
   describe('should render correctly with valid values', () => {
@@ -60,11 +73,11 @@ describe('FinesSection', () => {
     });
 
     it('should render component header', () => {
-      expect(screen.getByText(overdueFineIdTitle)).toBeVisible();
+      expect(screen.getByText(labelIds.overdueFineIdTitle)).toBeVisible();
     });
 
     it('should pass "fineSectionOpen" correctly', () => {
-      expect(screen.getByTestId('viewFineSectionTestId')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewFineSectionTestId)).toHaveAttribute('open');
     });
 
     it('should execute "getCheckboxValue" functions 3 times', () => {
@@ -72,46 +85,46 @@ describe('FinesSection', () => {
     });
 
     it('should render "overdue" section correctly', () => {
-      const expectedResult = overdueFine.quantity >= 0 ? perPeriodId : '-';
+      const expectedResult = overdueFine.quantity >= 0 ? labelIds.perPeriodId : '-';
 
-      expect(getElementByTestId('sectionOverdue').getByText(overdueFineId)).toBeVisible();
-      expect(getElementByTestId('sectionOverdue').getByText(expectedResult)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionOverdue).getByText(labelIds.overdueFineId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionOverdue).getByText(expectedResult)).toBeVisible();
     });
 
     it('should render "count closed" section correctly', () => {
-      expect(getElementByTestId('sectionCountClosed').getByText(countClosedDHMId)).toBeVisible();
-      expect(getElementByTestId('sectionCountClosed').getByText(mockedPolicy.countClosed)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionCountClosed).getByText(labelIds.countClosedDHMId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionCountClosed).getByText(mockedPolicy.countClosed)).toBeVisible();
     });
 
     it('should render "max overdue" section correctly', () => {
       const expectedResult = parseFloat(mockedPolicy.maxOverdueFine || 0.00).toFixed(2);
 
-      expect(getElementByTestId('sectionMaxOverdue').getByText(maximumOverdueFineId)).toBeVisible();
-      expect(getElementByTestId('sectionMaxOverdue').getByText(expectedResult)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionMaxOverdue).getByText(labelIds.maximumOverdueFineId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionMaxOverdue).getByText(expectedResult)).toBeVisible();
     });
 
     it('should render "forgive overdue" section correctly', () => {
-      expect(getElementByTestId('sectionForgiveOverdue').getByText(forgiveOverdueFineId)).toBeVisible();
-      expect(getElementByTestId('sectionForgiveOverdue').getByText(mockedPolicy.forgiveOverdueFine)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionForgiveOverdue).getByText(labelIds.forgiveOverdueFineId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionForgiveOverdue).getByText(mockedPolicy.forgiveOverdueFine)).toBeVisible();
     });
 
     it('should render "overdue recall" section correctly', () => {
-      const expectedResult = overdueRecallFine.quantity >= 0 ? perPeriodId : '-';
+      const expectedResult = overdueRecallFine.quantity >= 0 ? labelIds.perPeriodId : '-';
 
-      expect(getElementByTestId('sectionOverdueRecall').getByText(overdueRecallFineId)).toBeVisible();
-      expect(getElementByTestId('sectionOverdueRecall').getByText(expectedResult)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionOverdueRecall).getByText(labelIds.overdueRecallFineId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionOverdueRecall).getByText(expectedResult)).toBeVisible();
     });
 
     it('should render "grace period" section correctly', () => {
-      expect(getElementByTestId('sectionGracePeriod').getByText(ignoreGracePeriodsRecallsId)).toBeVisible();
-      expect(getElementByTestId('sectionGracePeriod').getByText(mockedPolicy.gracePeriodRecall)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionGracePeriod).getByText(labelIds.ignoreGracePeriodsRecallsId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionGracePeriod).getByText(mockedPolicy.gracePeriodRecall)).toBeVisible();
     });
 
     it('should render "max overdue recall" section correctly', () => {
       const expectedResult = parseFloat(mockedPolicy.maxOverdueRecallFine || 0.00).toFixed(2);
 
-      expect(getElementByTestId('sectionMaxOverdueRecall').getByText(maximumRecallOverdueFineId)).toBeVisible();
-      expect(getElementByTestId('sectionMaxOverdueRecall').getByText(expectedResult)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionMaxOverdueRecall).getByText(labelIds.maximumRecallOverdueFineId)).toBeVisible();
+      expect(getElementByTestId(testIds.sectionMaxOverdueRecall).getByText(expectedResult)).toBeVisible();
     });
   });
 
@@ -139,7 +152,7 @@ describe('FinesSection', () => {
     });
 
     it('should pass "fineSectionOpen" correctly', () => {
-      expect(screen.getByTestId('viewFineSectionTestId')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewFineSectionTestId)).not.toHaveAttribute('open');
     });
   });
 
@@ -154,7 +167,7 @@ describe('FinesSection', () => {
         intervalId: 100,
       };
       const expectedResult = {
-        id: perPeriodId,
+        id: labelIds.perPeriodId,
         values: {
           number: parseFloat(mockedFine.quantity).toFixed(2),
           period: mockedFine.intervalId,
@@ -163,7 +176,7 @@ describe('FinesSection', () => {
 
       render(getQuantityValue(mockedFine));
 
-      expect(screen.getByText(perPeriodId)).toBeVisible();
+      expect(screen.getByText(labelIds.perPeriodId)).toBeVisible();
       expect(FormattedMessage).toHaveBeenLastCalledWith(expectedResult, {});
     });
 

--- a/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.test.js
+++ b/src/settings/FinePolicy/components/ViewSections/OverdueAboutSection/OverdueAboutSection.test.js
@@ -9,8 +9,15 @@ import '../../../../../../test/jest/__mock__';
 
 import OverdueAboutSection from './OverdueAboutSection';
 
-const labelIdForNameField = 'ui-circulation.settings.finePolicy.overdueFinePolicyName';
-const labelIdForDescriptionField = 'ui-circulation.settings.finePolicy.description';
+const testIds = {
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+  overdueAboutSectionTestId: 'overdueAboutSectionTestId',
+};
+const labelIds = {
+  labelIdForNameField: 'ui-circulation.settings.finePolicy.overdueFinePolicyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.finePolicy.description',
+};
 
 describe('OverdueAboutSection', () => {
   beforeEach(() => {
@@ -24,23 +31,23 @@ describe('OverdueAboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(screen.getByTestId('overdueAboutSectionTestId')).toBeTruthy();
+    expect(screen.getByTestId(testIds.overdueAboutSectionTestId)).toBeTruthy();
   });
 
   it('should render label of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeVisible();
   });
 
   it('should render value of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText('name')).toBeVisible();
   });
 
   it('should render label of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeVisible();
   });
 
   it('should render value of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText('description')).toBeVisible();
   });
 
   it('should render dash if description has not found', () => {

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
@@ -98,7 +98,7 @@ class FixedDueDateScheduleForm extends React.Component {
         <FormattedMessage id="ui-circulation.settings.fDDSform.closeLabel">
           {ariaLabel => (
             <IconButton
-              data-testid="close-icon"
+              data-testid="closeIcon"
               aria-label={ariaLabel}
               icon="times"
               iconClassName="closeIcon"
@@ -218,7 +218,7 @@ class FixedDueDateScheduleForm extends React.Component {
                   xs
                 >
                   <ExpandAllButton
-                    data-testid="expand-all-button"
+                    data-testid="expandAllButton"
                     accordionStatus={sections}
                     onToggle={this.handleExpandAll}
                   />

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
@@ -51,9 +51,12 @@ AccordionSet.mockImplementation(({
 
 const name = 'test-name';
 const testIds = {
+  accordionSet: 'accordionSet',
+  closeIcon: 'closeIcon',
+  expandAllButton: 'expandAllButton',
   form: 'fixedDueDateScheduleForm',
 };
-const messageIds = {
+const labelIds = {
   about: 'ui-circulation.settings.fDDSform.about',
   editLabel: 'ui-circulation.settings.fDDS.editLabel',
   newFixDDSchedule: 'ui-circulation.settings.fDDSform.newFixDDSchedule',
@@ -139,7 +142,7 @@ describe('FixedDueDateScheduleForm', () => {
 
     it('"IconButton" should be rendered with correct props', () => {
       const expectedProps = {
-        'aria-label': [messageIds.closeLabel],
+        'aria-label': [labelIds.closeLabel],
         icon: 'times',
         iconClassName: 'closeIcon',
         onClick: defaultProps.onCancel,
@@ -149,13 +152,13 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('"onCancel" should be called after clicking on close icon', () => {
-      fireEvent.click(container.getByTestId('close-icon'));
+      fireEvent.click(container.getByTestId(testIds.closeIcon));
 
       expect(defaultProps.onCancel).toBeCalled();
     });
 
     it('"Pane" component should have correct title', () => {
-      expect(container.getByText(messageIds.newFixDDSchedule)).toBeInTheDocument();
+      expect(container.getByText(labelIds.newFixDDSchedule)).toBeInTheDocument();
     });
 
     it('"Field" for name should be called with correct props', () => {
@@ -171,7 +174,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Label of name "Field" should be rendered', () => {
-      expect(container.getByText(messageIds.name)).toBeInTheDocument();
+      expect(container.getByText(labelIds.name)).toBeInTheDocument();
     });
 
     it('"Field" for description should be called with correct props', () => {
@@ -185,7 +188,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('"Label of description "Field" should be rendered', () => {
-      expect(container.getByText(messageIds.description)).toBeInTheDocument();
+      expect(container.getByText(labelIds.description)).toBeInTheDocument();
     });
 
     it('"FieldArray" should be called with correct props', () => {
@@ -208,7 +211,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Label of "General" accordion should be rendered', () => {
-      expect(container.getByText(messageIds.about)).toBeInTheDocument();
+      expect(container.getByText(labelIds.about)).toBeInTheDocument();
     });
 
     it('"Schedule" accordion should be rendered with correct props', () => {
@@ -221,7 +224,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Label of "Schedule" accordion should be rendered', () => {
-      expect(container.getByText(messageIds.schedule)).toBeInTheDocument();
+      expect(container.getByText(labelIds.schedule)).toBeInTheDocument();
     });
 
     it('"ExpandAllButton" should be rendered with correct props', () => {
@@ -243,7 +246,7 @@ describe('FixedDueDateScheduleForm', () => {
         },
       };
 
-      fireEvent.click(container.getByTestId('expand-all-button'));
+      fireEvent.click(container.getByTestId(testIds.expandAllButton));
 
       expect(ExpandAllButton).toHaveBeenNthCalledWith(expandAllButtonCallOrder.update, expect.objectContaining(expectedProps), {});
     });
@@ -258,7 +261,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Name of "Cancel" button should be rendered', () => {
-      expect(container.getByText(messageIds.cancel)).toBeInTheDocument();
+      expect(container.getByText(labelIds.cancel)).toBeInTheDocument();
     });
 
     it('Footer should contain "Save and close" button with appropriate props', () => {
@@ -271,7 +274,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Name of "Save and close" button should be rendered', () => {
-      expect(container.getByText(messageIds.saveAndClose)).toBeInTheDocument();
+      expect(container.getByText(labelIds.saveAndClose)).toBeInTheDocument();
     });
 
     it('"AccordionSet" should be called with correct props', () => {
@@ -292,7 +295,7 @@ describe('FixedDueDateScheduleForm', () => {
         onToggle: expect.any(Function),
       };
 
-      fireEvent.click(container.getByTestId('accordionSet'));
+      fireEvent.click(container.getByTestId(testIds.accordionSet));
 
       expect(AccordionSet).toHaveBeenNthCalledWith(accordionSetCallOrder.update, expect.objectContaining(expectedProps), {});
     });
@@ -328,7 +331,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('"Pane" component should have correct title', () => {
-      expect(container.getByText(messageIds.editLabel)).toBeInTheDocument();
+      expect(container.getByText(labelIds.editLabel)).toBeInTheDocument();
     });
 
     it('Footer should contain "Save and close" button with appropriate props', () => {
@@ -341,7 +344,7 @@ describe('FixedDueDateScheduleForm', () => {
     });
 
     it('Name of "Save and close" button should be rendered', () => {
-      expect(container.getByText(messageIds.saveAndClose)).toBeInTheDocument();
+      expect(container.getByText(labelIds.saveAndClose)).toBeInTheDocument();
     });
 
     it('"ViewMetaData" should be called with correct props', () => {
@@ -433,7 +436,7 @@ describe('FixedDueDateScheduleForm', () => {
       });
 
       it('"uniqueName" error message should be rendered', () => {
-        waitFor(() => expect(messageIds.uniqueName).toBeInTheDocument());
+        waitFor(() => expect(labelIds.uniqueName).toBeInTheDocument());
       });
     });
 

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleManager.test.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleManager.test.js
@@ -33,12 +33,17 @@ jest.mock('../Models/FixedDueDateSchedule', () => ({
   defaultFixedDueDateSchedule: jest.fn(() => mockDefaultFixedDueDateScheduleReturnValue),
 }));
 
+const testIds = {
+  entryManager: 'entryManager',
+  deleteDisabled: 'deleteDisabled',
+};
+const labelIds = {
+  fDDSPaneTitle: 'ui-circulation.settings.fDDS.paneTitle',
+  fDDSformEntryLabel: 'ui-circulation.settings.fDDSform.entryLabel',
+  fDDSDeleteDisabled: 'ui-circulation.settings.fDDS.deleteDisabled',
+};
+
 describe('FixedDueDateScheduleManager', () => {
-  const labelIds = {
-    fDDSPaneTitle: 'ui-circulation.settings.fDDS.paneTitle',
-    fDDSformEntryLabel: 'ui-circulation.settings.fDDSform.entryLabel',
-    fDDSDeleteDisabled: 'ui-circulation.settings.fDDS.deleteDisabled',
-  };
   const testMutator = {
     fixedDueDateSchedules: {
       POST: jest.fn(),
@@ -158,7 +163,7 @@ describe('FixedDueDateScheduleManager', () => {
         />
       );
 
-      expect(getById('entryManager').getByTestId('deleteDisabled')).toBeVisible();
+      expect(getById(testIds.entryManager).getByTestId(testIds.deleteDisabled)).toBeVisible();
     });
 
     it('should not disabled delete when schedule has id which does not match some loans policy id', () => {
@@ -182,7 +187,7 @@ describe('FixedDueDateScheduleManager', () => {
         />
       );
 
-      expect(getById('entryManager').queryByTestId('deleteDisabled')).not.toBeInTheDocument();
+      expect(getById(testIds.entryManager).queryByTestId(testIds.deleteDisabled)).not.toBeInTheDocument();
     });
 
     it('should not disabled delete when loans policies are not passed', () => {
@@ -196,7 +201,7 @@ describe('FixedDueDateScheduleManager', () => {
         />
       );
 
-      expect(getById('entryManager').queryByTestId('deleteDisabled')).not.toBeInTheDocument();
+      expect(getById(testIds.entryManager).queryByTestId(testIds.deleteDisabled)).not.toBeInTheDocument();
     });
 
     it('should not disabled delete when schedule has no id', () => {
@@ -218,7 +223,7 @@ describe('FixedDueDateScheduleManager', () => {
         />
       );
 
-      expect(getById('entryManager').queryByTestId('deleteDisabled')).not.toBeInTheDocument();
+      expect(getById(testIds.entryManager).queryByTestId(testIds.deleteDisabled)).not.toBeInTheDocument();
     });
   });
 

--- a/src/settings/FixedDueDateSchedule/components/DetailsSections/ScedulesList/SchedulesList.test.js
+++ b/src/settings/FixedDueDateSchedule/components/DetailsSections/ScedulesList/SchedulesList.test.js
@@ -37,6 +37,12 @@ const expectedResults = [
 ];
 
 const eachScheduleTesting = (item, index) => {
+  const labelIds = {
+    dateFormTitle: 'ui-circulation.settings.fDDSform.dateFormTitle',
+    dateFrom: 'ui-circulation.settings.fDDSform.dateFrom',
+    dateTo: 'ui-circulation.settings.fDDSform.dateTo',
+    dueDate: 'ui-circulation.settings.fDDSform.dueDate',
+  };
   const currentItemNumber = index + 1;
   const currentItemSelector = () => within(screen.getByTestId(`ui-circulation.settings.fDDSform-${currentItemNumber}`));
   const {
@@ -50,13 +56,13 @@ const eachScheduleTesting = (item, index) => {
   });
 
   it(`should render header of element at number ${currentItemNumber}`, () => {
-    expect(currentItemSelector().getByText('ui-circulation.settings.fDDSform.dateFormTitle')).toBeTruthy();
+    expect(currentItemSelector().getByText(labelIds.dateFormTitle)).toBeTruthy();
   });
 
   it(`should render all necessary columns of element at number ${currentItemNumber}`, () => {
-    expect(currentItemSelector().getByText('ui-circulation.settings.fDDSform.dateFrom')).toBeTruthy();
-    expect(currentItemSelector().getByText('ui-circulation.settings.fDDSform.dateTo')).toBeTruthy();
-    expect(currentItemSelector().getByText('ui-circulation.settings.fDDSform.dueDate')).toBeTruthy();
+    expect(currentItemSelector().getByText(labelIds.dateFrom)).toBeTruthy();
+    expect(currentItemSelector().getByText(labelIds.dateTo)).toBeTruthy();
+    expect(currentItemSelector().getByText(labelIds.dueDate)).toBeTruthy();
   });
 
   it(`should render dates of element at number ${currentItemNumber} correctly`, () => {

--- a/src/settings/FixedDueDateSchedule/components/EditSections/components/ScheduleCard/ScheduleCard.test.js
+++ b/src/settings/FixedDueDateSchedule/components/EditSections/components/ScheduleCard/ScheduleCard.test.js
@@ -45,7 +45,10 @@ describe('ScheduleCard', () => {
       dateToColumn: 2,
       dueDateColumn: 3,
     };
-
+    const testIds = {
+      removeColumn: 'removeColumn',
+      onClickTestElement: 'onClickTestElement',
+    };
     const labelIds = {
       dateFormTitle: 'ui-circulation.settings.fDDSform.dateFormTitle',
       remove: 'ui-circulation.settings.fDDSform.remove',
@@ -131,7 +134,7 @@ describe('ScheduleCard', () => {
 
       it('should call "onRemoveSchedule" callback on remove button click', () => {
         const onClickTestElement =
-          within(screen.getByTestId('removeColumn')).getByTestId('onClickTestElement');
+          within(screen.getByTestId(testIds.removeColumn)).getByTestId(testIds.onClickTestElement);
 
         fireEvent.click(onClickTestElement);
 

--- a/src/settings/FixedDueDateSchedule/components/EditSections/components/SchedulesList/SchedulesList.test.js
+++ b/src/settings/FixedDueDateSchedule/components/EditSections/components/SchedulesList/SchedulesList.test.js
@@ -15,13 +15,22 @@ import '../../../../../../../test/jest/__mock__';
 import SchedulesList from './SchedulesList';
 import ScheduleCard from '../ScheduleCard';
 
+const testIds = {
+  addScheduleButton: 'addScheduleButton',
+  scheduleCard: 'scheduleCard',
+  errorRow: 'errorRow',
+};
+const labelIds = {
+  new: 'ui-circulation.settings.fDDSform.new',
+};
+
 jest.mock('../ScheduleCard', () => jest.fn(({
   onRemoveSchedule,
   scheduleIndex,
 }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div
-    data-testid="scheduleCard"
+    data-testid={testIds.scheduleCard}
     onClick={() => onRemoveSchedule(scheduleIndex)}
   />
 )));
@@ -56,10 +65,6 @@ describe('SchedulesList', () => {
     value: testFieldsValue,
   };
 
-  const labelIds = {
-    new: 'ui-circulation.settings.fDDSform.new',
-  };
-
   afterEach(() => {
     ScheduleCard.mockClear();
     testFields.push.mockClear();
@@ -83,12 +88,12 @@ describe('SchedulesList', () => {
     });
 
     it('should render "add schedule" button', () => {
-      expect(within(screen.getByTestId('addScheduleButton')).getByText(labelIds.new))
+      expect(within(screen.getByTestId(testIds.addScheduleButton)).getByText(labelIds.new))
         .toBeVisible();
     });
 
     it('should add schedule', () => {
-      const addScheduleButton = screen.getByTestId('addScheduleButton');
+      const addScheduleButton = screen.getByTestId(testIds.addScheduleButton);
 
       fireEvent.click(addScheduleButton);
 
@@ -116,7 +121,7 @@ describe('SchedulesList', () => {
         });
 
         it('should remove schedule', () => {
-          const scheduleCard = screen.getAllByTestId('scheduleCard');
+          const scheduleCard = screen.getAllByTestId(testIds.scheduleCard);
 
           fireEvent.click(scheduleCard[cardOrder]);
 
@@ -139,12 +144,12 @@ describe('SchedulesList', () => {
       if (submitFailed && error && !isArray(error)) {
         it('should render "error row" section', () => {
           expect(within(
-            screen.getByTestId('errorRow')
+            screen.getByTestId(testIds.errorRow)
           ).getByText(error)).toBeVisible();
         });
       } else {
         it('should not render "error row" section', () => {
-          expect(screen.queryByTestId('errorRow')).not.toBeInTheDocument();
+          expect(screen.queryByTestId(testIds.errorRow)).not.toBeInTheDocument();
         });
       }
     };

--- a/src/settings/LoanHistory/ExceptionsList.test.js
+++ b/src/settings/LoanHistory/ExceptionsList.test.js
@@ -18,11 +18,19 @@ jest.mock('./ExceptionCard', () => jest.fn(({
   return (
     // eslint-disable-next-line
     <div
-      data-testid={`exeptionCard-${exceptionIndex + 1}`}
+      data-testid={`exeptionCard${exceptionIndex + 1}`}
       onClick={() => onRemoveException(exceptionIndex)}
     />
   );
 }));
+
+const testIds = {
+  exceptionSectionHeader: 'exceptionSectionHeader',
+};
+const labelIds = {
+  exceptionSectionHeader: 'ui-circulation.settings.loanHistory.exceptionSectionHeader',
+  exceptionAddButton: 'ui-circulation.settings.loanHistory.addExceptionButton',
+};
 
 describe('ExceptionsList', () => {
   const mockedFields = {
@@ -53,10 +61,6 @@ describe('ExceptionsList', () => {
       ],
     },
   };
-  const labelIds = {
-    exceptionSectionHeader: 'ui-circulation.settings.loanHistory.exceptionSectionHeader',
-    exceptionAddButton: 'ui-circulation.settings.loanHistory.addExceptionButton',
-  };
 
   const getById = (id) => within(screen.getByTestId(id));
   const exeptionCardTest = (patch, index) => {
@@ -82,7 +86,9 @@ describe('ExceptionsList', () => {
 
     it(`should correctly execute "handleRemoveField" for ${number} "ExceptionCard"`, () => {
       expect(mockedFields.remove).toHaveBeenCalledTimes(0);
-      fireEvent.click(screen.getByTestId(`exeptionCard-${number}`));
+
+      fireEvent.click(screen.getByTestId(`exeptionCard${number}`));
+
       expect(mockedFields.remove).toHaveBeenCalledWith(index);
     });
   };
@@ -103,7 +109,7 @@ describe('ExceptionsList', () => {
   });
 
   it('should render header label', () => {
-    expect(getById('exceptionSectionHeader').getByText(labelIds.exceptionSectionHeader)).toBeVisible();
+    expect(getById(testIds.exceptionSectionHeader).getByText(labelIds.exceptionSectionHeader)).toBeVisible();
   });
 
   mockedFields.values.map(exeptionCardTest);
@@ -114,7 +120,9 @@ describe('ExceptionsList', () => {
 
   it('should correctly execute "handleAddField" on button click', () => {
     expect(mockedFields.push).toHaveBeenCalledTimes(0);
+
     fireEvent.click(screen.getByRole('button'));
+
     expect(mockedFields.push).toHaveBeenCalledWith({});
   });
 });

--- a/src/settings/LoanPolicy/components/EditSections/AboutSection/AboutSection.test.js
+++ b/src/settings/LoanPolicy/components/EditSections/AboutSection/AboutSection.test.js
@@ -13,14 +13,23 @@ import {
 } from '@folio/stripes/components';
 import AboutSection from './AboutSection';
 
-TextArea.mockImplementation(jest.fn((props) => <textarea {...props} data-testid="textAreaTestId" />));
-TextField.mockImplementation(jest.fn((props) => <input {...props} data-testid="textFieldTestId" />));
+const testIds = {
+  textAreaTestId: 'textAreaTestId',
+  textFieldTestId: 'textFieldTestId',
+  aboutSection: 'aboutSection',
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+};
+const labelIds = {
+  labelIdForHeader: 'ui-circulation.settings.loanPolicy.about',
+  labelIdForNameField: 'ui-circulation.settings.loanPolicy.policyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.loanPolicy.policyDescription',
+};
+
+TextArea.mockImplementation(jest.fn((props) => <textarea {...props} data-testid={testIds.textAreaTestId} />));
+TextField.mockImplementation(jest.fn((props) => <input {...props} data-testid={testIds.textFieldTestId} />));
 
 describe('AboutSection', () => {
-  const labelIdForHeader = 'ui-circulation.settings.loanPolicy.about';
-  const labelIdForNameField = 'ui-circulation.settings.loanPolicy.policyName';
-  const labelIdForDescriptionField = 'ui-circulation.settings.loanPolicy.policyDescription';
-
   beforeEach(() => {
     render(<AboutSection />);
   });
@@ -28,23 +37,23 @@ describe('AboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(screen.getByTestId('aboutSection')).toBeTruthy();
+    expect(screen.getByTestId(testIds.aboutSection)).toBeTruthy();
   });
 
   it('should render component header', () => {
-    expect(getItemByTestId('aboutSection').getByText(labelIdForHeader)).toBeVisible();
+    expect(getItemByTestId(testIds.aboutSection).getByText(labelIds.labelIdForHeader)).toBeVisible();
   });
 
   it('should render "name" field with the correct props', () => {
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('name', 'name');
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('required');
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
-    expect(getItemByTestId('nameTestId').getByTestId('textFieldTestId')).toBeVisible();
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('name', 'name');
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('required');
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByTestId(testIds.textFieldTestId)).toBeVisible();
   });
 
   it('should render "description" field with the correct props', () => {
-    expect(screen.getByTestId('descriptionTestId')).toHaveAttribute('name', 'description');
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
-    expect(getItemByTestId('descriptionTestId').getByTestId('textAreaTestId')).toBeVisible();
+    expect(screen.getByTestId(testIds.descriptionTestId)).toHaveAttribute('name', 'description');
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByTestId(testIds.textAreaTestId)).toBeVisible();
   });
 });

--- a/src/settings/LoanPolicy/components/EditSections/LoansSection/LoansSection.test.js
+++ b/src/settings/LoanPolicy/components/EditSections/LoansSection/LoansSection.test.js
@@ -25,7 +25,7 @@ jest.mock('../../../../utils/options-generator', () => jest.fn((func, options, i
   options,
 })));
 
-const messageIds = {
+const labelIds = {
   header: 'ui-circulation.settings.loanPolicy.loans',
   loanable: 'ui-circulation.settings.loanPolicy.loanable',
   loanProfile: 'ui-circulation.settings.loanPolicy.loanProfile',
@@ -83,7 +83,7 @@ describe('LoansSection', () => {
     });
 
     it('Should be rendered with correct header', () => {
-      expect(container.getByText(messageIds.header)).toBeInTheDocument();
+      expect(container.getByText(labelIds.header)).toBeInTheDocument();
     });
 
     it('Should render loanable checkbox correctly', () => {
@@ -95,7 +95,7 @@ describe('LoansSection', () => {
       };
 
       expect(Field).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.loanable)).toBeInTheDocument();
+      expect(container.getByText(labelIds.loanable)).toBeInTheDocument();
     });
   });
 
@@ -125,7 +125,7 @@ describe('LoansSection', () => {
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.loanProfile, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.loanProfile)).toBeInTheDocument();
+      expect(container.getByText(labelIds.loanProfile)).toBeInTheDocument();
     });
 
     it('Should render due date dropdown correctly', () => {
@@ -134,12 +134,12 @@ describe('LoansSection', () => {
         name: 'loansPolicy.closedLibraryDueDateManagementId',
         children: {
           options: longTermLoansOptions,
-          id: messageIds.pleaseSelect,
+          id: labelIds.pleaseSelect,
         }
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.closedDueDate, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.dueDate)).toBeInTheDocument();
+      expect(container.getByText(labelIds.dueDate)).toBeInTheDocument();
     });
 
     it('Should render item limit input correctly', () => {
@@ -151,17 +151,17 @@ describe('LoansSection', () => {
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.gracePeriod, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.itemLimit)).toBeInTheDocument();
+      expect(container.getByText(labelIds.itemLimit)).toBeInTheDocument();
     });
 
     it('"Period" component should get correct properties under "Grace period" section', () => {
       const expectedProps = {
-        fieldLabel: messageIds.gracePeriod,
+        fieldLabel: labelIds.gracePeriod,
         inputValuePath: 'loansPolicy.gracePeriod.duration',
         selectValuePath: 'loansPolicy.gracePeriod.intervalId',
         changeFormValue: initialProps.change,
         intervalPeriods: {
-          id: messageIds.selectInterval,
+          id: labelIds.selectInterval,
           options: intervalPeriods,
         },
       };
@@ -188,12 +188,12 @@ describe('LoansSection', () => {
 
     it('"Period" component should get correct properties under "Loan period" section', () => {
       const expectedProps = {
-        fieldLabel: messageIds.loanPeriod,
+        fieldLabel: labelIds.loanPeriod,
         inputValuePath: 'loansPolicy.period.duration',
         selectValuePath: 'loansPolicy.period.intervalId',
         changeFormValue: initialProps.change,
         intervalPeriods: {
-          id: messageIds.selectInterval,
+          id: labelIds.selectInterval,
           options: intervalPeriods,
         },
       };
@@ -211,7 +211,7 @@ describe('LoansSection', () => {
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.dueDateSchedule, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.fDDSLimit)).toBeInTheDocument();
+      expect(container.getByText(labelIds.fDDSLimit)).toBeInTheDocument();
     });
   });
 
@@ -241,7 +241,7 @@ describe('LoansSection', () => {
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.dueDateSchedule, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.fDDS)).toBeInTheDocument();
+      expect(container.getByText(labelIds.fDDS)).toBeInTheDocument();
     });
   });
 
@@ -268,12 +268,12 @@ describe('LoansSection', () => {
         name: 'loansPolicy.closedLibraryDueDateManagementId',
         children: {
           options: shortTermLoansOptions,
-          id: messageIds.pleaseSelect,
+          id: labelIds.pleaseSelect,
         }
       };
 
       expect(Field).toHaveBeenNthCalledWith(fieldComponentOrderCalls.closedDueDate, expect.objectContaining(expectedProps), {});
-      expect(container.getByText(messageIds.dueDate)).toBeInTheDocument();
+      expect(container.getByText(labelIds.dueDate)).toBeInTheDocument();
     });
   });
 
@@ -290,12 +290,12 @@ describe('LoansSection', () => {
 
     it('"Period" component should get correct properties for opening time offset field', () => {
       const expectedProps = {
-        fieldLabel: messageIds.openingTimeOffset,
+        fieldLabel: labelIds.openingTimeOffset,
         inputValuePath: 'loansPolicy.openingTimeOffset.duration',
         selectValuePath: 'loansPolicy.openingTimeOffset.intervalId',
         changeFormValue: initialProps.change,
         intervalPeriods: {
-          id: messageIds.selectInterval,
+          id: labelIds.selectInterval,
           options: intervalPeriods.slice(0, 2).reverse(),
         },
       };
@@ -331,3 +331,4 @@ describe('LoansSection', () => {
     });
   });
 });
+

--- a/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.test.js
+++ b/src/settings/LoanPolicy/components/EditSections/RequestManagementSection/RequestManagementSection.test.js
@@ -31,6 +31,11 @@ jest.mock('../../../../utils/options-generator', () => jest.fn((
 jest.mock('../../../../components/Period', () => jest.fn(() => null));
 
 describe('RequestManagementSection', () => {
+  const testIds = {
+    alternateRecallReturnIntervalPeriod: 'alternateRecallReturnIntervalPeriod',
+    alternateRenewalLoanPeriod: 'alternateRenewalLoanPeriod',
+    requestManagementSection: 'requestManagementSection',
+  };
   const labelIds = {
     requestManagement: 'ui-circulation.settings.requestManagement.requestManagement',
     recalls: 'ui-circulation.settings.requestManagement.recalls',
@@ -98,7 +103,7 @@ describe('RequestManagementSection', () => {
         />
       );
 
-      expect(screen.queryByTestId('requestManagementSection')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(testIds.requestManagementSection)).not.toBeInTheDocument();
     });
   });
 
@@ -115,11 +120,11 @@ describe('RequestManagementSection', () => {
     });
 
     it('should render component', () => {
-      expect(screen.getByTestId('requestManagementSection')).toBeVisible();
+      expect(screen.getByTestId(testIds.requestManagementSection)).toBeVisible();
     });
 
     it('should render request management title', () => {
-      expect(within(screen.getByTestId('requestManagementSection'))
+      expect(within(screen.getByTestId(testIds.requestManagementSection))
         .getByText(labelIds.requestManagement)).toBeVisible();
     });
 
@@ -286,7 +291,7 @@ describe('RequestManagementSection', () => {
 
         if (requestManagement?.recalls?.allowRecallsToExtendOverdueLoans) {
           it('should render period', () => {
-            expect(screen.getByTestId('alternateRecallReturnIntervalPeriod')).toBeVisible();
+            expect(screen.getByTestId(testIds.alternateRecallReturnIntervalPeriod)).toBeVisible();
             expect(Period).toHaveBeenNthCalledWith(
               periodCallOrderByPlace.alternateRecallReturnInterval,
               {
@@ -299,7 +304,7 @@ describe('RequestManagementSection', () => {
           });
         } else {
           it('should not render period', () => {
-            expect(screen.queryByTestId('alternateRecallReturnIntervalPeriod')).not.toBeInTheDocument();
+            expect(screen.queryByTestId(testIds.alternateRecallReturnIntervalPeriod)).not.toBeInTheDocument();
           });
         }
       });
@@ -351,7 +356,7 @@ describe('RequestManagementSection', () => {
             requestManagement?.holds?.renewItemsWithRequest
           ) {
             it('should render period', () => {
-              expect(screen.getByTestId('alternateRenewalLoanPeriod')).toBeVisible();
+              expect(screen.getByTestId(testIds.alternateRenewalLoanPeriod)).toBeVisible();
               expect(Period).toHaveBeenNthCalledWith(
                 periodCallOrderByPlace.alternateRenewalLoan,
                 {
@@ -364,7 +369,7 @@ describe('RequestManagementSection', () => {
             });
           } else {
             it('should not render period', () => {
-              expect(screen.queryByTestId('alternateRenewalLoanPeriod')).not.toBeInTheDocument();
+              expect(screen.queryByTestId(testIds.alternateRenewalLoanPeriod)).not.toBeInTheDocument();
             });
           }
         });

--- a/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.test.js
+++ b/src/settings/LoanPolicy/components/ViewSections/AboutSection/AboutSection.test.js
@@ -9,9 +9,16 @@ import '../../../../../../test/jest/__mock__';
 
 import AboutSection from './AboutSection';
 
-const labelIdForHeader = 'ui-circulation.settings.loanPolicy.about';
-const labelIdForNameField = 'ui-circulation.settings.loanPolicy.policyName';
-const labelIdForDescriptionField = 'ui-circulation.settings.loanPolicy.policyDescription';
+const testIds = {
+  aboutSectionTestId: 'aboutSectionTestId',
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+};
+const labelIds = {
+  labelIdForHeader: 'ui-circulation.settings.loanPolicy.about',
+  labelIdForNameField: 'ui-circulation.settings.loanPolicy.policyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.loanPolicy.policyDescription',
+};
 
 describe('AboutSection', () => {
   beforeEach(() => {
@@ -25,26 +32,26 @@ describe('AboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(getItemByTestId('aboutSectionTestId')).toBeTruthy();
+    expect(getItemByTestId(testIds.aboutSectionTestId)).toBeTruthy();
   });
 
   it('should render component header', () => {
-    expect(getItemByTestId('aboutSectionTestId').getByText(labelIdForHeader)).toBeVisible();
+    expect(getItemByTestId(testIds.aboutSectionTestId).getByText(labelIds.labelIdForHeader)).toBeVisible();
   });
 
   it('should render label of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeVisible();
   });
 
   it('should render value of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText('name')).toBeVisible();
   });
 
   it('should render label of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeVisible();
   });
 
   it('should render value of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText('description')).toBeVisible();
   });
 });

--- a/src/settings/LoanPolicy/components/ViewSections/LoansSection/LoansSection.test.js
+++ b/src/settings/LoanPolicy/components/ViewSections/LoansSection/LoansSection.test.js
@@ -15,6 +15,13 @@ import {
 } from '../../../../../constants';
 
 describe('LoansSection', () => {
+  const testIds = {
+    loansTestId: 'loansTestId',
+    loanProfileTestId: 'loanProfileTestId',
+    scheduleTestId: 'scheduleTestId',
+    closedDueDateTestId: 'closedDueDateTestId',
+    itemLimitTestId: 'itemLimitTestId',
+  };
   const labelIds = {
     loansLabelId: 'ui-circulation.settings.loanPolicy.loans',
     loanableLabelId: 'ui-circulation.settings.loanPolicy.loanable',
@@ -65,7 +72,7 @@ describe('LoansSection', () => {
     });
 
     it('should render "loans" section correctly', () => {
-      expect(getById('loansTestId').getByText(labelIds.loansLabelId)).toBeVisible();
+      expect(getById(testIds.loansTestId).getByText(labelIds.loansLabelId)).toBeVisible();
     });
 
     sectionTest('loanable', false);
@@ -89,22 +96,22 @@ describe('LoansSection', () => {
       });
 
       it('should render "loans" section correctly', () => {
-        expect(getById('loansTestId').getByText(labelIds.loansLabelId)).toBeVisible();
+        expect(getById(testIds.loansTestId).getByText(labelIds.loansLabelId)).toBeVisible();
       });
 
       it('should render "profile" section correctly', () => {
         const labelId = 'loansPolicy.profileId';
 
-        expect(getById('loanProfileTestId').getByText(labelIds.loanProfileLabelId)).toBeVisible();
-        expect(getById('loanProfileTestId').getByText(labelId)).toBeVisible();
+        expect(getById(testIds.loanProfileTestId).getByText(labelIds.loanProfileLabelId)).toBeVisible();
+        expect(getById(testIds.loanProfileTestId).getByText(labelId)).toBeVisible();
         expect(mockedGetDropdownValue).toHaveBeenNthCalledWith(1, labelId, loanProfileTypes);
       });
 
       sectionTest('period');
 
       it('should render "schedule" section correctly', () => {
-        expect(getById('scheduleTestId').getByText(labelIds.fDDSlimitLabelId)).toBeVisible();
-        expect(getById('scheduleTestId').getByText('loansPolicy.fixedDueDateScheduleId-processed')).toBeVisible();
+        expect(getById(testIds.scheduleTestId).getByText(labelIds.fDDSlimitLabelId)).toBeVisible();
+        expect(getById(testIds.scheduleTestId).getByText('loansPolicy.fixedDueDateScheduleId-processed')).toBeVisible();
       });
 
       it('should render "closed due date" section correctly', () => {
@@ -114,8 +121,8 @@ describe('LoansSection', () => {
         ];
         const labelId = 'loansPolicy.closedLibraryDueDateManagementId';
 
-        expect(getById('closedDueDateTestId').getByText(labelIds.closedDueDateLabelId)).toBeVisible();
-        expect(getById('closedDueDateTestId').getByText(labelId)).toBeVisible();
+        expect(getById(testIds.closedDueDateTestId).getByText(labelIds.closedDueDateLabelId)).toBeVisible();
+        expect(getById(testIds.closedDueDateTestId).getByText(labelId)).toBeVisible();
         expect(mockedGetDropdownValue).toHaveBeenNthCalledWith(2, labelId, expectedResult);
       });
 
@@ -150,8 +157,8 @@ describe('LoansSection', () => {
       sectionIsNotRenderedTest('openingTimeOffset');
 
       it('should render "item limit" section correctly', () => {
-        expect(getById('itemLimitTestId').getByText(labelIds.itemLimitLabelId)).toBeVisible();
-        expect(getById('itemLimitTestId').getByText('-')).toBeVisible();
+        expect(getById(testIds.itemLimitTestId).getByText(labelIds.itemLimitLabelId)).toBeVisible();
+        expect(getById(testIds.itemLimitTestId).getByText('-')).toBeVisible();
       });
     });
 
@@ -171,8 +178,8 @@ describe('LoansSection', () => {
       });
 
       it('should render "schedule" section correctly', () => {
-        expect(getById('scheduleTestId').getByText(labelIds.fDDSLabelId)).toBeVisible();
-        expect(getById('scheduleTestId').getByText('loansPolicy.fixedDueDateScheduleId-processed')).toBeVisible();
+        expect(getById(testIds.scheduleTestId).getByText(labelIds.fDDSLabelId)).toBeVisible();
+        expect(getById(testIds.scheduleTestId).getByText('loansPolicy.fixedDueDateScheduleId-processed')).toBeVisible();
       });
     });
   });

--- a/src/settings/LoanPolicy/components/ViewSections/RequestManagementSection/RequestManagementSection.test.js
+++ b/src/settings/LoanPolicy/components/ViewSections/RequestManagementSection/RequestManagementSection.test.js
@@ -30,7 +30,12 @@ Accordion.mockImplementation(jest.fn(({
 )));
 
 describe('RequestManagementSection', () => {
-  const requestManagementLabelId = 'ui-circulation.settings.requestManagement.requestManagement';
+  const testIds = {
+    sectionHeaderTestId: 'sectionHeaderTestId',
+  };
+  const labelIds = {
+    requestManagementLabelId: 'ui-circulation.settings.requestManagement.requestManagement',
+  };
   const mockedFunction = jest.fn();
   const defaultProps = {
     isVisible: true,
@@ -83,7 +88,7 @@ describe('RequestManagementSection', () => {
     });
 
     it('should render component header', () => {
-      expect(getById('sectionHeaderTestId').getByText(requestManagementLabelId)).toBeVisible();
+      expect(getById(testIds.sectionHeaderTestId).getByText(labelIds.requestManagementLabelId)).toBeVisible();
     });
 
     accordionTest('recalls');
@@ -119,7 +124,7 @@ describe('RequestManagementSection', () => {
     });
 
     it('should render component header', () => {
-      expect(getById('sectionHeaderTestId').getByText(requestManagementLabelId)).toBeVisible();
+      expect(getById(testIds.sectionHeaderTestId).getByText(labelIds.requestManagementLabelId)).toBeVisible();
     });
 
     accordionTest('recalls', false);
@@ -138,7 +143,7 @@ describe('RequestManagementSection', () => {
     });
 
     it('should not render anything', () => {
-      expect(screen.queryByTestId('sectionHeaderTestId')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(testIds.sectionHeaderTestId)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
@@ -13,13 +13,22 @@ import {
 } from '@folio/stripes/components';
 import LostItemFeeAboutSection from './LostItemFeeAboutSection';
 
-TextArea.mockImplementation(jest.fn((props) => <textarea {...props} data-testid="textAreaTestId" />));
-TextField.mockImplementation(jest.fn((props) => <input {...props} data-testid="textFieldTestId" />));
+const testIds = {
+  textAreaTestId: 'textAreaTestId',
+  textFieldTestId: 'textextFieldTestIdtAreaTestId',
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+  lostItemFeeAboutSectionTestId: 'lostItemFeeAboutSectionTestId',
+};
+const labelIds = {
+  labelIdForNameField: 'ui-circulation.settings.lostItemFee.lostItemFeePolicyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.lostItemFee.description',
+};
+
+TextArea.mockImplementation(jest.fn((props) => <textarea {...props} data-testid={testIds.textAreaTestId} />));
+TextField.mockImplementation(jest.fn((props) => <input {...props} data-testid={testIds.textFieldTestId} />));
 
 describe('LostItemFeeAboutSection', () => {
-  const labelIdForNameField = 'ui-circulation.settings.lostItemFee.lostItemFeePolicyName';
-  const labelIdForDescriptionField = 'ui-circulation.settings.lostItemFee.description';
-
   beforeEach(() => {
     render(<LostItemFeeAboutSection />);
   });
@@ -27,19 +36,19 @@ describe('LostItemFeeAboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(screen.getByTestId('lostItemFeeAboutSectionTestId')).toBeTruthy();
+    expect(screen.getByTestId(testIds.lostItemFeeAboutSectionTestId)).toBeTruthy();
   });
 
   it('should render "name" field with the correct props', () => {
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('name', 'name');
-    expect(screen.getByTestId('nameTestId')).toHaveAttribute('required');
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
-    expect(getItemByTestId('nameTestId').getByTestId('textFieldTestId')).toBeVisible();
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('name', 'name');
+    expect(screen.getByTestId(testIds.nameTestId)).toHaveAttribute('required');
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByTestId(testIds.textFieldTestId)).toBeVisible();
   });
 
   it('should render "description" field with the correct props', () => {
-    expect(screen.getByTestId('descriptionTestId')).toHaveAttribute('name', 'description');
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
-    expect(getItemByTestId('descriptionTestId').getByTestId('textAreaTestId')).toBeVisible();
+    expect(screen.getByTestId(testIds.descriptionTestId)).toHaveAttribute('name', 'description');
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByTestId(testIds.textAreaTestId)).toBeVisible();
   });
 });

--- a/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeSection/LostItemFeeSection.test.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeSection/LostItemFeeSection.test.js
@@ -36,6 +36,14 @@ jest.mock('../RadioGroup/RadioGroup', () => jest.fn(() => null));
 jest.mock('../../../../components/Period', () => jest.fn(() => null));
 
 describe('LostItemFeeSection', () => {
+  const testIds = {
+    chargeAmountItemPatronColumn: 'chargeAmountItemPatronColumn',
+    chargeAmountItemSystemColumn: 'chargeAmountItemSystemColumn',
+    returnedLostItemProcessingFeeColumn: 'returnedLostItemProcessingFeeColumn',
+    lostItemReturnedColumn: 'lostItemReturnedColumn',
+    replacementAllowedColumn: 'replacementAllowedColumn',
+    replacedLostItemProcessingFeeColumn: 'replacedLostItemProcessingFeeColumn',
+  };
   const labelIds = {
     lostItemSection: 'ui-circulation.settings.lostItemFee.lostItemSection',
     selectInterval: 'ui-circulation.settings.lostItemFee.selectInterval',
@@ -388,37 +396,37 @@ describe('LostItemFeeSection', () => {
 
     it('should render "chargeAmountItemPatron" text', () => {
       expect(
-        getById('chargeAmountItemPatronColumn').getByText(`${labelIds.chargeAmountItemPatron}?`)
+        getById(testIds.chargeAmountItemPatronColumn).getByText(`${labelIds.chargeAmountItemPatron}?`)
       ).toBeVisible();
     });
 
     it('should render "chargeAmountItemSystem" text', () => {
       expect(
-        getById('chargeAmountItemSystemColumn').getByText(`${labelIds.chargeAmountItemSystem}?`)
+        getById(testIds.chargeAmountItemSystemColumn).getByText(`${labelIds.chargeAmountItemSystem}?`)
       ).toBeVisible();
     });
 
     it('should render "returnedLostItemProcessing" text', () => {
       expect(
-        getById('returnedLostItemProcessingFeeColumn').getByText(labelIds.returnedLostItemProcessingFee)
+        getById(testIds.returnedLostItemProcessingFeeColumn).getByText(labelIds.returnedLostItemProcessingFee)
       ).toBeVisible();
     });
 
     it('should render "lostItemReturned" text', () => {
       expect(
-        getById('lostItemReturnedColumn').getByText(labelIds.lostItemReturned)
+        getById(testIds.lostItemReturnedColumn).getByText(labelIds.lostItemReturned)
       ).toBeVisible();
     });
 
     it('should render "replacementAllowed" text', () => {
       expect(
-        getById('replacementAllowedColumn').getByText(labelIds.replacementAllowed)
+        getById(testIds.replacementAllowedColumn).getByText(labelIds.replacementAllowed)
       ).toBeVisible();
     });
 
     it('should render "replacedLostItemProcessingFee" text', () => {
       expect(
-        getById('replacedLostItemProcessingFeeColumn').getByText(labelIds.replacedLostItemProcessingFee)
+        getById(testIds.replacedLostItemProcessingFeeColumn).getByText(labelIds.replacedLostItemProcessingFee)
       ).toBeVisible();
     });
   });

--- a/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.test.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/RadioGroup/RadioGroup.test.js
@@ -28,10 +28,17 @@ Field.mockImplementation(({ label, ...rest }) => {
 });
 
 describe('RadioGroup', () => {
-  const chargeAmountItemLabelId = 'ui-circulation.settings.lostItemFee.chargeAmountItem';
-  const actualCostLabelId = 'ui-circulation.settings.lostItemFee.actualCost';
-  const setCostLabelId = 'ui-circulation.settings.lostItemFee.setCost';
-  const chargeAmountLabelId = 'ui-circulation.settings.lostItemFee.chargeAmount';
+  const testIds = {
+    actualCostTestId: 'actualCostTestId',
+    chargeAmountItemTestId: 'chargeAmountItemTestId',
+    setCostTestId: 'setCostTestId',
+  };
+  const labelIds = {
+    chargeAmountItemLabelId: 'ui-circulation.settings.lostItemFee.chargeAmountItem',
+    actualCostLabelId: 'ui-circulation.settings.lostItemFee.actualCost',
+    setCostLabelId: 'ui-circulation.settings.lostItemFee.setCost',
+    chargeAmountLabelId: 'ui-circulation.settings.lostItemFee.chargeAmount',
+  };
 
   const getById = (id) => within(screen.getByTestId(id));
   const mockedOnBlure = jest.fn();
@@ -49,9 +56,9 @@ describe('RadioGroup', () => {
   });
 
   it('should render label of component correctly', () => {
-    expect(getById('chargeAmountItemTestId').getByText(chargeAmountItemLabelId)).toBeVisible();
-    expect(screen.getByTestId('chargeAmountItemTestId')).toHaveAttribute('for', 'chargeAmount');
-    expect(screen.getByTestId('chargeAmountItemTestId')).toHaveAttribute('id', 'chargeAmount-label');
+    expect(getById(testIds.chargeAmountItemTestId).getByText(labelIds.chargeAmountItemLabelId)).toBeVisible();
+    expect(screen.getByTestId(testIds.chargeAmountItemTestId)).toHaveAttribute('for', 'chargeAmount');
+    expect(screen.getByTestId(testIds.chargeAmountItemTestId)).toHaveAttribute('id', 'chargeAmount-label');
   });
 
   it('should use correct props for "Field" in "actual cost" section', () => {
@@ -63,7 +70,7 @@ describe('RadioGroup', () => {
       type: 'radio',
     };
 
-    expect(getById('actualCostTestId').getByText(actualCostLabelId)).toBeVisible();
+    expect(getById(testIds.actualCostTestId).getByText(labelIds.actualCostLabelId)).toBeVisible();
     expect(catchFunction).toHaveBeenNthCalledWith(1, expectedResult);
   });
 
@@ -75,13 +82,13 @@ describe('RadioGroup', () => {
       type: 'radio',
     };
 
-    expect(getById('setCostTestId').getByText(setCostLabelId)).toBeVisible();
+    expect(getById(testIds.setCostTestId).getByText(labelIds.setCostLabelId)).toBeVisible();
     expect(catchFunction).toHaveBeenNthCalledWith(2, expectedResult);
   });
 
   it('should use correct props for "Field" in "charge amount" section', () => {
     const expectedResult = {
-      'aria-label': chargeAmountLabelId,
+      'aria-label': labelIds.chargeAmountLabelId,
       name: 'chargeAmountItem.amount',
       component: TextField,
       type: 'number',

--- a/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
+++ b/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeAboutSection/LostItemFeeAboutSection.test.js
@@ -9,8 +9,15 @@ import '../../../../../../test/jest/__mock__';
 
 import LostItemFeeAboutSection from './LostItemFeeAboutSection';
 
-const labelIdForNameField = 'ui-circulation.settings.lostItemFee.lostItemFeePolicyName';
-const labelIdForDescriptionField = 'ui-circulation.settings.lostItemFee.description';
+const testIds = {
+  lostItemFeeAboutSectionTestId: 'lostItemFeeAboutSectionTestId',
+  nameTestId: 'nameTestId',
+  descriptionTestId: 'descriptionTestId',
+};
+const labelIds = {
+  labelIdForNameField: 'ui-circulation.settings.lostItemFee.lostItemFeePolicyName',
+  labelIdForDescriptionField: 'ui-circulation.settings.lostItemFee.description',
+};
 
 describe('LostItemFeeAboutSection', () => {
   beforeEach(() => {
@@ -24,23 +31,23 @@ describe('LostItemFeeAboutSection', () => {
   const getItemByTestId = (id) => within(screen.getByTestId(id));
 
   it('should render component', () => {
-    expect(getItemByTestId('lostItemFeeAboutSectionTestId')).toBeTruthy();
+    expect(getItemByTestId(testIds.lostItemFeeAboutSectionTestId)).toBeTruthy();
   });
 
   it('should render label of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText(labelIdForNameField)).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText(labelIds.labelIdForNameField)).toBeVisible();
   });
 
   it('should render value of "name" field', () => {
-    expect(getItemByTestId('nameTestId').getByText('name')).toBeVisible();
+    expect(getItemByTestId(testIds.nameTestId).getByText('name')).toBeVisible();
   });
 
   it('should render label of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText(labelIdForDescriptionField)).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText(labelIds.labelIdForDescriptionField)).toBeVisible();
   });
 
   it('should render value of "description" field', () => {
-    expect(getItemByTestId('descriptionTestId').getByText('description')).toBeVisible();
+    expect(getItemByTestId(testIds.descriptionTestId).getByText('description')).toBeVisible();
   });
 
   it('should render dash if description has not found', () => {

--- a/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeSection/LostItemFeeSection.test.js
+++ b/src/settings/LostItemFeePolicy/components/ViewSections/LostItemFeeSection/LostItemFeeSection.test.js
@@ -22,13 +22,20 @@ const testSectionKeyValues = (testName, testId, expectedValue) => {
 const getFormattedValue = (value) => parseFloat(value).toFixed(2);
 
 describe('View LostItemFeeSection', () => {
+  const testIds = {
+    chargeAmountItem: 'chargeAmountItem',
+    viewLostItemFeeSection: 'viewLostItemFeeSection',
+    viewLostItemFeeSectionAccordion: 'viewLostItemFeeSectionAccordion',
+  };
+  const labelIds = {
+    lostItemSectionAccordionLabel: 'ui-circulation.settings.lostItemFee.lostItemSection',
+    displayYes: 'ui-circulation.settings.lostItemFee.yes',
+    displayNo: 'ui-circulation.settings.lostItemFee.no',
+    actualCost: 'ui-circulation.settings.lostItemFee.actualCost',
+    lostItemReturnedCharged: 'ui-circulation.settings.lostItemFee.lostItemChargeOverdueBased',
+    lostItemReturnedRemove: 'ui-circulation.settings.lostItemFee.lostItemRemoveOverdueFines',
+  };
   const dash = '-';
-  const lostItemSectionAccordionLabel = 'ui-circulation.settings.lostItemFee.lostItemSection';
-  const displayYes = 'ui-circulation.settings.lostItemFee.yes';
-  const displayNo = 'ui-circulation.settings.lostItemFee.no';
-  const actualCost = 'ui-circulation.settings.lostItemFee.actualCost';
-  const lostItemReturnedCharged = 'ui-circulation.settings.lostItemFee.lostItemChargeOverdueBased';
-  const lostItemReturnedRemove = 'ui-circulation.settings.lostItemFee.lostItemRemoveOverdueFines';
   const lostItemFeeSectionProps = {
     formatMessage: jest.fn(() => dash),
     getPeriodValue: jest.fn((value) => value || dash),
@@ -108,15 +115,15 @@ describe('View LostItemFeeSection', () => {
     });
 
     it('should render LostItemFeeSection component', () => {
-      expect(screen.getByTestId('viewLostItemFeeSection')).toBeVisible();
+      expect(screen.getByTestId(testIds.viewLostItemFeeSection)).toBeVisible();
     });
 
     it('should render open accordion with label', () => {
-      const viewLostItemFeeSectionAccordionTestIdValue = screen.getByTestId('viewLostItemFeeSectionAccordion');
+      const viewLostItemFeeSectionAccordionTestIdValue = screen.getByTestId(testIds.viewLostItemFeeSectionAccordion);
 
       expect(viewLostItemFeeSectionAccordionTestIdValue).toBeVisible();
       expect(viewLostItemFeeSectionAccordionTestIdValue).toHaveAttribute('open');
-      expect(within(viewLostItemFeeSectionAccordionTestIdValue).getByText(lostItemSectionAccordionLabel)).toBeVisible();
+      expect(within(viewLostItemFeeSectionAccordionTestIdValue).getByText(labelIds.lostItemSectionAccordionLabel)).toBeVisible();
     });
 
     testSectionKeyValues('item aged', 'itemeAgedLostOverdue', 'itemAgedLostOverdue');
@@ -124,15 +131,15 @@ describe('View LostItemFeeSection', () => {
     testSectionKeyValues('item recalled aged', 'itemRecalledAgedLostOverdue', 'recalledItemAgedLostOverdue');
     testSectionKeyValues('patron billed recalled', 'patronBilledAfterRecalledAgedLost', 'patronBilledAfterRecalledItemAgedLost');
     testSectionKeyValues('lost item fee', 'lostItemProcessingFee', getFormattedValue(lostItemFeeSectionProps.policy.lostItemProcessingFee));
-    testSectionKeyValues('charge amount', 'chargeAmountItem', actualCost);
+    testSectionKeyValues('charge amount', 'chargeAmountItem', labelIds.actualCost);
     testSectionKeyValues('fees/fines shall refunded', 'feesFinesShallRefunded', dash);
-    testSectionKeyValues('lost by patron', 'chargeAmountItemPatron', displayYes);
-    testSectionKeyValues('lost by system', 'chargeAmountItemSystem', displayYes);
+    testSectionKeyValues('lost by patron', 'chargeAmountItemPatron', labelIds.displayYes);
+    testSectionKeyValues('lost by system', 'chargeAmountItemSystem', labelIds.displayYes);
     testSectionKeyValues('close loan after', 'lostItemNotChargeFeesFine', 'lostItemChargeFeeFine');
-    testSectionKeyValues('replaced lost item processing fee', 'replacedLostItemProcessingFee', displayYes);
+    testSectionKeyValues('replaced lost item processing fee', 'replacedLostItemProcessingFee', labelIds.displayYes);
     testSectionKeyValues('replacement fee', 'replacementProcessFee', getFormattedValue(lostItemFeeSectionProps.policy.replacementProcessingFee));
-    testSectionKeyValues('replacement allowed', 'replacementAllowed', displayYes);
-    testSectionKeyValues('if lost item returned', 'lostItemReturned', lostItemReturnedCharged);
+    testSectionKeyValues('replacement allowed', 'replacementAllowed', labelIds.displayYes);
+    testSectionKeyValues('if lost item returned', 'lostItemReturned', labelIds.lostItemReturnedCharged);
   });
 
   describe('with lostItemFeeSectionAlternativeProps', () => {
@@ -141,18 +148,18 @@ describe('View LostItemFeeSection', () => {
     });
 
     it('should render close accordion', () => {
-      expect(screen.getByTestId('viewLostItemFeeSectionAccordion')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewLostItemFeeSectionAccordion)).not.toHaveAttribute('open');
     });
 
     it('should render charge amount with other cost', () => {
-      expect(screen.getByTestId('chargeAmountItem')).toBeVisible();
+      expect(screen.getByTestId(testIds.chargeAmountItem)).toBeVisible();
     });
 
-    testSectionKeyValues('lost by patron', 'chargeAmountItemPatron', displayNo);
-    testSectionKeyValues('lost by system', 'chargeAmountItemSystem', displayNo);
-    testSectionKeyValues('replaced lost item processing fee', 'replacedLostItemProcessingFee', displayNo);
-    testSectionKeyValues('returned lost item processing fee', 'returnedLostItemProcessingFee', displayNo);
-    testSectionKeyValues('replacement allowed', 'replacementAllowed', displayNo);
-    testSectionKeyValues('if lost item returned', 'lostItemReturned', lostItemReturnedRemove);
+    testSectionKeyValues('lost by patron', 'chargeAmountItemPatron', labelIds.displayNo);
+    testSectionKeyValues('lost by system', 'chargeAmountItemSystem', labelIds.displayNo);
+    testSectionKeyValues('replaced lost item processing fee', 'replacedLostItemProcessingFee', labelIds.displayNo);
+    testSectionKeyValues('returned lost item processing fee', 'returnedLostItemProcessingFee', labelIds.displayNo);
+    testSectionKeyValues('replacement allowed', 'replacementAllowed', labelIds.displayNo);
+    testSectionKeyValues('if lost item returned', 'lostItemReturned', labelIds.lostItemReturnedRemove);
   });
 });

--- a/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/FeeFineNoticesSection/FeeFineNoticesSection.test.js
@@ -18,7 +18,12 @@ jest.mock('../components', () => (
   jest.fn(() => null)
 ));
 
-const labelId = 'ui-circulation.settings.noticePolicy.feeFineNotices';
+const testIds = {
+  accordionTestId: 'accordionTestId',
+};
+const labelIds = {
+  feeFineNotices: 'ui-circulation.settings.noticePolicy.feeFineNotices',
+};
 const isOpen = true;
 
 const mockedFeeFineNotice = {
@@ -94,15 +99,15 @@ describe('FeeFineNoticesSection', () => {
   });
 
   it('should render component', () => {
-    expect(screen.getByTestId('accordionTestId')).toBeTruthy();
+    expect(screen.getByTestId(testIds.accordionTestId)).toBeTruthy();
   });
 
   it('should render label', () => {
-    expect(screen.getByText(labelId)).toBeTruthy();
+    expect(screen.getByText(labelIds.feeFineNotices)).toBeTruthy();
   });
 
   it('should have `open` attribute', () => {
-    expect(screen.getByTestId('accordionTestId')).toHaveAttribute('open');
+    expect(screen.getByTestId(testIds.accordionTestId)).toHaveAttribute('open');
   });
 
   describe('inner NoticeCard component', () => {

--- a/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/GeneralSection/GeneralSection.test.js
@@ -11,18 +11,23 @@ jest.mock('../../../../components', () => ({
 }));
 
 describe('GeneralSection', () => {
+  const testIds = {
+    generalInformationTestId: 'generalInformationTestId',
+  };
+  const labelIds = {
+    generalInformationId: 'ui-circulation.settings.loanPolicy.generalInformation',
+    policyNameId: 'ui-circulation.settings.noticePolicy.policyName',
+    activeLabelId: 'ui-circulation.settings.noticePolicy.active',
+    activeStatusId: 'ui-circulation.settings.loanPolicy.yes',
+    inactiveStatusId: 'ui-circulation.settings.loanPolicy.no',
+    policyDescriptionId: 'ui-circulation.settings.loanPolicy.policyDescription',
+  };
   const mockedMetadata = {
     data: 'mockedMetadata',
   };
   const mockedName = 'mockedPolicyName';
   const mockedDescription = 'mockedPolicyDescription';
   const getItemById = (id) => within(screen.getByTestId(id));
-  const generalInformationId = 'ui-circulation.settings.loanPolicy.generalInformation';
-  const policyNameId = 'ui-circulation.settings.noticePolicy.policyName';
-  const activeLabelId = 'ui-circulation.settings.noticePolicy.active';
-  const activeStatusId = 'ui-circulation.settings.loanPolicy.yes';
-  const inactiveStatusId = 'ui-circulation.settings.loanPolicy.no';
-  const policyDescriptionId = 'ui-circulation.settings.loanPolicy.policyDescription';
   const sectionTesting = (policy, labelId, contentValue) => {
     it(`should render "policy ${policy}" section correctly`, () => {
       expect(screen.getByTestId(`policy${policy}TestId`)).toBeVisible();
@@ -46,12 +51,12 @@ describe('GeneralSection', () => {
     });
 
     it('should render general information section correctly', () => {
-      expect(screen.getByTestId('generalInformationTestId')).toBeVisible();
-      expect(getItemById('generalInformationTestId').getByText(generalInformationId)).toBeVisible();
+      expect(screen.getByTestId(testIds.generalInformationTestId)).toBeVisible();
+      expect(getItemById(testIds.generalInformationTestId).getByText(labelIds.generalInformationId)).toBeVisible();
     });
 
     it('should pass "isOpen" property correctly', () => {
-      expect(screen.getByTestId('generalInformationTestId')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.generalInformationTestId)).toHaveAttribute('open');
     });
 
     it('should execute "Metadata" with correct props', () => {
@@ -63,11 +68,11 @@ describe('GeneralSection', () => {
       expect(Metadata).toHaveBeenLastCalledWith(expectedResult, {});
     });
 
-    sectionTesting('Name', policyNameId, mockedName);
+    sectionTesting('Name', labelIds.policyNameId, mockedName);
 
-    sectionTesting('Active', activeLabelId, activeStatusId);
+    sectionTesting('Active', labelIds.activeLabelId, labelIds.activeStatusId);
 
-    sectionTesting('Description', policyDescriptionId, mockedDescription);
+    sectionTesting('Description', labelIds.policyDescriptionId, mockedDescription);
   });
 
   describe('with negative props', () => {
@@ -84,9 +89,9 @@ describe('GeneralSection', () => {
     });
 
     it('should pass "isOpen" property correctly', () => {
-      expect(screen.getByTestId('generalInformationTestId')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.generalInformationTestId)).not.toHaveAttribute('open');
     });
 
-    sectionTesting('Active', activeLabelId, inactiveStatusId);
+    sectionTesting('Active', labelIds.activeLabelId, labelIds.inactiveStatusId);
   });
 });

--- a/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/LoanNoticesSection/LoanNoticesSection.test.js
@@ -17,6 +17,13 @@ import {
 
 jest.mock('../components', () => jest.fn(() => null));
 
+const testIds = {
+  viewLoanNoticesTestId: 'viewLoanNoticesTestId',
+};
+const labelIds = {
+  loanNoticesId: 'ui-circulation.settings.noticePolicy.loanNotices',
+};
+
 describe('LoanNoticesSection', () => {
   const mockedPolicy = {
     loanNotices: ['firstTestNotice', 'secondTestNotice'],
@@ -31,7 +38,6 @@ describe('LoanNoticesSection', () => {
       label: 'secondTestLabel',
     },
   ];
-  const loanNoticesId = 'ui-circulation.settings.noticePolicy.loanNotices';
   const eachNoticeTest = (notice, index) => {
     const number = index + 1;
     const expectedResult = {
@@ -64,12 +70,12 @@ describe('LoanNoticesSection', () => {
     });
 
     it('should render accrodion with label', () => {
-      expect(screen.getByTestId('viewLoanNoticesTestId')).toBeVisible();
-      expect(within(screen.getByTestId('viewLoanNoticesTestId')).getByText(loanNoticesId)).toBeVisible();
+      expect(screen.getByTestId(testIds.viewLoanNoticesTestId)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.viewLoanNoticesTestId)).getByText(labelIds.loanNoticesId)).toBeVisible();
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewLoanNoticesTestId')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewLoanNoticesTestId)).toHaveAttribute('open');
     });
 
     mockedPolicy.loanNotices.map(eachNoticeTest);
@@ -87,7 +93,7 @@ describe('LoanNoticesSection', () => {
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewLoanNoticesTestId')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewLoanNoticesTestId)).not.toHaveAttribute('open');
     });
   });
 });

--- a/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/RequestNoticesSection/RequestNoticesSection.test.js
@@ -17,6 +17,13 @@ import {
 
 jest.mock('../components', () => jest.fn(() => null));
 
+const testIds = {
+  viewRequestNoticesTestId: 'viewRequestNoticesTestId',
+};
+const labelIds = {
+  requestNoticesId: 'ui-circulation.settings.noticePolicy.requestNotices',
+};
+
 describe('RequestNoticesSection', () => {
   const mockedPolicy = {
     requestNotices: [
@@ -34,7 +41,6 @@ describe('RequestNoticesSection', () => {
       label: 'secondTemplateData',
     },
   ];
-  const requestNoticesId = 'ui-circulation.settings.noticePolicy.requestNotices';
 
   describe('when "isOpen" prop is true', () => {
     beforeEach(() => {
@@ -52,11 +58,11 @@ describe('RequestNoticesSection', () => {
     });
 
     it('should render accordion label correctly', () => {
-      expect(within(screen.getByTestId('viewRequestNoticesTestId')).getByText(requestNoticesId)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.viewRequestNoticesTestId)).getByText(labelIds.requestNoticesId)).toBeVisible();
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewRequestNoticesTestId')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewRequestNoticesTestId)).toHaveAttribute('open');
     });
 
     it('should execute each "NoticeCard" with correct props', () => {
@@ -87,7 +93,7 @@ describe('RequestNoticesSection', () => {
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('viewRequestNoticesTestId')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.viewRequestNoticesTestId)).not.toHaveAttribute('open');
     });
   });
 });

--- a/src/settings/NoticePolicy/components/DetailSections/components/NoticeCard/NoticeCard.test.js
+++ b/src/settings/NoticePolicy/components/DetailSections/components/NoticeCard/NoticeCard.test.js
@@ -32,6 +32,7 @@ const testIds = {
   noticeCardSendByIntervalId: 'noticeCardSendByIntervalId',
   noticeCardSendEveryDuration: 'noticeCardSendEveryDuration',
   noticeCardSendEveryIntervalId: 'noticeCardSendEveryIntervalId',
+  header: 'header',
 };
 
 const testKeyValues = (testId, label, value) => {
@@ -100,7 +101,7 @@ describe('View NoticeCard in DetailSection', () => {
     });
 
     it('should render correct header', () => {
-      expect(within(screen.getByTestId('header')).getByText(noticeCard.header)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.header)).getByText(noticeCard.header)).toBeVisible();
     });
 
     describe('test KeyValues', () => {

--- a/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/LoanNoticesSection/LoanNoticesSection.test.js
@@ -21,6 +21,13 @@ import {
 
 jest.mock('../components', () => jest.fn(() => null));
 
+const testIds = {
+  editLoanNotices: 'editLoanNotices',
+};
+const labelIds = {
+  loanNoticesId: 'ui-circulation.settings.noticePolicy.loanNotices',
+};
+
 describe('LoanNoticesSection', () => {
   const mockedPolicy = {
     policy: 'testPolicyData',
@@ -37,8 +44,6 @@ describe('LoanNoticesSection', () => {
   ];
 
   describe('when it is open', () => {
-    const loanNoticesId = 'ui-circulation.settings.noticePolicy.loanNotices';
-
     beforeEach(() => {
       render(
         <LoanNoticesSection
@@ -54,11 +59,11 @@ describe('LoanNoticesSection', () => {
     });
 
     it('should render accordion with label', () => {
-      expect(within(screen.getByTestId('editLoanNotices')).getByText(loanNoticesId)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.editLoanNotices)).getByText(labelIds.loanNoticesId)).toBeVisible();
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('editLoanNotices')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.editLoanNotices)).toHaveAttribute('open');
     });
 
     it('should execute "FieldArray" with correct props', () => {
@@ -89,7 +94,7 @@ describe('LoanNoticesSection', () => {
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('editLoanNotices')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.editLoanNotices)).not.toHaveAttribute('open');
     });
   });
 

--- a/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/RequestNoticesSection/RequestNoticesSection.test.js
@@ -21,6 +21,13 @@ import {
 
 jest.mock('../components', () => jest.fn(() => null));
 
+const testIds = {
+  editRequestNotices: 'editRequestNotices',
+};
+const labelIds = {
+  requestNoticesId: 'ui-circulation.settings.noticePolicy.requestNotices',
+};
+
 describe('RequestNoticesSection', () => {
   const mockedPolicy = {
     requestNotices: [
@@ -38,7 +45,6 @@ describe('RequestNoticesSection', () => {
       label: 'secondTemplateData',
     },
   ];
-  const requestNoticesId = 'ui-circulation.settings.noticePolicy.requestNotices';
 
   describe('with positive props', () => {
     beforeEach(() => {
@@ -52,11 +58,11 @@ describe('RequestNoticesSection', () => {
     });
 
     it('should render accordion label correctly', () => {
-      expect(within(screen.getByTestId('editRequestNotices')).getByText(requestNoticesId)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.editRequestNotices)).getByText(labelIds.requestNoticesId)).toBeVisible();
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('editRequestNotices')).toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.editRequestNotices)).toHaveAttribute('open');
     });
 
     it('should execute "FieldArray" with correct props', () => {
@@ -87,7 +93,7 @@ describe('RequestNoticesSection', () => {
     });
 
     it('should pass "isOpen" prop correctly', () => {
-      expect(screen.getByTestId('editRequestNotices')).not.toHaveAttribute('open');
+      expect(screen.getByTestId(testIds.editRequestNotices)).not.toHaveAttribute('open');
     });
   });
 

--- a/src/settings/NoticePolicy/components/EditSections/components/NoticesList/NoticesList.test.js
+++ b/src/settings/NoticePolicy/components/EditSections/components/NoticesList/NoticesList.test.js
@@ -11,6 +11,13 @@ import '../../../../../../../test/jest/__mock__';
 import NoticesList from './NoticesList';
 import NoticeCard from '../NoticeCard';
 
+const testIds = {
+  addNotice: 'addNotice',
+};
+const labelIds = {
+  addNotice: 'ui-circulation.settings.noticePolicy.addNotice',
+};
+
 jest.mock('../NoticeCard', () => jest.fn(({
   onRemoveNotice,
   noticeIndex,
@@ -23,9 +30,6 @@ jest.mock('../NoticeCard', () => jest.fn(({
 )));
 
 describe('NoticesList', () => {
-  const labelIds = {
-    addNotice: 'ui-circulation.settings.noticePolicy.addNotice',
-  };
   const testFieldsNames = [
     'notice1',
     'notice2',
@@ -140,11 +144,11 @@ describe('NoticesList', () => {
     });
 
     it('should render add notice button', () => {
-      expect(within(screen.getByTestId('addNotice')).getByText(labelIds.addNotice)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.addNotice)).getByText(labelIds.addNotice)).toBeVisible();
     });
 
     it('should add notice', () => {
-      const addNotice = screen.getByTestId('addNotice');
+      const addNotice = screen.getByTestId(testIds.addNotice);
 
       fireEvent.click(addNotice);
 

--- a/src/settings/PatronNotices/PatronNoticeDetail.test.js
+++ b/src/settings/PatronNotices/PatronNoticeDetail.test.js
@@ -49,6 +49,12 @@ AccordionSet.mockImplementation(({ children, onToggle }) => (
 ));
 
 describe('PatronNoticeDetail', () => {
+  const testIds = {
+    accordionSet: 'accordionSet',
+    emailAccordionContent: 'emailAccordionContent',
+    previewModal: 'previewModal',
+    previewButtonColumn: 'previewButtonColumn',
+  };
   const labelIds = {
     noticeName: 'ui-circulation.settings.patronNotices.notice.name',
     noticeActive: 'ui-circulation.settings.patronNotices.notice.active',
@@ -144,7 +150,7 @@ describe('PatronNoticeDetail', () => {
           }), {}
         );
 
-        const accordionSet = screen.getByTestId('accordionSet');
+        const accordionSet = screen.getByTestId(testIds.accordionSet);
         fireEvent.click(accordionSet);
 
         expect(AccordionSet).toHaveBeenLastCalledWith(
@@ -224,7 +230,7 @@ describe('PatronNoticeDetail', () => {
 
         if (localizedTemplates.en.body) {
           it('should render email accordion content', () => {
-            expect(screen.getByTestId('emailAccordionContent')).toBeVisible();
+            expect(screen.getByTestId(testIds.emailAccordionContent)).toBeVisible();
           });
 
           it('should render "subject" KeyValue', () => {
@@ -248,16 +254,16 @@ describe('PatronNoticeDetail', () => {
           });
 
           it('should render "preview" Button', () => {
-            expect(getById('previewButtonColumn').getByText(labelIds.preview)).toBeVisible();
+            expect(getById(testIds.previewButtonColumn).getByText(labelIds.preview)).toBeVisible();
           });
 
           describe('open/close preview dialog', () => {
             const openPreviewDialog = () => {
-              const previewButton = getById('previewButtonColumn').getByText(labelIds.preview);
+              const previewButton = getById(testIds.previewButtonColumn).getByText(labelIds.preview);
               fireEvent.click(previewButton);
             };
             const closePreviewDialog = () => {
-              const previewModal = screen.getByTestId('previewModal');
+              const previewModal = screen.getByTestId(testIds.previewModal);
               fireEvent.click(previewModal);
             };
             const testPreviewModalOpen = (open) => {
@@ -295,7 +301,7 @@ describe('PatronNoticeDetail', () => {
           });
         } else {
           it('should not render email accordion content', () => {
-            expect(screen.queryByTestId('emailAccordionContent')).not.toBeInTheDocument();
+            expect(screen.queryByTestId(testIds.emailAccordionContent)).not.toBeInTheDocument();
           });
         }
       }

--- a/src/settings/PatronNotices/PatronNoticeForm.test.js
+++ b/src/settings/PatronNotices/PatronNoticeForm.test.js
@@ -29,10 +29,39 @@ import {
 } from '../components';
 
 const mockGetTokensReturnValue = 'getTokensReturnValue';
+const testIds = {
+  accordionSet: 'accordionSet',
+  form: 'patronNoticeForm',
+  patronNoticePaneset: 'patronNoticePaneset',
+  patronNoticeTemplatePane: 'patronNoticeTemplatePane',
+  patronNoticeCancelButton: 'patronNoticeCancelButton',
+  patronNoticeFooterPane: 'patronNoticeFooterPane',
+  patronNoticesNoticeName: 'patronNoticesNoticeName',
+  patronNoticesNoticeActive: 'patronNoticesNoticeActive',
+  patronNoticesNoticeDescription: 'patronNoticesNoticeDescription',
+  patronNoticesNoticeCategory: 'patronNoticesNoticeCategory',
+  patronNoticesSubject: 'patronNoticesSubject',
+  patronNoticesBody: 'patronNoticesBody',
+  patronNoticesAccordionSet: 'patronNoticesAccordionSet',
+  patronNoticesEmail: 'patronNoticesEmail',
+};
+const labelIds = {
+  patronNoticesNew: 'ui-circulation.settings.patronNotices.newLabel',
+  patronNoticesCloseDialog: 'ui-circulation.settings.patronNotices.closeDialog',
+  patronNoticesNoticeName: 'ui-circulation.settings.patronNotices.notice.name',
+  patronNoticesNoticeActive: 'ui-circulation.settings.patronNotices.notice.active',
+  patronNoticesNoticeDescription: 'ui-circulation.settings.patronNotices.notice.description',
+  patronNoticesNoticeCategory: 'ui-circulation.settings.patronNotices.notice.category',
+  patronNoticesEmail: 'ui-circulation.settings.patronNotices.email',
+  patronNoticesSubject: 'ui-circulation.settings.patronNotices.subject',
+  patronNoticesBody: 'ui-circulation.settings.patronNotices.body',
+  patronNoticesFormPreviewHeader: 'ui-circulation.settings.patronNotices.form.previewHeader',
+  patronNoticesPredefinedWarning: 'ui-circulation.settings.patronNotices.predefinedWarning',
+};
 
 AccordionSet.mockImplementation(({ children, onToggle }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-  <span data-testid="accordionSet" onClick={() => onToggle({ id: 'email-template-form' })}>
+  <span data-testid={testIds.accordionSet} onClick={() => onToggle({ id: 'email-template-form' })}>
     {children}
   </span>
 ));
@@ -53,34 +82,6 @@ jest.mock('../../constants', () => ({
 }));
 
 describe('PatronNoticeForm', () => {
-  const testIds = {
-    form: 'patronNoticeForm',
-    patronNoticePaneset: 'patronNoticePaneset',
-    patronNoticeTemplatePane: 'patronNoticeTemplatePane',
-    patronNoticeCancelButton: 'patronNoticeCancelButton',
-    patronNoticeFooterPane: 'patronNoticeFooterPane',
-    patronNoticesNoticeName: 'patronNoticesNoticeName',
-    patronNoticesNoticeActive: 'patronNoticesNoticeActive',
-    patronNoticesNoticeDescription: 'patronNoticesNoticeDescription',
-    patronNoticesNoticeCategory: 'patronNoticesNoticeCategory',
-    patronNoticesSubject: 'patronNoticesSubject',
-    patronNoticesBody: 'patronNoticesBody',
-    patronNoticesAccordionSet: 'patronNoticesAccordionSet',
-    patronNoticesEmail: 'patronNoticesEmail',
-  };
-  const labelIds = {
-    patronNoticesNew: 'ui-circulation.settings.patronNotices.newLabel',
-    patronNoticesCloseDialog: 'ui-circulation.settings.patronNotices.closeDialog',
-    patronNoticesNoticeName: 'ui-circulation.settings.patronNotices.notice.name',
-    patronNoticesNoticeActive: 'ui-circulation.settings.patronNotices.notice.active',
-    patronNoticesNoticeDescription: 'ui-circulation.settings.patronNotices.notice.description',
-    patronNoticesNoticeCategory: 'ui-circulation.settings.patronNotices.notice.category',
-    patronNoticesEmail: 'ui-circulation.settings.patronNotices.email',
-    patronNoticesSubject: 'ui-circulation.settings.patronNotices.subject',
-    patronNoticesBody: 'ui-circulation.settings.patronNotices.body',
-    patronNoticesFormPreviewHeader: 'ui-circulation.settings.patronNotices.form.previewHeader',
-    patronNoticesPredefinedWarning: 'ui-circulation.settings.patronNotices.predefinedWarning',
-  };
   const testOkapi = {
     url: 'testUrl',
     tenant: 'testTenant',
@@ -239,7 +240,7 @@ describe('PatronNoticeForm', () => {
           },
         }, true);
 
-        const accordionSet = screen.getByTestId('accordionSet');
+        const accordionSet = screen.getByTestId(testIds.accordionSet);
         fireEvent.click(accordionSet);
 
         componentPropsCheck(AccordionSet, testIds.patronNoticesAccordionSet, {

--- a/src/settings/PatronNotices/TokensList/TokensList.test.js
+++ b/src/settings/PatronNotices/TokensList/TokensList.test.js
@@ -90,6 +90,10 @@ const testTokensSection = (sectionTestId) => {
   });
 };
 
+const testIds = {
+  tokenListWrapper: 'tokenListWrapper',
+};
+
 describe('View TokensList', () => {
   const defaultProps = {
     onLoopSelect: jest.fn(),
@@ -105,7 +109,7 @@ describe('View TokensList', () => {
     });
 
     it('should render TokensList component', () => {
-      expect(screen.getByTestId('tokenListWrapper')).toBeVisible();
+      expect(screen.getByTestId(testIds.tokenListWrapper)).toBeVisible();
     });
 
     testTokensSection('item');

--- a/src/settings/StaffSlips/StaffSlipForm.test.js
+++ b/src/settings/StaffSlips/StaffSlipForm.test.js
@@ -42,16 +42,22 @@ jest.mock('./components/EditSections', () => ({
 }));
 Field.mockImplementation(jest.fn(() => null));
 
-const mockTestIds = {
+const testIds = {
   expandAllButton: 'expandAllButton',
   accordion: 'accordion',
   accordionSet: 'accordionSet',
+  formStaffSlip: 'formStaffSlip',
+};
+const labelIds = {
+  new: 'ui-circulation.settings.staffSlips.new',
+  staffSlipsGeneralInformation: 'ui-circulation.settings.staffSlips.generalInformation',
+  staffSlipsTemplateContent: 'ui-circulation.settings.staffSlips.templateContent',
 };
 
 ExpandAllButton.mockImplementation(({ onToggle }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div
-    data-testid={mockTestIds.expandAllButton}
+    data-testid={testIds.expandAllButton}
     onClick={() => onToggle({
       generalInformation: false,
       templateContent: false,
@@ -60,11 +66,6 @@ ExpandAllButton.mockImplementation(({ onToggle }) => (
 ));
 
 describe('StaffSlipForm', () => {
-  const labelIds = {
-    new: 'ui-circulation.settings.staffSlips.new',
-    staffSlipsGeneralInformation: 'ui-circulation.settings.staffSlips.generalInformation',
-    staffSlipsTemplateContent: 'ui-circulation.settings.staffSlips.templateContent',
-  };
   const mockedHandleSubmit = jest.fn();
   const mockedOnCancel = jest.fn();
   const mockedHandleExpandAll = jest.fn();
@@ -120,12 +121,12 @@ describe('StaffSlipForm', () => {
     });
 
     it('"form" component should have correct attributes', () => {
-      expect(screen.getByTestId('formStaffSlip')).toHaveAttribute('noValidate');
+      expect(screen.getByTestId(testIds.formStaffSlip)).toHaveAttribute('noValidate');
     });
 
     it('on "form" submit should execute passed function', () => {
       expect(mockedHandleSubmit).toHaveBeenCalledTimes(0);
-      fireEvent.submit(screen.getByTestId('formStaffSlip'));
+      fireEvent.submit(screen.getByTestId(testIds.formStaffSlip));
       expect(mockedHandleSubmit).toHaveBeenCalledTimes(1);
     });
 
@@ -194,7 +195,7 @@ describe('StaffSlipForm', () => {
       });
 
       it('should expand all accordions statuses', () => {
-        fireEvent.click(screen.getByTestId(mockTestIds.expandAllButton));
+        fireEvent.click(screen.getByTestId(testIds.expandAllButton));
 
         expect(ExpandAllButton).toHaveBeenLastCalledWith(expect.objectContaining({
           accordionStatus: {
@@ -210,7 +211,7 @@ describe('StaffSlipForm', () => {
         Accordion.mockImplementationOnce(({ onToggle, children }) => (
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
           <div
-            data-testid={mockTestIds.accordion}
+            data-testid={testIds.accordion}
             onClick={() => onToggle({ id: mockGeneralStaffSlipDetailId })}
           >
             {children}
@@ -232,7 +233,7 @@ describe('StaffSlipForm', () => {
           }), {}
         );
 
-        fireEvent.click(screen.getByTestId(mockTestIds.accordion));
+        fireEvent.click(screen.getByTestId(testIds.accordion));
 
         expect(Accordion).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelect.test.js
@@ -11,6 +11,10 @@ import AnonymizingTypeSelect from './AnonymizingTypeSelect';
 RadioButton.mockImplementation(() => null);
 Field.mockImplementation(() => null);
 
+const testIds = {
+  anonymizingTypeRowTestId: 'anonymizingTypeRowTestId',
+};
+
 describe('AnonymizingTypeSelect', () => {
   const mockedProps = {
     name: 'testName',
@@ -56,7 +60,7 @@ describe('AnonymizingTypeSelect', () => {
   });
 
   it(`should render ${mockedProps.types.length} rows`, () => {
-    expect(screen.getAllByTestId('anonymizingTypeRowTestId')).toHaveLength(mockedProps.types.length);
+    expect(screen.getAllByTestId(testIds.anonymizingTypeRowTestId)).toHaveLength(mockedProps.types.length);
   });
 
   mockedProps.types.forEach(testAnonymizingTypeRow);

--- a/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.test.js
+++ b/src/settings/components/AnonymizingTypeSelect/AnonymizingTypeSelectContainer.test.js
@@ -27,19 +27,24 @@ jest.mock('./AnonymizingTypeSelect', () => jest.fn(({ types }) => (
 jest.mock('../Period', () => jest.fn(() => null));
 
 describe('AnonymizingTypeSelectContainer', () => {
+  const testIds = {
+    period: 'period',
+  };
   const labelIds = {
     afterClose: 'ui-circulation.settings.loanHistory.afterClose',
+    immediatelyAfterClose: 'ui-circulation.settings.loanHistory.immediatelyAfterClose',
+    interval: 'ui-circulation.settings.loanHistory.interval',
   };
   const testName = 'testName';
   const testPath = 'testPath';
   const testTypes = [
     {
       value: 'immediately',
-      label: 'ui-circulation.settings.loanHistory.immediatelyAfterClose',
+      label: labelIds.immediatelyAfterClose,
     },
     {
       value: 'interval',
-      label: 'ui-circulation.settings.loanHistory.interval',
+      label: labelIds.interval,
     },
   ];
   const testDefaultProps = {
@@ -71,7 +76,7 @@ describe('AnonymizingTypeSelectContainer', () => {
         selectValuePath: `${testPath}.intervalId`,
       }), {});
 
-      expect(within(screen.getByTestId('period')).getByText(labelIds.afterClose)).toBeVisible();
+      expect(within(screen.getByTestId(testIds.period)).getByText(labelIds.afterClose)).toBeVisible();
     });
 
     it('should render Field component', () => {

--- a/src/settings/components/CancelButton/CancelButton.test.js
+++ b/src/settings/components/CancelButton/CancelButton.test.js
@@ -14,6 +14,10 @@ const renderCancelButton = (props) => {
   );
 };
 
+const labelIds = {
+  closeEntryDialog: 'ui-circulation.settings.common.closeEntryDialog',
+};
+
 describe('Cancel Button', () => {
   let renderButton;
   beforeEach(() => {
@@ -28,6 +32,6 @@ describe('Cancel Button', () => {
 
     expect(container).toBeVisible();
     expect(iconCancelButton).toBeVisible();
-    expect(queryByLabelText('ui-circulation.settings.common.closeEntryDialog')).toBeTruthy();
+    expect(queryByLabelText(labelIds.closeEntryDialog)).toBeTruthy();
   });
 });

--- a/src/settings/components/Metadata/Metadata.test.js
+++ b/src/settings/components/Metadata/Metadata.test.js
@@ -9,13 +9,18 @@ import '../../../../test/jest/__mock__';
 
 import Metadata from './Metadata';
 
+const testIds = {
+  connectedComponentTestId: 'connectedComponentTestId',
+  metadataTestId: 'metadataTestId',
+};
+
 describe('Metadata', () => {
   const mockedConnect = jest.fn((Component) => {
     return class extends React.Component {
       render() {
         return (
           <Component
-            data-testid="connectedComponentTestId"
+            data-testid={testIds.connectedComponentTestId}
             {...this.props}
           />
         );
@@ -42,16 +47,16 @@ describe('Metadata', () => {
     });
 
     it('should render component', () => {
-      expect(screen.getByTestId('metadataTestId')).toBeVisible();
+      expect(screen.getByTestId(testIds.metadataTestId)).toBeVisible();
     });
 
     it('should use "connect" function on correct component', () => {
       expect(mockedConnect).toHaveBeenCalled();
-      expect(screen.getByTestId('connectedComponentTestId')).toBeVisible();
+      expect(screen.getByTestId(testIds.connectedComponentTestId)).toBeVisible();
     });
 
     it('should receive correct props', () => {
-      expect(within(screen.getByTestId('connectedComponentTestId')).getByText(`${mockedMetadata.createdDate}`));
+      expect(within(screen.getByTestId(testIds.connectedComponentTestId)).getByText(`${mockedMetadata.createdDate}`));
     });
   });
 
@@ -63,7 +68,7 @@ describe('Metadata', () => {
         />
       );
 
-      expect(screen.queryByTestId('metadataTestId')).not.toBe();
+      expect(screen.queryByTestId(testIds.metadataTestId)).not.toBe();
     });
 
     it('should not render element if "createdDate" in "metadata" is absent', () => {
@@ -74,7 +79,7 @@ describe('Metadata', () => {
         />
       );
 
-      expect(screen.queryByTestId('metadataTestId')).not.toBe();
+      expect(screen.queryByTestId(testIds.metadataTestId)).not.toBe();
     });
   });
 });

--- a/src/settings/components/Period/Period.test.js
+++ b/src/settings/components/Period/Period.test.js
@@ -16,12 +16,26 @@ import {
   Select,
 } from '@folio/stripes/components';
 
-import Period, { transformInputValue } from './Period';
+import Period, {
+  transformInputValue,
+} from './Period';
+
+const testIds = {
+  onClearFieldTestElement: 'onClearFieldTestElement',
+  periodLabelSection: 'periodLabelSection',
+  periodIntervalColumn: 'periodIntervalColumn',
+  finePolicyDurationColumn: 'finePolicyDurationColumn',
+  finePolicyIntervalColumn: 'finePolicyIntervalColumn',
+};
+const labelIds = {
+  fieldLabelId: 'testFieldLabelId',
+  intervalPeriodsSuffixId: 'testIntervalPeriodsSuffix',
+};
 
 Field.mockImplementation(({ onClearField }) => {
   return (
     // eslint-disable-next-line
-    <div data-testid="onClearFieldTestElement" onClick={onClearField} />
+    <div data-testid={testIds.onClearFieldTestElement} onClick={onClearField} />
   );
 });
 
@@ -35,10 +49,6 @@ describe('Period', () => {
     Field.mockClear();
   });
 
-  const labelIds = {
-    fieldLabelId: 'testFieldLabelId',
-    intervalPeriodsSuffixId: 'testIntervalPeriodsSuffix',
-  };
   const commonMockedProps = {
     inputValuePath: 'inputValuePathTestValue',
     selectValuePath: 'selectValuePathTestValue',
@@ -58,13 +68,13 @@ describe('Period', () => {
     });
 
     it('should not render period label section', () => {
-      const periodLabelSection = screen.queryByTestId('periodLabelSection');
+      const periodLabelSection = screen.queryByTestId(testIds.periodLabelSection);
 
       expect(periodLabelSection).not.toBeInTheDocument();
     });
 
     it('should render fine policy duration column', () => {
-      const finePolicyDurationColumn = screen.getByTestId('finePolicyDurationColumn');
+      const finePolicyDurationColumn = screen.getByTestId(testIds.finePolicyDurationColumn);
 
       expect(finePolicyDurationColumn).toHaveAttribute('xs', '2');
       expect(Field).toHaveBeenNthCalledWith(
@@ -81,7 +91,7 @@ describe('Period', () => {
     });
 
     it('should render fine policy interval column', () => {
-      const finePolicyIntervalColumn = screen.getByTestId('finePolicyIntervalColumn');
+      const finePolicyIntervalColumn = screen.getByTestId(testIds.finePolicyIntervalColumn);
 
       expect(finePolicyIntervalColumn).toHaveAttribute('xs', '2');
       expect(Field).toHaveBeenNthCalledWith(
@@ -97,7 +107,7 @@ describe('Period', () => {
     });
 
     it('should not render period interval column', () => {
-      const periodIntervalColumn = screen.queryByTestId('periodIntervalColumn');
+      const periodIntervalColumn = screen.queryByTestId(testIds.periodIntervalColumn);
 
       expect(periodIntervalColumn).not.toBeInTheDocument();
     });
@@ -108,9 +118,9 @@ describe('Period', () => {
 
     render(<Period {...commonMockedProps} changeFormValue={changeFormValueMock} />);
 
-    const finePolicyDurationColumn = screen.getByTestId('finePolicyDurationColumn');
+    const finePolicyDurationColumn = screen.getByTestId(testIds.finePolicyDurationColumn);
     const textFieldOnClearFieldTestElement =
-      within(finePolicyDurationColumn).getByTestId('onClearFieldTestElement');
+      within(finePolicyDurationColumn).getByTestId(testIds.onClearFieldTestElement);
 
     fireEvent.click(textFieldOnClearFieldTestElement);
 
@@ -150,7 +160,7 @@ describe('Period', () => {
     });
 
     it('should render period label section', () => {
-      const periodLabelSection = screen.getByTestId('periodLabelSection');
+      const periodLabelSection = screen.getByTestId(testIds.periodLabelSection);
       const periodLabel = within(periodLabelSection).getByText(labelIds.fieldLabelId);
 
       expect(periodLabelSection).toBeVisible();
@@ -170,7 +180,7 @@ describe('Period', () => {
     });
 
     it('should render period label section', () => {
-      const periodLabelSection = screen.getByTestId('periodLabelSection');
+      const periodLabelSection = screen.getByTestId(testIds.periodLabelSection);
       const periodLabel = within(periodLabelSection).getByText(labelIds.fieldLabelId);
 
       expect(periodLabel).toHaveAttribute('required');
@@ -188,7 +198,7 @@ describe('Period', () => {
     });
 
     it('should render fine policy duration column', () => {
-      const finePolicyDurationColumn = screen.getByTestId('finePolicyDurationColumn');
+      const finePolicyDurationColumn = screen.getByTestId(testIds.finePolicyDurationColumn);
 
       expect(finePolicyDurationColumn).toHaveAttribute('xs', '3');
     });
@@ -205,7 +215,7 @@ describe('Period', () => {
     });
 
     it('should render period interval column', () => {
-      const periodIntervalColumn = screen.getByTestId('periodIntervalColumn');
+      const periodIntervalColumn = screen.getByTestId(testIds.periodIntervalColumn);
       const periodLabel = within(periodIntervalColumn).getByText(labelIds.intervalPeriodsSuffixId);
 
       expect(periodIntervalColumn).toBeVisible();
@@ -226,13 +236,13 @@ describe('Period', () => {
     });
 
     it('should render fine policy interval column', () => {
-      const finePolicyIntervalColumn = screen.getByTestId('finePolicyIntervalColumn');
+      const finePolicyIntervalColumn = screen.getByTestId(testIds.finePolicyIntervalColumn);
 
       expect(finePolicyIntervalColumn).toHaveAttribute('xs', '3');
     });
 
     it('should render period interval column', () => {
-      const periodIntervalColumn = screen.getByTestId('periodIntervalColumn');
+      const periodIntervalColumn = screen.getByTestId(testIds.periodIntervalColumn);
 
       expect(periodIntervalColumn).toHaveAttribute('xs', '3');
     });

--- a/src/settings/lib/RuleEditor/RulesForm.js
+++ b/src/settings/lib/RuleEditor/RulesForm.js
@@ -52,7 +52,7 @@ class RulesForm extends React.Component {
       <form
         id="form-loan-rules"
         data-test-circulation-rules-form
-        data-testid="form-loan-rules"
+        data-testid="formLoanRules"
         className={styles.circulationRulesForm}
         onSubmit={handleSubmit}
       >

--- a/src/settings/lib/RuleEditor/RulesForm.test.js
+++ b/src/settings/lib/RuleEditor/RulesForm.test.js
@@ -9,7 +9,7 @@ import '../../../../test/jest/__mock__';
 
 import {
   Button,
-  TextField
+  TextField,
 } from '@folio/stripes/components';
 
 import { Field } from 'react-final-form';
@@ -25,8 +25,8 @@ describe('RulesForm', () => {
     checkoutSave: 'ui-circulation.settings.checkout.save',
   };
   const testIds = {
-    formLoanRules: 'form-loan-rules',
-    ruleFilter: 'rule-filter',
+    formLoanRules: 'formLoanRules',
+    ruleFilter: 'ruleFilter',
   };
   const testEditorProps = {
     propA: 'testValue',

--- a/src/settings/utils/options-generator.js
+++ b/src/settings/utils/options-generator.js
@@ -23,7 +23,7 @@ export default (formatMessage = noop, config = {}, placeholder = '') => {
   forEach(config, ({ value, label }, index) => {
     options.push(
       <option
-        data-testid={`optionTestId-${index}`}
+        data-testid={`optionTestId${index}`}
         value={value}
         key={value}
       >

--- a/src/settings/utils/options-generator.test.js
+++ b/src/settings/utils/options-generator.test.js
@@ -8,14 +8,18 @@ import {
 
 import optionsGenerator from './options-generator';
 
+const testIds = {
+  placeholderTestId: 'placeholderTestId',
+};
+
 describe('settings utils', () => {
   describe('optionsGenerator', () => {
     const mockedFormatMessage = jest.fn(({ id }) => id);
     const getById = (id) => within(screen.getByTestId(id));
     const optionTest = (config) => {
       config.forEach((item, index) => {
-        expect(screen.getByTestId(`optionTestId-${index}`)).toBeVisible();
-        expect(getById(`optionTestId-${index}`).getByText(item.label)).toBeVisible();
+        expect(screen.getByTestId(`optionTestId${index}`)).toBeVisible();
+        expect(getById(`optionTestId${index}`).getByText(item.label)).toBeVisible();
       });
     };
     const mockedConfigData = [
@@ -28,7 +32,7 @@ describe('settings utils', () => {
         label: 'secondTestLabel',
       },
     ];
-    const mockedPlaceholder = 'Test PLaceholder';
+    const mockedPlaceholder = 'Test Placeholder';
 
     afterEach(() => {
       mockedFormatMessage.mockClear();
@@ -46,7 +50,7 @@ describe('settings utils', () => {
       render(result.map((item) => item));
 
       expect(screen.getAllByRole('option')).toHaveLength(1);
-      expect(screen.getByText('Test PLaceholder')).toBeVisible();
+      expect(screen.getByText(mockedPlaceholder)).toBeVisible();
       expect(mockedFormatMessage).toHaveBeenCalledTimes(1);
     });
 
@@ -55,7 +59,7 @@ describe('settings utils', () => {
 
       render(result.map((item) => item));
 
-      expect(screen.queryByTestId('placeholderTestId')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(testIds.placeholderTestId)).not.toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(2);
       expect(mockedFormatMessage).toHaveBeenCalledTimes(2);
       optionTest(mockedConfigData);

--- a/src/settings/wrappers/withPreventDelete.test.js
+++ b/src/settings/wrappers/withPreventDelete.test.js
@@ -9,6 +9,7 @@ import '../../../test/jest/__mock__';
 
 import withPreventDelete from './withPreventDelete';
 
+const policyInUse = 'Policy is in use!';
 const mockComponent = ({
   checkPolicy,
   closeText,
@@ -20,7 +21,7 @@ const mockComponent = ({
     <span>{labelText}</span>
     <span>{messageText}</span>
     {checkPolicy() &&
-      <span>Policy is in use!</span>
+      <span>{policyInUse}</span>
     }
   </>
 );
@@ -53,13 +54,18 @@ const props = {
 
 const WrappedComponent = withPreventDelete(mockComponent, 'test');
 const renderWithPreventDelete = (extraProps = {}) => render(<WrappedComponent {...props} {...extraProps} />);
+const labelIds = {
+  commonClose: 'ui-circulation.settings.common.close',
+  denyDeleteHeader: 'ui-circulation.settings.test.denyDelete.header',
+  denyDeleteBody: 'ui-circulation.settings.policy.denyDelete.body',
+};
 
 describe('withPreventDelete', () => {
   it('passes in props', () => {
     renderWithPreventDelete();
-    expect(screen.getByText('ui-circulation.settings.common.close')).toBeInTheDocument();
-    expect(screen.getByText('ui-circulation.settings.test.denyDelete.header')).toBeInTheDocument();
-    expect(screen.getByText('ui-circulation.settings.policy.denyDelete.body')).toBeInTheDocument();
+    expect(screen.getByText(labelIds.commonClose)).toBeInTheDocument();
+    expect(screen.getByText(labelIds.denyDeleteHeader)).toBeInTheDocument();
+    expect(screen.getByText(labelIds.denyDeleteBody)).toBeInTheDocument();
   });
 
   describe('Checking policy in use', () => {
@@ -73,12 +79,12 @@ describe('withPreventDelete', () => {
         }
       };
       renderWithPreventDelete(overrideResources);
-      expect(screen.getByText('Policy is in use!')).toBeInTheDocument();
+      expect(screen.getByText(policyInUse)).toBeInTheDocument();
     });
 
     it('does not say policy is in use if there are no records', () => {
       renderWithPreventDelete();
-      const policyText = screen.queryByText('Policy is in use!');
+      const policyText = screen.queryByText(policyInUse);
       expect(policyText).toBeNull();
     });
   });


### PR DESCRIPTION
## Purpose
- Use camel case notation for all data-testid
- Remove magic strings for testIds and labelIds

## Refs
https://issues.folio.org/browse/UICIRC-912