### PR TITLE
UICIRC-920: Support feesfines interface version 18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add metadata info to view of Patron Notice Templates (Settings > Circulation > Patron Notice Templates). Refs UICIRC-856.
 * Add metadata info and accordion organization to Patron Notice Templates edit screen. REFs UICIRC-906.
 * Create a new permission that grants View-only access to Settings > Circulation > Circulation rules. Refs UICIRC-843.
+* Support `feesfines` interface version `18.0`. Refs UICIRC-920.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "patron-notice-policy-storage": "0.11",
       "location-units": "2.0",
       "locations": "3.0",
-      "feesfines": "16.0 17.0"
+      "feesfines": "16.0 17.0 18.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
Support feesfines interface version 18.0

## Approach
In /feefineactions  (https://s3.amazonaws.com/foliodocs/api/mod-feesfines/r/feefineactions.html)  createdAt field was changed from string to UUID string and added originalCreatedAt field.
These changes do not affect this module and we just need to update the interface.

## Refs
https://issues.folio.org/browse/UICIRC-920

## Notes 
Associated with https://issues.folio.org/browse/MODFEE-315.
Could you please notify us if we miss something?
