### PR TITLE
UICIRC-959: UI tests replacement with RTL/Jest for RequestCancellationReasons.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Create a new Circulation setting Print hold requests (Open – Not yet filled) – Printing search slips. Refs UICIRC-1000.
 * Change label for count closed days. Refs UICIRC-1017.
 * Unfreeze the first five selection menus for reminder fees. Refs UICIRC-1002, UICIRC-1005, UICIRC-1006.
+* UI tests replacement with RTL/Jest for `RequestCancellationReasons.js`. Refs UICIRC-959.
 
 ## [9.0.3](https://github.com/folio-org/ui-circulation/tree/v9.0.3) (2023-11-09)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.2...v9.0.3)

--- a/src/settings/RequestCancellationReasons.test.js
+++ b/src/settings/RequestCancellationReasons.test.js
@@ -1,0 +1,41 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { ControlledVocab } from '@folio/stripes/smart-components';
+
+import RequestCancellationReasons from './RequestCancellationReasons';
+
+describe('RequestCancellationReasons', () => {
+  const props = {
+    resources: {},
+  };
+
+  beforeEach(() => {
+    render(<RequestCancellationReasons {...props} />);
+  });
+
+  it('should pass correct props', () => {
+    const expectedResult = {
+      ...props,
+      baseUrl: 'cancellation-reason-storage/cancellation-reasons',
+      records: 'cancellationReasons',
+      label: expect.any(Object),
+      translations: {
+        cannotDeleteTermHeader: 'ui-circulation.settings.cancelReasons.cannotDeleteTermHeader',
+        cannotDeleteTermMessage: 'ui-circulation.settings.cancelReasons.cannotDeleteTermMessage',
+        deleteEntry: 'ui-circulation.settings.cancelReasons.deleteEntry',
+        termDeleted: 'ui-circulation.settings.cancelReasons.termDeleted',
+        termWillBeDeleted: 'ui-circulation.settings.cancelReasons.termWillBeDeleted',
+      },
+      objectLabel: '',
+      visibleFields: ['name', 'description', 'publicDescription'],
+      hiddenFields: ['lastUpdated', 'numberOfObjects'],
+      columnMapping: expect.any(Object),
+      actionSuppressor: expect.any(Object),
+      nameKey: 'name',
+      id: 'request-cancellation-reasons',
+      sortby: 'name',
+    };
+
+    expect(ControlledVocab).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+  });
+});

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -1,16 +1,24 @@
 import React from 'react';
 
-jest.mock('@folio/stripes/core', () => ({
-  stripesConnect: (Component) => (props) => (
-    <Component
-      {...props}
-      stripes={{
-        logger: () => {},
-      }}
-    />
-  ),
-  stripesShape: {},
-  withStripes: (Component) => (props) => <Component {...props} />,
-  IfPermission: jest.fn(({ children }) => <div>{children}</div>),
-  useCustomFields: jest.fn(() => []),
-}));
+jest.mock('@folio/stripes/core', () => {
+  const STRIPES = {
+    connect: (Component) => Component,
+    logger: () => {},
+  };
+  const stripesConnect = (Component) => ({ stripes, ...rest }) => {
+    const fakeStripes = {
+      ...STRIPES,
+      ...stripes,
+    };
+
+    return <Component {...rest} stripes={fakeStripes} />;
+  };
+
+  return {
+    stripesConnect,
+    stripesShape: {},
+    withStripes: (Component) => (props) => <Component {...props} />,
+    IfPermission: jest.fn(({ children }) => <div>{children}</div>),
+    useCustomFields: jest.fn(() => []),
+  };
+});

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ConfigManager: jest.fn(() => null),
+  ControlledVocab: jest.fn((props) => <div {...props} />),
   ViewMetaData: jest.fn(({ metadata, ...rest }) => (
     <div {...rest}>{metadata.createdDate}</div>
   )),


### PR DESCRIPTION
## Purpose
UI tests replacement with RTL/Jest for RequestCancellationReasons.js

# Refs
https://issues.folio.org/browse/UICIRC-959

