### PR TITLE
UICIRC-1066: Use Save & close button label stripes-component translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add `displaySummary` token for patron notice templates and for staff slips templates. Refs UICIRC-1059.
 * Fix that Save & close button is missing in the circulation forms. Refs UICIRC-1064.
 * Only certain HTML tags should be rendered when displaying staff slips. Refs UICIRC-1070.
+* Use Save & close button label stripes-component translation key. Refs UICIRC-1066.
 
 ## [9.0.4](https://github.com/folio-org/ui-circulation/tree/v9.0.4) (2024-02-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.3...v9.0.4)

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.js
@@ -118,7 +118,7 @@ class FixedDueDateScheduleForm extends React.Component {
             buttonStyle="primary mega"
             disabled={(pristine || submitting)}
           >
-            <FormattedMessage id="ui-circulation.settings.common.saveAndClose" />
+            <FormattedMessage id="stripes-components.saveAndClose" />
           </Button>
         </div>
       </PaneFooter>

--- a/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
+++ b/src/settings/FixedDueDateSchedule/FixedDueDateScheduleForm.test.js
@@ -33,7 +33,7 @@ const labelIds = {
   closeLabel: 'ui-circulation.settings.fDDSform.closeLabel',
   cancel: 'ui-circulation.settings.fDDSform.cancel',
   delete: 'stripes-core.button.delete',
-  saveAndClose: 'ui-circulation.settings.common.saveAndClose',
+  saveAndClose: /saveAndClose/,
   schedule: 'ui-circulation.settings.fDDSform.schedule',
   name: 'ui-circulation.settings.fDDSform.name',
   description: 'ui-circulation.settings.fDDSform.description',

--- a/src/settings/components/FooterPane/FooterPane.js
+++ b/src/settings/components/FooterPane/FooterPane.js
@@ -35,7 +35,7 @@ const FooterPane = (props) => {
             buttonStyle="primary mega"
             disabled={isSaveButtonDisabled}
           >
-            <FormattedMessage id="ui-circulation.settings.common.saveAndClose" />
+            <FormattedMessage id="stripes-components.saveAndClose" />
           </Button>
         }
       </div>

--- a/src/settings/components/FooterPane/FooterPane.test.js
+++ b/src/settings/components/FooterPane/FooterPane.test.js
@@ -54,6 +54,6 @@ describe('Footer Pane', () => {
     const { container } = footerPane;
 
     expect(getByText(container, 'ui-circulation.settings.common.cancel')).toBeTruthy();
-    expect(getByText(container, 'ui-circulation.settings.common.saveAndClose')).toBeTruthy();
+    expect(getByText(container, /saveAndClose/)).toBeTruthy();
   });
 });

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -40,7 +40,6 @@
 
   "settings.loanPolicy.entryLabel": "Loan policy",
   "settings.loanPolicy.paneTitle": "Loan policies",
-  "settings.loanPolicy.saveAndClose": "Save and close",
   "settings.loanPolicy.deleteLoanPolicy": "Delete loan policy",
   "settings.loanPolicy.createEntryLabel": "New loan policy",
   "settings.loanPolicy.selectFDDS": "Please select a fixed due date schedule",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UICIRC-1066
We removed local `saveAndClose` label and replace it with s`tripes-components.saveAndClose`. Also all related tests updated