### PR TITLE
UICIRC-963: Allowing Selection of Some Pickup Service Points as Optional When Creating a New Request Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add New setting to enable hold requests to fail. Refs UICIRC-949.
 * Fix Circ rules editor crashes when certain special characters entered in filter box. Refs UICIRC-921.
 * Prevent editing of shared settings from outside "Consortium manager". Refs UICIRC-962.
+* Allowing Selection of Some Pickup Service Points as Optional When Creating a New Request Policy. Refs UICIRC-963.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -510,6 +510,8 @@ export const feeFineNoticesTriggeringEvents = [
   },
 ];
 
+export const MAX_RECORDS = '10000';
+
 export const MAX_UNPAGED_RESOURCE_COUNT = '1000';
 
 export default '';
@@ -563,4 +565,9 @@ export const TLR_FIELDS_FOR_RESET = [
 
 export const RECORD_SOURCE = {
   CONSORTIUM: 'consortium',
+};
+
+export const REQUEST_TYPE_RULES = {
+  ALLOW_ALL: 'allowAll',
+  ALLOW_SOME: 'allowSome',
 };

--- a/src/settings/Models/RequestPolicy/RequestPolicy.js
+++ b/src/settings/Models/RequestPolicy/RequestPolicy.js
@@ -10,6 +10,7 @@ export default class RequestPolicy {
     this.name = policy.name;
     this.description = policy.description;
     this.requestTypes = policy.requestTypes;
+    this.allowedServicePoints = policy.allowedServicePoints;
     this.metadata = new Metadata(policy.metadata);
   }
 }

