### PR TITLE
UICIRC-1101 - Add staffSlip.staffUsername and request.barcodeImage as staff slips tokens in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Create new permission 'Settings (Circ): Can enable request print details'. Refs UICIRC-1093.
 * Create a new circ settings page and configuration to enable request print history. Refs UICIRC-1087.
 * Add page title to Circulation settings - View Print Details Page. Refs UICIRC-1089.
+* Add staffUsername as staff slips token in Settings. Refs UICIRC-1101.
+* Add request.barcodeImage as staff slips token in Settings. Refs UICIRC-1103.
 
 ## [9.1.0](https://github.com/folio-org/ui-circulation/tree/v9.1.0) (2024-03-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.5...v9.1.0)

--- a/src/settings/StaffSlips/tokens.js
+++ b/src/settings/StaffSlips/tokens.js
@@ -169,6 +169,11 @@ const getTokens = (locale) => ({
       previewValue: 'Please deliver to the History building for Professor McCoy.',
       allowedFor: allowedForAllStaffSlips,
     },
+    {
+      token: 'request.barcodeImage',
+      previewValue: '<Barcode>40afe5ce68a47</Barcode>',
+      allowedFor: allowedForAllStaffSlips,
+    },
   ],
   requestDeliveryAddress: [
     {
@@ -258,6 +263,11 @@ const getTokens = (locale) => ({
     {
       token: 'staffSlip.currentDateTime',
       previewValue: '3/18/22, 11:59 AM',
+      allowedFor: allowedForAllStaffSlips,
+    },
+    {
+      token: 'staffSlip.staffUsername',
+      previewValue: 'johndoe',
       allowedFor: allowedForAllStaffSlips,
     },
   ],


### PR DESCRIPTION
## Purpose
[UICIRC-1101](https://folio-org.atlassian.net/browse/UICIRC-1101) - Add staffUsername as staff slips token in Settings.
[UICIRC-1103](https://folio-org.atlassian.net/browse/UICIRC-1103) - Add request.barcodeImage as staff slips token in Settings.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICIRC-551
-->

## Screenshots
![7Q9VaTUZwv](https://github.com/user-attachments/assets/c5157a9b-9dbe-4e47-afc8-ad2fedb1b5dc)

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
