### PR TITLE
UICIRC-983: Rename hours to minutes in reminder fees

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -378,7 +378,7 @@ export const closingTypesMap = {
 };
 
 export const timeUnitsMap = {
-  HOUR: 'hour',
+  MINUTE: 'minute',
   DAY: 'day',
   WEEK: 'week',
 };
@@ -411,8 +411,8 @@ export const closedLoansRules = {
 
 export const timeUnits = [
   {
-    value: timeUnitsMap.HOUR,
-    label: 'ui-circulation.settings.finePolicy.reminderFees.timeUnit.hours',
+    value: timeUnitsMap.MINUTE,
+    label: 'ui-circulation.settings.finePolicy.reminderFees.timeUnit.minutes',
   },
   {
     value: timeUnitsMap.DAY,

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -440,6 +440,7 @@
   "settings.finePolicy.reminderFees.selectNoticeMethod": "Select notice method",
   "settings.finePolicy.reminderFees.selectNoticeTemplate": "Select notice template",
   "settings.finePolicy.reminderFees.selectBlockTemplate": "Select block template",
+  "settings.finePolicy.reminderFees.timeUnit.minutes": "Minute(s)",
   "settings.finePolicy.reminderFees.timeUnit.hours": "Hour(s)",
   "settings.finePolicy.reminderFees.timeUnit.days": "Day(s)",
   "settings.finePolicy.reminderFees.timeUnit.weeks": "Week(s)",


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-983

It was decided that  hours should be replaced with minutes under reminder fees section.