### PR TITLE
UICIRC-972: Make visible selected service points after page reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add possible for run axe tests. Refs UICIRC-965.
 * Update Node.js to v18 in GitHub Actions. Refs UICIRC-969.
 * *BREAKING* Upgrade React to v18. Refs UICIRC-966.
+* Make visible selected service points after page reloading. Refs UICIRC-972.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/src/settings/RequestPolicy/RequestPolicyForm.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.js
@@ -48,6 +48,7 @@ class RequestPolicyForm extends React.Component {
     intl: PropTypes.object.isRequired,
     location: PropTypes.shape({
       search: PropTypes.string.isRequired,
+      pathname: PropTypes.string.isRequired,
     }).isRequired,
     parentResources: PropTypes.shape({
       requestPolicies: PropTypes.object,
@@ -102,10 +103,10 @@ class RequestPolicyForm extends React.Component {
       parentResources: {
         requestPolicies,
       },
-      initialValues,
+      location,
     } = this.props;
     const allowedServicePoints = requestPolicies.records
-      .find(({ id }) => id === initialValues.id)?.allowedServicePoints;
+      .find(({ id }) => location.pathname.includes(id))?.allowedServicePoints;
 
     if (allowedServicePoints) {
       const selectedRequestTypes = Object.keys(allowedServicePoints);

--- a/src/settings/RequestPolicy/RequestPolicyForm.test.js
+++ b/src/settings/RequestPolicy/RequestPolicyForm.test.js
@@ -79,6 +79,7 @@ describe('RequestPolicyForm', () => {
   };
   const onCancel = jest.fn();
   const handleSubmit = jest.fn();
+  const pathname = '/policyId/test';
   const defaultProps = {
     okapi,
     pristine: true,
@@ -88,6 +89,7 @@ describe('RequestPolicyForm', () => {
     handleSubmit,
     location: {
       search: '',
+      pathname,
     },
     parentResources: {
       requestPolicies: {
@@ -223,6 +225,7 @@ describe('RequestPolicyForm', () => {
           form={form}
           location={{
             search: 'edit',
+            pathname,
           }}
         />
       );
@@ -359,6 +362,7 @@ describe('RequestPolicyForm', () => {
       ...defaultProps,
       location: {
         search: 'edit',
+        pathname,
       },
     };
 


### PR DESCRIPTION
## Purpose
When a user edits a request policy that already has "Allow some pickup service points" selected with chosen service point(s) and if a user updates the page he should see service point(s) that was/were initially added to the request policy. But a user could not see it due to lack of data inside "initialValues" property.

## Approach
I used "location" property to find a correct request policy id.

## Refs
[UICIRC-972](https://issues.folio.org/browse/UICIRC-972)