### PR TITLE
UICIRC-992: Also support feesfines interface version 19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-circulation
 
-## 10.0.0 IN PROGRESS
+## 9.1.0 IN PROGRESS
 
 * Also support `feesfines` interface version `19.0`. Refs UICIRC-992.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-circulation
 
+## 10.0.0 IN PROGRESS
+
+* Also support `feesfines` interface version `19.0`. Refs UICIRC-992.
+
 ## [9.0.0](https://github.com/folio-org/ui-circulation/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.1...v9.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/circulation",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Circulation manager",
   "repository": "folio-org/ui-circulation",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "patron-notice-policy-storage": "0.11",
       "location-units": "2.0",
       "locations": "3.0",
-      "feesfines": "16.0 17.0 18.0"
+      "feesfines": "16.0 17.0 18.0 19.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
Also support `feesfines` interface version `19.0`

## Approach
Changes was in endpoint `/accounts` that do not used in current module
This is part of `Quesnelia (R1 2024)` release
Should be merged after merging https://issues.folio.org/browse/MODFEE-337

## Refs
https://issues.folio.org/browse/UICIRC-992