### PR TITLE
UICIRC-1013: Fix permission error for Settings (Circ): Can create, edit and remove overdue fine policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Also support `feesfines` interface version `19.0`. Refs UICIRC-992.
 * Remove `None` option from notice methods. Fixes UICIRC-995.
+* Fix permission error for Settings (Circ): Can create, edit and remove overdue fine policies. Refs UICIRC-1013.
 
 ## [9.0.0](https://github.com/folio-org/ui-circulation/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.1...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -265,8 +265,10 @@
         "displayName": "Settings (Circ): Can view overdue fine policies",
         "subPermissions": [
           "circulation.loans.collection.get",
+          "manual-block-templates.collection.get",
           "overdue-fines-policies.collection.get",
           "overdue-fines-policies.item.get",
+          "templates.collection.get",
           "users.collection.get",
           "users.item.get",
           "settings.circulation.enabled"


### PR DESCRIPTION
## Purpose
Fix permission error for Settings (Circ): Can create, edit and remove overdue fine policies

## Approach
View permission used as sub permission for create, edit and remove

## Refs
https://issues.folio.org/browse/UICIRC-1013