### PR TITLE
UICIRC-967: Get rid of automatic alert after request failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add possible for run axe tests. Refs UICIRC-965.
 * Update Node.js to v18 in GitHub Actions. Refs UICIRC-969.
 * *BREAKING* Upgrade React to v18. Refs UICIRC-966.
+* Get rid of automatic alert after request failure. UICIRC-967.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/RequestPolicy/RequestPolicySettings.js
+++ b/src/settings/RequestPolicy/RequestPolicySettings.js
@@ -60,6 +60,7 @@ class RequestPolicySettings extends React.Component {
         query: 'cql.allRecords=1',
         limit: MAX_UNPAGED_RESOURCE_COUNT,
       },
+      throwErrors: false,
     },
     circulationRules: {
       type: 'okapi',


### PR DESCRIPTION
## Purpose
When a user tries to create/edit request policy he should see only a callout with message at the bottom of the screen. An automatic alert should not be shown (see screenshots below).

## Refs
[UICIRC-967](https://issues.folio.org/browse/UICIRC-967)

## Screenshots

### Before
![image](https://github.com/folio-org/ui-circulation/assets/42437614/07f5e0fe-08ac-428f-9a58-7e7306c2cae1)


### After
![2023-08-28_19h14_27](https://github.com/folio-org/ui-circulation/assets/42437614/5c4092eb-9b44-45bf-89de-0c2a4158b12a)
