### PR TITLE
UICIRC-1106 - Update warning message when disabling 'Enable view print details (Pick slips)' configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add page title to Circulation settings - View Print Details Page. Refs UICIRC-1089.
 * Add staffUsername as staff slips token in Settings. Refs UICIRC-1101.
 * Add request.barcodeImage as staff slips token in Settings. Refs UICIRC-1103.
+* Update warning message when disabling the "Enable view print details (Pick slips)" configuration. Refs UICIRC-1106.
 
 ## [9.1.0](https://github.com/folio-org/ui-circulation/tree/v9.1.0) (2024-03-22)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v9.0.5...v9.1.0)

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -350,7 +350,7 @@
   "settings.ViewPrintDetails.callout.success": "Setting was successfully updated.",
   "settings.ViewPrintDetails.callout.error": "Something went wrong.",
   "settings.ViewPrintDetails.warningPopup.heading": "Disable view print details (Pick slips)",
-  "settings.ViewPrintDetails.warningPopup.message": "Disabling this setting will result in the loss of existing print history logs. Are you sure ?",
+  "settings.ViewPrintDetails.warningPopup.message": "Selecting Confirm will stop the recording of print job details.",
   "settings.ViewPrintDetails.warningPopup.message.confirm": "Confirm",
   "settings.ViewPrintDetails.warningPopup.message.cancel": "Cancel",
 


### PR DESCRIPTION
[UICIRC-1106](https://folio-org.atlassian.net/browse/UICIRC-1106)

## Screenshot
![image](https://github.com/user-attachments/assets/72d04817-e8c5-4dd7-bf57-4302ca12942f)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
