### PR TITLE
UICIRC-1093 - Add New 'Settings (Circ): Can enable request print details' permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use Save & close button label stripes-component translation key. Refs UICIRC-1066.
 * Remove bigtests from github actions. Refs UICIRC-1079.
+* Create new permission 'Settings (Circ): Can enable request print details'. Refs UICIRC-3153.
 
 ## [9.1.0](https://github.com/folio-org/ui-circulation/tree/v9.1.0) (2024-03-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.5...v9.1.0)

--- a/package.json
+++ b/package.json
@@ -227,7 +227,9 @@
         "permissionName": "ui-circulation.settings.request-print-details",
         "displayName": "Settings (Circ): Can enable request print details",
         "subPermissions": [
-          "settings.circulation.enabled"
+          "settings.circulation.enabled",
+          "circulation.settings.item.get",
+          "circulation.settings.item.post"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -224,6 +224,14 @@
         "visible": true
       },
       {
+        "permissionName": "ui-circulation.settings.request-print-details",
+        "displayName": "Settings (Circ): Can enable request print details",
+        "subPermissions": [
+          "settings.circulation.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-circulation.settings.request-policies",
         "displayName": "Settings (Circ): Can create, edit and remove request policies",
         "subPermissions": [

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
 import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { TitleManager } from '@folio/stripes/core';
 
-import Circulation from './';
+import Circulation from '.';
 
 const props = {
   stripes: {},

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -549,6 +549,7 @@
   "permission.settings.view-staff-slips": "Settings (Circulation): Can view staff slips",
   "permission.settings.edit-staff-slips": "Settings (Circ): Can edit staff slips",
   "permission.settings.staff-slips": "Settings (Circ): Can create, edit and remove staff slips",
+  "permission.settings.request-print-details": "Settings (Circ): Can enable request print details",
   "permission.settings.request-policies": "Settings (Circ): Can create, edit and remove request policies",
   "permission.settings.other-settings": "Settings (Circ): Can create, edit and remove other settings",
   "permission.settings.notice-templates": "Settings (Circ): Can create, edit and remove patron notice templates",


### PR DESCRIPTION
[UICIRC-1093](https://folio-org.atlassian.net/browse/UICIRC-1093) - Add New 'Settings (Circ): Can enable request print details' permission.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
