### PR TITLE
UICIRC-1087 - Add New 'Settings (Circ): Can enable request print details' permission (follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
         "displayName": "Settings (Circ): Can enable request print details",
         "subPermissions": [
           "settings.circulation.enabled",
+          "circulation.settings.collection.get",
           "circulation.settings.item.get",
           "circulation.settings.item.put",
           "circulation.settings.item.post"


### PR DESCRIPTION
[UICIRC-1093](https://folio-org.atlassian.net/browse/UICIRC-1093) - Add New 'Settings (Circ): Can enable request print details' permission

## Purpose
This PR is to add the missing permissions.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
