### PR TITLE
UICIRC-1002: Adjust reminder fee field

### DIFF
--- a/src/settings/FinePolicy/components/EditSections/ReminderFeesSection/ReminderFeesSection.js
+++ b/src/settings/FinePolicy/components/EditSections/ReminderFeesSection/ReminderFeesSection.js
@@ -83,6 +83,7 @@ const ReminderFeesSection = ({ sectionOpen, noticeTemplates, blockTemplates }) =
               label={<FormattedMessage id="ui-circulation.settings.finePolicy.reminderFees.clearPatronBlockWhenPaid" />}
               name="reminderFeesPolicy.clearPatronBlockWhenPaid"
               component={Select}
+              disabled
               dataOptions={dataOptions}
             />
           </Col>


### PR DESCRIPTION
This is related to the work in: https://github.com/folio-org/ui-circulation/pull/1100

It has been decided to disable: `reminderFeesPolicy.clearPatronBlockWhenPaid` for now.