### PR TITLE
UICIRC-838: Make the token feeCharge.additionalInfo selectable for automated f/f charge notice templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Changed translation for token section. Refs UICIRC-911.
 * Fields use full use screen width (part 1). Refs UICIRC-917.
 * Update patron notice policy: Multiples options for "Lost item fee(s) charged". Refs UICIRC-895.
+* Make the token feeCharge.additionalInfo selectable for automated f/f charge notice templates. Refs UICIRC-838.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -358,6 +358,7 @@ const getTokens = (locale) => ({
       allowedFor: [
         patronNoticeCategoryIds.FEE_FINE_CHARGE,
         patronNoticeCategoryIds.FEE_FINE_ACTION,
+        patronNoticeCategoryIds.AUTOMATED_FEE_FINE_CHARGE,
         patronNoticeCategoryIds.AUTOMATED_FEE_FINE_ADJUSTMENT,
       ],
     },


### PR DESCRIPTION
## Purpose
Make the token feeCharge.additionalInfo selectable for automated f/f charge notice templates

## Refs
https://issues.folio.org/browse/UICIRC-838