### PR TITLE
UICIRC-917: Fields use full screen width (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add "Departments" as staff slip token in Settings. Refs UICIRC-844.
 * FE | Make the token "feeCharge.additionalInfo" selectable for automated f/f adjustment notice templates. Refs UICIRC-862.
 * Changed translation for token section. Refs UICIRC-911.
+* Fields use full use screen width (part 1). Refs UICIRC-917.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/FinePolicy/components/EditSections/FinesSection/FinesSection.js
+++ b/src/settings/FinePolicy/components/EditSections/FinesSection/FinesSection.js
@@ -44,7 +44,7 @@ class FinesSection extends React.Component {
           open={fineSectionOpen}
           label={formatMessage({ id: 'ui-circulation.settings.finePolicy.overdueFine' })}
         >
-          <section className={css.accordionSection}>
+          <section>
             <div data-test-fine-section-overdue>
               <OverdueFinesSection
                 label={formatMessage({ id: 'ui-circulation.settings.finePolicy.overdueFine' })}

--- a/src/settings/FinePolicy/components/EditSections/FinesSection/FinesSection.js
+++ b/src/settings/FinePolicy/components/EditSections/FinesSection/FinesSection.js
@@ -14,8 +14,6 @@ import optionsGenerator from '../../../../utils/options-generator';
 import OverdueFinesSection from '../RangeSection/OverdueFinesSection';
 import OverdueFinesSectionColumn from '../RangeSection/OverdueFinesSectionColumn';
 
-import css from '../../../FineSection.css';
-
 class FinesSection extends React.Component {
   static propTypes = {
     intl: PropTypes.object.isRequired,

--- a/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
+++ b/src/settings/FinePolicy/components/EditSections/OverdueAboutSection/OverdueAboutSection.js
@@ -15,7 +15,7 @@ const OverdueAboutSection = () => (
     data-testid="overdueAboutSection"
   >
     <Row>
-      <Col xs={3} data-test-about-section-policy-name>
+      <Col xs={12} data-test-about-section-policy-name>
         <Field
           data-testid="nameTestId"
           label={<FormattedMessage id="ui-circulation.settings.finePolicy.overdueFinePolicyName" />}
@@ -28,7 +28,7 @@ const OverdueAboutSection = () => (
       </Col>
     </Row>
     <Row>
-      <Col xs={5} data-test-about-section-policy-description>
+      <Col xs={12} data-test-about-section-policy-description>
         <Field
           data-testid="descriptionTestId"
           label={<FormattedMessage id="ui-circulation.settings.finePolicy.description" />}

--- a/src/settings/FixedDueDateSchedule/FixedDueDateSchedule.css
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateSchedule.css
@@ -1,14 +1,6 @@
 @import "@folio/stripes-components/lib/variables.css";
 
-.accordionSection{
-  max-width:700px;
-  margin-left:20px;
-}
-
-.smformItem{
-  max-width:40%;
-}
-.adjustDelete{
+.adjustDelete {
   margin: 10px 0 10px 0;
 }
 

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleDetail.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleDetail.js
@@ -16,8 +16,6 @@ import { ViewMetaData } from '@folio/stripes/smart-components';
 
 import SchedulesList from './components/DetailsSections/ScedulesList';
 
-import css from './FixedDueDateSchedule.css';
-
 class FixedDueDateScheduleDetail extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleDetail.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleDetail.js
@@ -80,7 +80,7 @@ class FixedDueDateScheduleDetail extends React.Component {
             open={sections.generalFixedDueDateScheduleDetail}
             label={<FormattedMessage id="ui-circulation.settings.fDDSform.about" />}
           >
-            <section className={css.accordionSection}>
+            <section>
               {(fixedDueDateSchedule.metadata && fixedDueDateSchedule.metadata.createdDate) &&
                 <this.cViewMetaData metadata={fixedDueDateSchedule.metadata} />}
               <Row>
@@ -107,7 +107,7 @@ class FixedDueDateScheduleDetail extends React.Component {
             label={<FormattedMessage id="ui-circulation.settings.fDDSform.schedule" />}
             open={sections.fixedDueDateSchedule}
           >
-            <section className={css.accordionSection}>
+            <section>
               <SchedulesList
                 schedules={fixedDueDateSchedule.schedules}
                 timezone={timezone}

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
@@ -233,17 +233,11 @@ class FixedDueDateScheduleForm extends React.Component {
                   open={sections.generalFixedDueDate}
                   label={<FormattedMessage id="ui-circulation.settings.fDDSform.about" />}
                 >
-                  <section
-                    className={css.accordionSection}
-                    data-test-fdds-form-general-section
-                  >
+                  <section data-test-fdds-form-general-section>
                     {(initialValues.metadata && initialValues.metadata.createdDate) && (
                       <this.cViewMetaData metadata={initialValues.metadata} />
                     )}
-                    <div
-                      className={css.smformItem}
-                      data-test-general-section-name
-                    >
+                    <div data-test-general-section-name>
                       <Field
                         id="input_schedule_name"
                         autoFocus
@@ -270,10 +264,7 @@ class FixedDueDateScheduleForm extends React.Component {
                   id="schedule"
                   label={<FormattedMessage id="ui-circulation.settings.fDDSform.schedule" />}
                 >
-                  <section
-                    className={css.accordionSection}
-                    data-test-fdds-form-schedule-section
-                  >
+                  <section data-test-fdds-form-schedule-section>
                     <FieldArray
                       component={SchedulesList}
                       name="schedules"

--- a/src/settings/FixedDueDateSchedule/components/DetailsSections/ScedulesList/SchedulesList.css
+++ b/src/settings/FixedDueDateSchedule/components/DetailsSections/ScedulesList/SchedulesList.css
@@ -5,7 +5,7 @@
   border-width: 1px;
   border-style: solid;
   width: 100%;
-  margin-bottom: 25px;
+  margin: -1px -1px 25px;
 }
 
 .scheduleHeader {

--- a/src/settings/FixedDueDateSchedule/components/EditSections/components/ScheduleCard/ScheduleCard.css
+++ b/src/settings/FixedDueDateSchedule/components/EditSections/components/ScheduleCard/ScheduleCard.css
@@ -5,7 +5,7 @@
   border-width: 1px;
   border-style: solid;
   width: 100%;
-  margin-bottom: 25px;
+  margin: -1px -1px 25px;
 }
 
 .scheduleHeader {

--- a/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
+++ b/src/settings/LostItemFeePolicy/components/EditSections/LostItemFeeAboutSection/LostItemFeeAboutSection.js
@@ -16,7 +16,7 @@ const LostItemFeeAboutSection = () => (
   >
     <Row>
       <Col
-        xs={3}
+        xs={12}
         data-test-about-section-policy-name
       >
         <Field
@@ -33,7 +33,7 @@ const LostItemFeeAboutSection = () => (
     </Row>
     <Row>
       <Col
-        xs={5}
+        xs={12}
         data-test-about-section-policy-description
       >
         <Field

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
@@ -49,7 +49,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
     <div data-testid="patronNoticeAboutSection">
       <Row>
         <Col
-          xs={8}
+          xs={12}
           data-test-patron-notice-template-name
         >
           <Field
@@ -65,7 +65,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
         </Col>
       </Row>
       <Row>
-        <Col xs={3}>
+        <Col xs={12}>
           <Field
             data-testid="patronNoticesNoticeActive"
             label={formatMessage({ id:'ui-circulation.settings.patronNotices.notice.active' })}
@@ -78,7 +78,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
       </Row>
       <br />
       <Row>
-        <Col xs={8}>
+        <Col xs={12}>
           <Field
             data-testid="patronNoticesNoticeDescription"
             label={formatMessage({ id:'ui-circulation.settings.patronNotices.notice.description' })}
@@ -89,7 +89,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
         </Col>
       </Row>
       <Row>
-        <Col xs={8}>
+        <Col xs={12}>
           <div data-test-template-category>
             <Field
               data-testid="patronNoticesNoticeCategory"

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailSection.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailSection.js
@@ -19,7 +19,7 @@ const PatronNoticeEmailSection = ({ category, locale }) => {
   return (
     <div data-testid="emailAccordionContent">
       <Row>
-        <Col xs={8}>
+        <Col xs={12}>
           <Field
             data-testid="patronNoticesSubject"
             id="input-patron-notice-subject"
@@ -31,7 +31,7 @@ const PatronNoticeEmailSection = ({ category, locale }) => {
         </Col>
       </Row>
       <Row>
-        <Col xs={8}>
+        <Col xs={12}>
           <Field
             data-testid="patronNoticesBody"
             label={<FormattedMessage id="ui-circulation.settings.patronNotices.body" />}

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipAboutSection/StaffSlipAboutSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipAboutSection/StaffSlipAboutSection.js
@@ -17,7 +17,7 @@ const StaffSlipAboutSection = ({ initialValues, disabled }) => {
       data-testid="staffSlipAboutSectionEditTestId"
     >
       <Row>
-        <Col xs={8}>
+        <Col xs={12}>
           <div
             data-test-staff-slip-name
             data-testid="staffSlipName"
@@ -32,7 +32,7 @@ const StaffSlipAboutSection = ({ initialValues, disabled }) => {
       <Row>
         <Col
           data-test-staff-slip-description
-          xs={8}
+          xs={12}
         >
           <Field
             label={<FormattedMessage id="ui-circulation.settings.staffSlips.description" />}

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
@@ -23,7 +23,7 @@ const StaffSlipTemplateContentSection = ({ intl }) => {
 
   return (
     <Row>
-      <Col xs={8}>
+      <Col xs={12}>
         <Field
           label={formatMessage({ id:'ui-circulation.settings.staffSlips.display' })}
           component={TemplateEditor}


### PR DESCRIPTION
## Purpose
Fields use full screen width

## Refs
https://issues.folio.org/browse/UICIRC-917

## Notes
Fields below should use full use screen width:
1. Staff slips (/settings/circulation/staffslips/*?layer=edit)
Description
Template content
2. Fine policies (/settings/circulation/fine-policies?layer=add)
Overdue fine policy name
Description
3. Lost item fee policy (/settings/circulation/lost-item-fee-policy?layer=add)
Lost item fee policy name
Description
4. Patron notices policy (/settings/circulation/patron-notices?layer=add)
Patron notice template name
Description
Category
Subject
Body
5. Fixed due date schedules (/settings/circulation/fixed-due-date-schedules?layer=add)
Fixed due date schedule name
Description
Date range