### PR TITLE
UICIRC-968: Upgrade babel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fix Circ rules editor crashes when certain special characters entered in filter box. Refs UICIRC-921.
 * Prevent editing of shared settings from outside "Consortium manager". Refs UICIRC-962.
 * Allowing Selection of Some Pickup Service Points as Optional When Creating a New Request Policy. Refs UICIRC-963.
+* Upgrade babel config. Refs UICIRC-968.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/package.json
+++ b/package.json
@@ -336,9 +336,6 @@
   "devDependencies": {
     "@babel/core": "^7.18.2",
     "@babel/eslint-parser": "^7.18.2",
-    "@babel/plugin-transform-class-properties": "^7.13.0",
-    "@babel/plugin-proposal-decorators": "^7.13.5",
-    "@babel/plugin-transform-runtime": "^7.13.10",
     "@folio/eslint-config-stripes": "^6.0.0",
     "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.0.0",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,15 +1,5 @@
+const { babelOptions } = require('@folio/stripes-cli');
+
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    ['@babel/preset-react', {
-      'runtime': 'automatic'
-    }],
-  ],
-  plugins: [
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-transform-class-properties', { loose: true }],
-    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
-    ['@babel/plugin-transform-private-methods', { loose: true }],
-    '@babel/plugin-transform-runtime',
-  ],
+  ...babelOptions,
 };


### PR DESCRIPTION
## Purpose
Upgrade babel config

## Approach
Pulling the babel config directly from stripes-webpack via stripes-cli, in order to guarantee the babel plugins, versions, and config are all aligned.

## Refs
https://issues.folio.org/browse/UICIRC-968