### PR TITLE
UICIRC-1001: Create and Display new Staff slip (Search slip (Hold requests))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix wrong position of "Cancel" and "Save & close" button. Refs UICIRC-1014.
 * Extend "Settings (Circ): Can create, edit and remove request policies" permission to be able to see service points. Refs UICIRC-1016.
 * Fix problem with accordions on Circulation settings page. Refs UICIRC-1009.
+* Create and Display new Staff slip (Search slip (Hold requests)). Refs UICIRC-1001.
 
 ## [9.0.1](https://github.com/folio-org/ui-circulation/tree/v9.0.1) (2023-11-02)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.0...v9.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -333,6 +333,7 @@ export const staffSlipMap = {
   TRANSIT: 'Transit',
   PICK_SLIP: 'Pick slip',
   REQUEST_DELIVERY: 'Request delivery',
+  SEARCH_SLIP_HOLD_REQUESTS: 'Search slip (Hold requests)',
 };
 
 export const patronNoticeCategoryIds = {


### PR DESCRIPTION
## Purpose
Create and Display new Staff slip (Search slip (Hold requests))

## Approach
We read the information from DB, then render data with `EntryManager`. No other changes are needed.

## Refs
https://issues.folio.org/browse/UICIRC-1001

## Screenshots
![image](https://github.com/folio-org/ui-circulation/assets/24813219/ebafe0a6-f1a4-4098-bec2-620cf1248056)
![image](https://github.com/folio-org/ui-circulation/assets/24813219/02c0aaa3-8917-4edf-9ff8-6bf92da55a1a)


