### PR TITLE
UICIRC-916: Update folio/stripes-template-editor to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Use camel case notation for all data-testid. Refs UICIRC-912.
 * Replace `labelSingular` with `translations` in props to `ControlledVocab`. Refs UICIRC-849.
 * Add metadata info to view of Patron Notice Templates (Settings > Circulation > Patron Notice Templates). Refs UICIRC-856.
+* Update `folio/stripes-template-editor` to `3.2.0`. Refs UICIRC-916.
 
 ## [8.0.0](https://github.com/folio-org/ui-circulation/tree/v8.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v7.2.1...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/stripes-template-editor": "^3.0.0",
+    "@folio/stripes-template-editor": "^3.2.0",
     "codemirror": "^5.61.1",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
## Purpose
Update folio/stripes-template-editor to 3.2.0

## Refs
https://issues.folio.org/browse/UICIRC-916