--- a/src/settings/Models/RequestPolicy/RequestPolicy.test.js
+++ b/src/settings/Models/RequestPolicy/RequestPolicy.test.js
@@ -7,6 +7,9 @@ describe('RequestPolicy', () => {
     name: 'name',
     description: 'description',
     requestTypes: 'type',
+    allowedServicePoints: {
+      Hold: ['holdId']
+    },
     metadata: {
       createdByUserId: 'id',
       createdDate: 'date',
@@ -26,6 +29,7 @@ describe('RequestPolicy', () => {
       name: undefined,
       description: undefined,
       requestTypes: undefined,
+      allowedServicePoints: undefined,
       metadata: {
         createdByUserId: undefined,
         createdDate: undefined,

--- a/src/settings/RequestPolicy/RequestPolicyForm.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.js
@@ -28,6 +28,10 @@ import {
   isEditLayer,
   validateUniqueNameById,
 } from '../utils/utils';
+import {
+  REQUEST_TYPE_RULES,
+  requestPolicyTypes,
+} from '../../constants';
 
 import css from './RequestPolicyForm.css';
 
@@ -45,6 +49,10 @@ class RequestPolicyForm extends React.Component {
     location: PropTypes.shape({
       search: PropTypes.string.isRequired,
     }).isRequired,
+    parentResources: PropTypes.shape({
+      requestPolicies: PropTypes.object,
+      servicePoints: PropTypes.object,
+    }).isRequired,
   };
 
   static defaultProps = {
@@ -58,7 +66,28 @@ class RequestPolicyForm extends React.Component {
       sections: {
         generalRequestPolicyForm: true,
       },
+      requestTypesRules: requestPolicyTypes.reduce((acc, name) => {
+        acc[name] = name;
+
+        return acc;
+      }, {}),
     };
+  }
+
+  componentDidMount() {
+    this.setRequestTypesRules();
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      parentResources: {
+        requestPolicies,
+      },
+    } = this.props;
+
+    if (prevProps.parentResources.requestPolicies.records !== requestPolicies.records) {
+      this.setRequestTypesRules();
+    }
   }
 
   handleSectionToggle = ({ id }) => {
@@ -66,6 +95,51 @@ class RequestPolicyForm extends React.Component {
       sections[id] = !sections[id];
       return { sections };
     });
+  };
+
+  setRequestTypesRules = () => {
+    const {
+      parentResources: {
+        requestPolicies,
+      },
+      initialValues,
+    } = this.props;
+    const allowedServicePoints = requestPolicies.records
+      .find(({ id }) => id === initialValues.id)?.allowedServicePoints;
+
+    if (allowedServicePoints) {
+      const selectedRequestTypes = Object.keys(allowedServicePoints);
+      const rules = {};
+
+      selectedRequestTypes.forEach(requestType => rules[requestType] = REQUEST_TYPE_RULES.ALLOW_SOME);
+
+      this.setState((prevState) => ({
+        requestTypesRules: {
+          ...prevState.requestTypesRules,
+          ...rules,
+        },
+      }));
+    }
+  };
+
+  handleChangeRequestTypesRules = (e, requestType) => {
+    const {
+      form: {
+        change,
+      },
+    } = this.props;
+    const {
+      name,
+      value,
+    } = e.target;
+
+    this.setState((prevState) => ({
+      requestTypesRules: {
+        ...prevState.requestTypesRules,
+        [requestType]: value,
+      },
+    }));
+    change(name, value);
   };
 
   handleExpandAll = (sections) => {
@@ -108,17 +182,20 @@ class RequestPolicyForm extends React.Component {
       intl: {
         formatMessage,
       },
+      parentResources: {
+        servicePoints,
+        requestPolicies,
+      },
     } = this.props;
-
-    const { sections } = this.state;
-
+    const {
+      sections,
+      requestTypesRules,
+    } = this.state;
     const { values = {} } = getState();
     const policy = new RequestPolicy(values);
-
     const panelTitle = policy.id
       ? policy.name
       : formatMessage({ id: 'ui-circulation.settings.requestPolicy.createEntryLabel' });
-
     const footerPaneProps = {
       pristine,
       submitting,
@@ -128,6 +205,8 @@ class RequestPolicyForm extends React.Component {
     if (isEditLayer(search) && !id) {
       return null;
     }
+
+    const isDataLoading = servicePoints.isPending || requestPolicies.isPending;
 
     return (
       <form
@@ -164,6 +243,10 @@ class RequestPolicyForm extends React.Component {
                   metadata={policy.metadata}
                   connect={stripes.connect}
                   validateName={this.validateName}
+                  handleChangeRequestTypesRules={this.handleChangeRequestTypesRules}
+                  requestTypesRules={requestTypesRules}
+                  servicePoints={servicePoints.records}
+                  isLoading={isDataLoading}
                 />
               </AccordionSet>
             </>

--- a/src/settings/RequestPolicy/RequestPolicyForm.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.js
@@ -111,7 +111,9 @@ class RequestPolicyForm extends React.Component {
       const selectedRequestTypes = Object.keys(allowedServicePoints);
       const rules = {};
 
-      selectedRequestTypes.forEach(requestType => rules[requestType] = REQUEST_TYPE_RULES.ALLOW_SOME);
+      selectedRequestTypes.forEach(requestType => {
+        rules[requestType] = REQUEST_TYPE_RULES.ALLOW_SOME;
+      });
 
       this.setState((prevState) => ({
         requestTypesRules: {

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -78,6 +78,23 @@ describe('RequestPolicyForm', () => {
     location: {
       search: '',
     },
+    parentResources: {
+      requestPolicies: {
+        records: [
+          {
+            id: 'policyId',
+            allowedServicePoints: {
+              Page: ['servicePointId'],
+            },
+          }
+        ],
+        isPending: false,
+      },
+      servicePoints: {
+        records: [],
+        isPending: false,
+      },
+    },
   };
 
   afterEach(() => {
@@ -92,6 +109,7 @@ describe('RequestPolicyForm', () => {
   describe('with default props', () => {
     const form = {
       getState: jest.fn(() => ({})),
+      change: jest.fn(),
     };
 
     beforeEach(() => {
@@ -181,6 +199,7 @@ describe('RequestPolicyForm', () => {
     };
     const form = {
       getState: jest.fn(() => ({ values: initialValues })),
+      change: jest.fn(),
     };
 
     const testPolicy = new RequestPolicy(initialValues);
@@ -309,6 +328,7 @@ describe('RequestPolicyForm', () => {
   describe('Edit layer without data', () => {
     const form = {
       getState: jest.fn(() => ({})),
+      change: jest.fn(),
     };
     const props = {
       ...defaultProps,

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -22,7 +22,17 @@ import {
 import RequestPolicy from '../Models/RequestPolicy';
 
 jest.mock('./components', () => ({
-  GeneralSection: jest.fn(() => null),
+  GeneralSection: jest.fn(({
+    handleChangeRequestTypesRules,
+    ...rest
+  }) => (
+    <div {...rest}>
+      <input
+        data-testid="generalSectionInput"
+        onChange={handleChangeRequestTypesRules}
+      />
+    </div>
+  )),
 }));
 jest.mock('../components', () => ({
   CancelButton: jest.fn(() => null),
@@ -57,6 +67,7 @@ describe('RequestPolicyForm', () => {
   const testIds = {
     form: 'form',
     accordionSet: 'accordionSet',
+    generalSectionInput: 'generalSectionInput',
   };
   const okapi = {
     url: 'url',
@@ -227,6 +238,20 @@ describe('RequestPolicyForm', () => {
       expect(GeneralSection).toHaveBeenCalledWith(expect.objectContaining({
         metadata: testPolicy.metadata,
       }), {});
+    });
+
+    it('should trigger "form.change" with correct arguments', () => {
+      const generalSectionInput = screen.getByTestId(testIds.generalSectionInput);
+      const event = {
+        target: {
+          value: 'testValue',
+          name: 'testName',
+        },
+      };
+
+      fireEvent.change(generalSectionInput, event);
+
+      expect(form.change).toHaveBeenCalledWith(event.target.name, event.target.value);
     });
 
     describe('validation check', () => {

--- a/src/settings/RequestPolicy/RequestPolicySettings.js
+++ b/src/settings/RequestPolicy/RequestPolicySettings.js
@@ -36,8 +36,7 @@ export const parseInitialValues = (servicePoints) => (values = {}) => {
         .map((id) => ({
           label: findServicePointById(servicePoints, id)?.name,
           value: id,
-        })
-      );
+        }));
     } else {
       requestTypesRules[name] = REQUEST_TYPE_RULES.ALLOW_ALL;
     }

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.js
@@ -52,7 +52,7 @@ export const renderTypes = (props) => {
   } = props;
   const dataOptions = getDataOptions(servicePoints);
   const onChangeRequestTypeRules = (name) => (e) => {
-    handleChangeRequestTypesRules(e, name)
+    handleChangeRequestTypesRules(e, name);
   };
   const items = requestPolicyTypes.map((name, index) => {
     const isAllowedSomeServicePoints = requestTypesRules[name] === REQUEST_TYPE_RULES.ALLOW_SOME;

--- a/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
+++ b/src/settings/RequestPolicy/components/EditSections/GeneralSection/GeneralSection.test.js
@@ -18,8 +18,12 @@ import {
 import { Metadata } from '../../../../components';
 import GeneralSection, {
   renderTypes,
+  getDataOptions,
 } from './GeneralSection';
-import { requestPolicyTypes } from '../../../../../constants';
+import {
+  REQUEST_TYPE_RULES,
+  requestPolicyTypes,
+} from '../../../../../constants';
 
 jest.mock('../../../../components', () => ({
   Metadata: jest.fn(() => null),
@@ -47,11 +51,25 @@ describe('GeneralSection', () => {
   const mockedConnect = jest.fn();
   const mockedValidateName = jest.fn();
   const getById = (id) => within(screen.getByTestId(id));
+  const renderTypesProps = {
+    handleChangeRequestTypesRules: jest.fn(),
+    requestTypesRules: {
+      Hold: REQUEST_TYPE_RULES.ALLOW_ALL,
+    },
+    servicePoints: [
+      {
+        id: 'id',
+        name: 'name',
+      }
+    ],
+    isLoading: false,
+  };
   const defaultProps = {
     isOpen: true,
     metadata: mockedMetadata,
     connect: mockedConnect,
     validateName: mockedValidateName,
+    ...renderTypesProps,
   };
 
   afterEach(() => {
@@ -115,6 +133,7 @@ describe('GeneralSection', () => {
       const expectedResult = {
         name: 'requestTypes',
         component: renderTypes,
+        ...renderTypesProps,
       };
 
       expect(FieldArray).toHaveBeenLastCalledWith(expectedResult, {});
@@ -143,7 +162,6 @@ describe('GeneralSection', () => {
   describe('renderTypes', () => {
     const policyTypesLabelId = 'ui-circulation.settings.requestPolicy.policyTypes';
     const polycyTypeTest = (name, index) => {
-      const number = index + 1;
       const expectedResult = {
         component: Checkbox,
         type: 'checkbox',
@@ -152,14 +170,19 @@ describe('GeneralSection', () => {
         name: `requestTypes[${index}]`,
       };
 
-      it(`should render ${number} policy with right props`, () => {
-        expect(Field).toHaveBeenNthCalledWith(number, expectedResult, {});
+      it(`should render ${name} policy with correct props`, () => {
+        expect(Field).toHaveBeenCalledWith(expectedResult, {});
       });
     };
 
     beforeEach(() => {
       render(
-        renderTypes()
+        renderTypes({
+          ...renderTypesProps,
+          fields: {
+            value: [true],
+          },
+        })
       );
     });
 
@@ -168,5 +191,31 @@ describe('GeneralSection', () => {
     });
 
     requestPolicyTypes.forEach(polycyTypeTest);
+  });
+
+  describe('getDataOptions', () => {
+    it('should correctly modify service points', () => {
+      const name = 'name';
+      const id = 'id';
+      const servicePoints = [
+        {
+          name,
+          id,
+          test: 'test',
+        }
+      ];
+      const expectedResult = [
+        {
+          label: name,
+          value: id,
+        }
+      ];
+
+      expect(getDataOptions(servicePoints)).toEqual(expectedResult);
+    });
+
+    it('should return empty array', () => {
+      expect(getDataOptions()).toEqual([]);
+    });
   });
 });

--- a/src/settings/RequestPolicy/utils/normalize.js
+++ b/src/settings/RequestPolicy/utils/normalize.js
@@ -1,4 +1,8 @@
-import { requestPolicyTypes } from '../../../constants';
+import { isEmpty } from 'lodash';
+import {
+  REQUEST_TYPE_RULES,
+  requestPolicyTypes,
+} from '../../../constants';
 
 const normalize = (policy) => {
   const requestTypes = policy.requestTypes.reduce((acc, type, index) => {
@@ -7,8 +11,30 @@ const normalize = (policy) => {
     }
     return acc;
   }, []);
+  const allowedServicePoints = {};
 
-  return { ...policy, requestTypes };
+  requestTypes.forEach((key) => {
+    if (policy.allowedServicePoints[key] && policy.requestTypesRules[key] === REQUEST_TYPE_RULES.ALLOW_SOME) {
+      allowedServicePoints[key] = policy.allowedServicePoints[key].map(({ value }) => value);
+    }
+  });
+
+  delete policy.requestTypesRules;
+
+  if (isEmpty(allowedServicePoints)) {
+    delete policy.allowedServicePoints;
+
+    return {
+      ...policy,
+      requestTypes,
+    };
+  }
+
+  return {
+    ...policy,
+    requestTypes,
+    allowedServicePoints,
+  };
 };
 
 export default normalize;

--- a/src/settings/RequestPolicy/utils/normalize.test.js
+++ b/src/settings/RequestPolicy/utils/normalize.test.js
@@ -1,33 +1,70 @@
 import normalize from './normalize';
-import { requestPolicyTypes } from '../../../constants';
+import {
+  REQUEST_TYPE_RULES,
+  requestPolicyTypes,
+} from '../../../constants';
 
 describe('normalize', () => {
-  describe('when "type" is a correct value', () => {
-    const policy = {
-      test: 'test',
-      requestTypes: ['Hold'],
-    };
+  const holdRequestType = requestPolicyTypes[0];
+  const basePolicy = {
+    allowedServicePoints: {
+      [holdRequestType]: [
+        {
+          value: REQUEST_TYPE_RULES.ALLOW_SOME,
+        }
+      ],
+    },
+    requestTypesRules: {
+      [holdRequestType]: REQUEST_TYPE_RULES.ALLOW_SOME,
+    },
+    requestTypes: [holdRequestType],
+  };
 
+  describe('when "type" is a correct value', () => {
     it('should return object with not empty "requestTypes" field', () => {
       const expectedResult = {
-        ...policy,
-        requestTypes: [requestPolicyTypes[0]],
+        ...basePolicy,
+        allowedServicePoints: {
+          [holdRequestType]: [REQUEST_TYPE_RULES.ALLOW_SOME],
+        },
+        requestTypesRules: undefined,
+      };
+
+      expect(normalize(basePolicy)).toEqual(expectedResult);
+    });
+  });
+
+  describe('when "type" is not a correct value', () => {
+    const policy = {
+      ...basePolicy,
+      requestTypes: [''],
+    };
+
+    it('should return object with "requestTypes" field as empty array', () => {
+      const expectedResult = {
+        ...basePolicy,
+        requestTypesRules: undefined,
+        allowedServicePoints: undefined,
+        requestTypes: [],
       };
 
       expect(normalize(policy)).toEqual(expectedResult);
     });
   });
 
-  describe('when "type" is not a correct value', () => {
+  describe('when policy allows all service points', () => {
     const policy = {
-      test: 'test',
-      requestTypes: [''],
+      ...basePolicy,
+      requestTypesRules: {
+        [holdRequestType]: REQUEST_TYPE_RULES.ALLOW_ALL,
+      },
     };
 
-    it('should return object with "requestTypes" field as empty array', () => {
+    it('should return policy without allowed service points', () => {
       const expectedResult = {
-        ...policy,
-        requestTypes: [],
+        ...basePolicy,
+        requestTypesRules: undefined,
+        allowedServicePoints: undefined,
       };
 
       expect(normalize(policy)).toEqual(expectedResult);

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -110,6 +110,7 @@ jest.mock('@folio/stripes/components', () => ({
   PaneMenu: jest.fn((props) => <div>{props.children}</div>),
   Paneset: jest.fn(({ children }) => (<div>{children}</div>)),
   RadioButton: jest.fn(() => <input type="radio" />),
+  RadioButtonGroup: jest.fn(({ children }) => (<div>{children}</div>)),
   Row: jest.fn(({ children, ...rest }) => <div {...rest}>{children}</div>),
   Select: jest.fn(() => <select> </select>),
   TextArea: jest.fn((props) => <textarea {...props} />),

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -301,8 +301,11 @@
   "settings.requestPolicy.saveAndClose": "Save",
   "settings.requestPolicy.createEntryLabel": "New request policy",
   "settings.requestPolicy.errors.nameExists": "A request policy with this name already exists",
+  "settings.requestPolicy.errors.selectServicePoint": "Please select at least one service point",
   "settings.requestPolicy.cannotDelete.label": "Request policy cannot be deleted",
   "settings.requestPolicy.cannotDelete.message": "This request policy is used by circulation rules and it cannot be deleted",
+  "settings.requestPolicy.requestTypes.allowAll": "Allow all pickup service points",
+  "settings.requestPolicy.requestTypes.allowSome": "Allow some pickup service points",
 
   "settings.titleLevelRequests.paneTitle": "Title level requests",
   "settings.titleLevelRequests.allow": "Allow title level requests",


### PR DESCRIPTION
## Purpose
Allowing the selection of some Service Points as optional when creating a new request policy.
A user will be able to allow all available service points to some request type or/and a user will be able to allow only some service points to some request type.

## Refs
[UICIRC-963](https://issues.folio.org/browse/UICIRC-963)

## Screenshots
![alignment](https://github.com/folio-org/ui-circulation/assets/42437614/9404962d-9c6c-4585-8edb-ac0dc4fc5bcd)
