### PR TITLE
UICIRC-1059: Add displaySummary token for email templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * RulesEditor should use stripes.hasPerm. Refs UICIRC-1047.
 * Disable block template under reminder fees. Refs UICIRC-1046.
 * UI tests replacement with RTL/Jest for `CirculationRules.js`. Refs UICIRC-958.
+* Add `displaySummary` token for patron notice templates and for staff slips templates. Refs UICIRC-1059.
 
 ## [9.0.4](https://github.com/folio-org/ui-circulation/tree/v9.0.4) (2024-02-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.3...v9.0.4)

--- a/src/settings/PatronNotices/tokens.js
+++ b/src/settings/PatronNotices/tokens.js
@@ -45,6 +45,11 @@ const item = [
     allowedFor: allowedForAllCategories,
   },
   {
+    token: 'item.displaySummary',
+    previewValue: 'no.1-2v. 121948-1962 (Board)',
+    allowedFor: allowedForAllCategories,
+  },
+  {
     token: 'item.enumeration',
     previewValue: 'no.1-3',
     allowedFor: allowedForAllCategories,

--- a/src/settings/PatronNotices/tokens.test.js
+++ b/src/settings/PatronNotices/tokens.test.js
@@ -23,6 +23,11 @@ describe('getTokens', () => {
   };
   const fieldsForCheck = [
     {
+      category: 'item',
+      name: 'item.displaySummary',
+      expectedResult: 'no.1-2v. 121948-1962 (Board)',
+    },
+    {
       category: 'request',
       name: 'request.requestExpirationDate',
       expectedResult: expectedShortResult,

--- a/src/settings/StaffSlips/tokens.js
+++ b/src/settings/StaffSlips/tokens.js
@@ -51,6 +51,11 @@ const getTokens = (locale) => ({
       allowedFor: allowedForAllStaffSlips,
     },
     {
+      token: 'item.displaySummary',
+      previewValue: 'no.1-2v. 121948-1962 (Board)',
+      allowedFor: allowedForAllStaffSlips,
+    },
+    {
       token: 'item.enumeration',
       previewValue: 'no.1-3',
       allowedFor: allowedForAllStaffSlips,

--- a/src/settings/StaffSlips/tokens.test.js
+++ b/src/settings/StaffSlips/tokens.test.js
@@ -19,6 +19,11 @@ describe('getTokens', () => {
   const fieldsForCheck = [
     {
       category: 'item',
+      name: 'item.displaySummary',
+      expectedResult: 'no.1-2v. 121948-1962 (Board)',
+    },
+    {
+      category: 'item',
       name: 'item.lastCheckedInDateTime',
       expectedResult: expectedDateResult,
     },


### PR DESCRIPTION
## Purpose
Add `displaySummary` token for patron notice templates and for staff slips templates.

## Refs
[UICIRC-1059](https://folio-org.atlassian.net/browse/UICIRC-1059)