### PR TITLE
UICIRC-971: Restore previously deleted Jest/RTL tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Get rid of automatic alert after request failure. UICIRC-967.
 * Change enums for notice method. UICIRC-973.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UICIRC-977.
+* Restore previously deleted Jest/RTL tests that were failing. Refs UICIRC-971.
 
 ## [8.0.1](https://github.com/folio-org/ui-circulation/tree/v8.0.1) (2023-03-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.0...v8.0.1)

--- a/package.json
+++ b/package.json
@@ -349,7 +349,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.4",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
     "@folio/stripes-template-editor": "^3.2.0",

--- a/src/settings/PatronNotices/PatronNotices.test.js
+++ b/src/settings/PatronNotices/PatronNotices.test.js
@@ -1,0 +1,211 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+import { EntryManager } from '@folio/stripes/smart-components';
+
+// eslint-disable-next-line import/no-named-as-default
+import PatronNotices, {
+  isTemplateExist,
+  PatronNotices as PatronNoticesClass,
+} from './PatronNotices';
+import PatronNoticeDetail from './PatronNoticeDetail';
+import PatronNoticeForm from './PatronNoticeForm';
+import {
+  MAX_UNPAGED_RESOURCE_COUNT,
+  patronNoticeCategories,
+} from '../../constants';
+
+jest.mock('./PatronNoticeDetail', () => () => null);
+jest.mock('./PatronNoticeForm', () => () => null);
+
+describe('PatronNotices', () => {
+  const labelIds = {
+    close: 'ui-circulation.settings.common.close',
+    header: 'ui-circulation.settings.patronNotices.denyDelete.header',
+    body: 'ui-circulation.settings.patronNotices.denyDelete.body',
+  };
+  const mockedLabel = 'testLabel';
+  const mockedEntries = {
+    records: [
+      {
+        name: 'Bob',
+      },
+      {
+        name: 'John',
+      },
+      {
+        name: 'Ann',
+      },
+    ],
+  };
+  const mockedPatronNoticePolicies = {
+    entries: {
+      records: [{
+        test: 'testPatronNoticePoliciesData',
+      }],
+    },
+  };
+  const mockedMutator = {
+    entries: {
+      POST: jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  };
+  const defaultProps = {
+    label: mockedLabel,
+    resources: {
+      entries: mockedEntries,
+      patronNoticePolicies: mockedPatronNoticePolicies,
+    },
+    mutator: mockedMutator,
+  };
+
+  afterEach(() => {
+    EntryManager.mockClear();
+  });
+
+  it('"EntryManager" should be executed with correct props', () => {
+    const expectedNameOrder = [
+      {
+        name: 'Ann',
+      },
+      {
+        name: 'Bob',
+      },
+      {
+        name: 'John',
+      },
+    ];
+
+    render(
+      <PatronNotices
+        {...defaultProps}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      parentMutator: mockedMutator,
+      entryList: expectedNameOrder,
+      detailComponent: PatronNoticeDetail,
+      paneTitle: mockedLabel,
+      entryLabel: mockedLabel,
+      entryFormComponent: PatronNoticeForm,
+      defaultEntry: {
+        active: true,
+        outputFormats: ['text/html'],
+        templateResolver: 'mustache',
+        category: patronNoticeCategories[0].id,
+      },
+      nameKey: 'name',
+      permissions: {
+        put: 'ui-circulation.settings.notice-templates',
+        post: 'ui-circulation.settings.notice-templates',
+        delete: 'ui-circulation.settings.notice-templates',
+      },
+      enableDetailsActionMenu: true,
+      editElement: 'both',
+      prohibitItemDelete: {
+        close: labelIds.close,
+        label: labelIds.header,
+        message: labelIds.body,
+      },
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "records" in "entries"', () => {
+    render(
+      <PatronNotices
+        {...defaultProps}
+        resources={{
+          ...defaultProps.resources,
+          entries: {},
+        }}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  it('should execute "EntryManager" with correct props when no "entries" in "resources"', () => {
+    render(
+      <PatronNotices
+        {...defaultProps}
+        resources={{
+          patronNoticePolicies: mockedPatronNoticePolicies,
+        }}
+      />
+    );
+
+    expect(EntryManager).toBeCalledWith(expect.objectContaining({
+      entryList: [],
+    }), {});
+  });
+
+  describe('manifest', () => {
+    describe('patronNoticePolicies', () => {
+      it('should have limit from config', () => {
+        const maxUnpagedResourceCount = 10;
+        const limitProps = {
+          stripes: {
+            config: {
+              maxUnpagedResourceCount,
+            }
+          }
+        };
+        const result = PatronNoticesClass.manifest.patronNoticePolicies.params.limit('', '', '', '', limitProps);
+
+        expect(result).toBe(maxUnpagedResourceCount);
+      });
+
+      it('should have default limit', () => {
+        const limitProps = {
+          stripes: {
+            config: {}
+          }
+        };
+        const result = PatronNoticesClass.manifest.patronNoticePolicies.params.limit('', '', '', '', limitProps);
+
+        expect(result).toBe(MAX_UNPAGED_RESOURCE_COUNT);
+      });
+    });
+  });
+
+  describe('isTemplateExist', () => {
+    const templateId = 'templateId';
+    const commonNoticePolicies = {
+      loanNotices: [{
+        templateId: '1',
+      }],
+      requestNotices: [{
+        templateId: '2',
+      }],
+    };
+
+    describe('when template already exists', () => {
+      it('should return true', () => {
+        const noticePolicies = [{
+          ...commonNoticePolicies,
+          feeFineNotices: [{
+            templateId,
+          }],
+        }];
+
+        expect(isTemplateExist(templateId, noticePolicies)).toBe(true);
+      });
+    });
+
+    describe('when template does not exist', () => {
+      it('should return false', () => {
+        const noticePolicies = [{
+          ...commonNoticePolicies,
+          feeFineNotices: [{
+            templateId: '3',
+          }],
+        }];
+
+        expect(isTemplateExist(templateId, noticePolicies)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
@@ -1,10 +1,10 @@
+import { Field } from 'react-final-form';
+
 import {
   render,
   screen,
   within,
 } from '@folio/jest-config-stripes/testing-library/react';
-
-import { Field } from 'react-final-form';
 import {
   TextField,
   Row,

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
@@ -1,0 +1,89 @@
+import {
+  render,
+  screen,
+  within,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import { Field } from 'react-final-form';
+import {
+  TextField,
+  Row,
+  Col,
+} from '@folio/stripes/components';
+import { TemplateEditor } from '@folio/stripes-template-editor';
+
+import { componentPropsCheck } from '../../../../../../test/jest/helpers';
+import PatronNoticeEmailSection from './PatronNoticeEmailSection';
+import TokensList from '../../../TokensList';
+
+const mockGetTokensReturnValue = 'getTokensReturnValue';
+
+jest.mock('../../../tokens', () => jest.fn(() => mockGetTokensReturnValue));
+jest.mock('../../../TokensList', () => jest.fn(() => null));
+jest.mock('@folio/stripes-template-editor', () => ({
+  TemplateEditor: jest.fn(() => null),
+}));
+
+describe('PatronNoticeEmailEditSection', () => {
+  const categoryValue = 'testCategory';
+  const testIds = {
+    emailAccordionContent: 'emailAccordionContent',
+    patronNoticesSubject: 'patronNoticesSubject',
+    patronNoticesBody: 'patronNoticesBody',
+  };
+  const labelIds = {
+    patronNoticesSubject: 'ui-circulation.settings.patronNotices.subject',
+    patronNoticesBody: 'ui-circulation.settings.patronNotices.body',
+  };
+  const getItemByTestId = (id) => within(screen.getByTestId(id));
+
+  beforeEach(() => {
+    render(
+      <PatronNoticeEmailSection
+        category="testCategory"
+        locale="en"
+      />
+    );
+  });
+
+  afterEach(() => {
+    Row.mockClear();
+    Col.mockClear();
+    Field.mockClear();
+    TextField.mockClear();
+  });
+
+  it('should render component', () => {
+    expect(screen.getByTestId(testIds.emailAccordionContent)).toBeVisible();
+  });
+
+  it('should render "Subject" label', () => {
+    expect(getItemByTestId(testIds.patronNoticesSubject).getByText(labelIds.patronNoticesSubject)).toBeVisible();
+  });
+
+  it('should trigger Field component for notice subject with correct props', () => {
+    componentPropsCheck(Field, testIds.patronNoticesSubject, {
+      id: 'input-patron-notice-subject',
+      component: TextField,
+      required: true,
+      name: 'localizedTemplates.en.header',
+    }, true);
+  });
+
+  it('should render "Body" label', () => {
+    expect(getItemByTestId(testIds.patronNoticesBody).getByText(labelIds.patronNoticesBody)).toBeVisible();
+  });
+
+  it('should trigger Field component for patron notices body with correct props', () => {
+    componentPropsCheck(Field, testIds.patronNoticesBody, {
+      'data-testid': 'patronNoticesBody',
+      required: true,
+      name: 'localizedTemplates.en.body',
+      id: 'input-email-template-body',
+      component: TemplateEditor,
+      tokens: mockGetTokensReturnValue,
+      tokensList: TokensList,
+      selectedCategory: categoryValue,
+    }, true);
+  });
+});

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
@@ -1,0 +1,43 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+import { TemplateEditor } from '@folio/stripes-template-editor';
+
+import { Field } from 'react-final-form';
+
+import StaffSlipTemplateContentSection from './StaffSlipTemplateContentSection';
+import TokensList from '../../../TokensList';
+import getTokens from '../../../tokens';
+
+jest.mock('@folio/stripes-template-editor', () => ({
+  TemplateEditor: jest.fn(() => null),
+}));
+
+Field.mockImplementation(jest.fn(() => null));
+
+describe('StaffSlipTemplateContentEditSection', () => {
+  const labelIds = {
+    display: 'ui-circulation.settings.staffSlips.display',
+    preview: 'ui-circulation.settings.staffSlips.form.previewLabel',
+  };
+
+  afterEach(() => {
+    Field.mockClear();
+  });
+
+  beforeEach(() => {
+    render(<StaffSlipTemplateContentSection />);
+  });
+
+  it("should trigger 'Field' with correct props", () => {
+    const expectedResult = {
+      label: labelIds.display,
+      component: TemplateEditor,
+      tokens: getTokens('en'),
+      name: 'template',
+      previewModalHeader: labelIds.preview,
+      tokensList: TokensList,
+      printable: true,
+    };
+
+    expect(Field).toHaveBeenCalledWith(expectedResult, {});
+  });
+});

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
@@ -1,7 +1,7 @@
+import { Field } from 'react-final-form';
+
 import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { TemplateEditor } from '@folio/stripes-template-editor';
-
-import { Field } from 'react-final-form';
 
 import StaffSlipTemplateContentSection from './StaffSlipTemplateContentSection';
 import TokensList from '../../../TokensList';


### PR DESCRIPTION
## Purpose
- Restore and fix previously deleted Jest/RTL tests
- add "regenerator-runtime" package that was previously deleted

## Refs
[UICIRC-971](https://issues.folio.org/browse/UICIRC-971)