### PR TITLE
UICIRC-921: Fix Circ rules editor crashes when certain special characters entered in filter box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Update record metadata object when saving circulation rules. Refs UICIRC-858.
 * Add extra fields to reminder fees policy. Refs UICIRC-955.
 * Add New setting to enable hold requests to fail. Refs UICIRC-949.
+* Fix Circ rules editor crashes when certain special characters entered in filter box. Refs UICIRC-921.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/lib/RuleEditor/RulesEditor.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.js
@@ -152,6 +152,9 @@ export const hintOptions = {
   }
 };
 
+// eslint-disable-next-line no-useless-escape
+export const escapingForSpecialCharactersWhichCanBreakRegExp = (string = '') => string.replace(/[\\?()\[\]+*]/g, '\\$&');
+
 class RulesEditor extends React.Component {
   constructor(props) {
     super(props);
@@ -276,7 +279,8 @@ class RulesEditor extends React.Component {
 
     // scan rows with '#'
     const ranges = [];
-    const re = new RegExp(filter, 'i');
+    const filterStringWithEscaping = escapingForSpecialCharactersWhichCanBreakRegExp(filter);
+    const re = new RegExp(filterStringWithEscaping, 'i');
     let found = true;
     const rng = {};
 

--- a/src/settings/lib/RuleEditor/RulesEditor.test.js
+++ b/src/settings/lib/RuleEditor/RulesEditor.test.js
@@ -16,7 +16,9 @@ import RulesEditor, {
   handleEnter,
   selectHint,
   handleTab,
-  createTriangle, hintOptions,
+  createTriangle,
+  hintOptions,
+  escapingForSpecialCharactersWhichCanBreakRegExp,
 } from './RulesEditor';
 import {
   rulesHint,
@@ -904,6 +906,49 @@ describe('RulesEditor', () => {
           expect(Codemirror.showHint).not.toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe('escapingForSpecialCharactersWhichCanBreakRegExp', () => {
+    it('should return empty string', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp()).toBe('');
+    });
+
+    it('should escape \\', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('\\')).toBe('\\\\');
+    });
+
+    it('should escape ?', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('?')).toBe('\\?');
+    });
+
+    it('should escape (', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('(')).toBe('\\(');
+    });
+
+    it('should escape )', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp(')')).toBe('\\)');
+    });
+
+    it('should escape [', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('[')).toBe('\\[');
+    });
+
+    it('should escape ]', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp(']')).toBe('\\]');
+    });
+
+    it('should escape +', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('+')).toBe('\\+');
+    });
+
+    it('should escape *', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('*')).toBe('\\*');
+    });
+
+    it('should escape special characters in string', () => {
+      expect(escapingForSpecialCharactersWhichCanBreakRegExp('(test) + [test] * ? \\ (){}[]-_=+<>/?.,~'))
+        .toBe('\\(test\\) \\+ \\[test\\] \\* \\? \\\\ \\(\\){}\\[\\]-_=\\+<>/\\?.,~');
     });
   });
 });


### PR DESCRIPTION
## Purpose
Fix Circ rules editor crashes when certain special characters entered in filter box

## Refs
https://issues.folio.org/browse/UICIRC-921