### PR TITLE
UICIRC-995: Remove 'None' option from notice methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.1.0 IN PROGRESS
 
 * Also support `feesfines` interface version `19.0`. Refs UICIRC-992.
+* Remove `None` option from notice methods. Fixes UICIRC-995.
 
 ## [9.0.0](https://github.com/folio-org/ui-circulation/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.1...v9.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -386,7 +386,6 @@ export const timeUnitsMap = {
 export const noticeMethodMap = {
   EMAIL: 'Email',
   PRINT: 'Print',
-  NONE: 'None',
 };
 
 export const closingTypes = [
@@ -433,10 +432,6 @@ export const noticeMethods = [
     value: noticeMethodMap.PRINT,
     label: 'ui-circulation.settings.finePolicy.reminderFees.noticeMethods.print',
   },
-  {
-    value: noticeMethodMap.NONE,
-    label: 'ui-circulation.settings.finePolicy.reminderFees.noticeMethods.none',
-  }
 ];
 
 export const yesNoOptions = [


### PR DESCRIPTION
https://issues.folio.org/browse/UICIRC-995


This PR removes `None` option from notice methods under overdue fine policies.