### PR TITLE
UICIRC-1000: Add missing permission for Create a new Circulation setting Print hold requests (Open – Not yet filled) – Printing search slips

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
         "permissionName": "ui-circulation.settings.staff-slips",
         "displayName": "Settings (Circ): Can create, edit and remove staff slips",
         "subPermissions": [
+          "configuration.entries.collection.get",
           "ui-circulation.settings.edit-staff-slips",
           "circulation-storage.staff-slips.item.delete",
           "circulation-storage.staff-slips.collection.delete",


### PR DESCRIPTION
## Purpose
Add missing permission for Create a new Circulation setting Print hold requests (Open – Not yet filled) – Printing search slips

## Approach
Add permission that was missing in https://github.com/folio-org/ui-circulation/pull/1090
Changelog already updated https://github.com/folio-org/ui-circulation/blob/master/CHANGELOG.md?plain=1#L7

## Refs
https://issues.folio.org/browse/UICIRC-1000

## Screenshots
![image](https://github.com/folio-org/ui-circulation/assets/24813219/35614ab5-a857-4fb1-a8c9-1f7461b3f93e)

