### PR TITLE
UICIRC-1000: Add missing permission for Create a new Circulation setting Print hold requests (Open – Not yet filled) – Printing search slips

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
         "subPermissions": [
           "configuration.entries.collection.get",
           "configuration.entries.item.put",
+          "configuration.entries.item.post",
           "ui-circulation.settings.edit-staff-slips",
           "circulation-storage.staff-slips.item.delete",
           "circulation-storage.staff-slips.collection.delete",


### PR DESCRIPTION
## Purpose
Add missing permission for Create a new Circulation setting Print hold requests (Open – Not yet filled) – Printing search slips

## Approach
Add permission that was missing in https://github.com/folio-org/ui-circulation/pull/1090
Changelog already updated https://github.com/folio-org/ui-circulation/blob/master/CHANGELOG.md?plain=1#L7

## Refs
https://issues.folio.org/browse/UICIRC-1000

