### PR TITLE
UICIRC-1016: Error message and cannot see or edit pickup service points in "allow some pickup service points"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Also support `feesfines` interface version `19.0`. Refs UICIRC-992.
 * Remove `None` option from notice methods. Fixes UICIRC-995.
+* Extend "Settings (Circ): Can create, edit and remove request policies" permission to be able to see service points. Refs UICIRC-1016.
 
 ## [9.0.0](https://github.com/folio-org/ui-circulation/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v8.0.1...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -227,7 +227,8 @@
           "circulation-storage.request-policies.item.put",
           "users.collection.get",
           "users.item.get",
-          "settings.circulation.enabled"
+          "settings.circulation.enabled",
+          "inventory-storage.service-points.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Extend "Settings (Circ): Can create, edit and remove request policies" permission to be able to see service points.

## Refs
[UICIRC-1016](https://issues.folio.org/browse/UICIRC-1016)