### PR TITLE
UIREQ-858: Remove unnecessary `recordsRequired` manifest param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Changed translation for token section. Refs UICIRC-911.
 * Fields use full use screen width (part 1). Refs UICIRC-917.
 * Update patron notice policy: Multiples options for "Lost item fee(s) charged". Refs UICIRC-895.
+* Remove unnecessary `recordsRequired` manifest param. Refs UIREQ-858.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/PatronNotices/PatronNotices.js
+++ b/src/settings/PatronNotices/PatronNotices.js
@@ -68,7 +68,6 @@ export class PatronNotices extends React.Component {
       params: {
         query: 'cql.allRecords=1 AND category=""',
       },
-      recordsRequired: MAX_UNPAGED_RESOURCE_COUNT,
       perRequest: MAX_UNPAGED_RESOURCE_COUNT,
     },
     patronNoticePolicies: {

--- a/src/settings/TitleLevelRequests/TitleLevelRequestsForm.js
+++ b/src/settings/TitleLevelRequests/TitleLevelRequestsForm.js
@@ -158,7 +158,6 @@ TitleLevelRequestsForm.manifest = Object.freeze({
     params: {
       query: `cql.allRecords=1 AND category="${patronNoticeCategoryIds.REQUEST}" AND active="true"`,
     },
-    recordsRequired: MAX_UNPAGED_RESOURCE_COUNT,
     perRequest: MAX_UNPAGED_RESOURCE_COUNT,
   },
   requests: {


### PR DESCRIPTION
## Purpose
Remove unnecessary `recordsRequired` manifest param

## Refs
[UIREQ-858](https://issues.folio.org/browse/UIREQ-858)
