### PR TITLE
Disable ESlint false positive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import LoanHistorySettings from './settings/LoanHistory/LoanHistorySettings';
 import LoanPolicySettings from './settings/LoanPolicy/LoanPolicySettings';
 import FinePolicySettings from './settings/FinePolicy/FinePolicySettings';
 import LostItemFeePolicySettings from './settings/LostItemFeePolicy/LostItemFeePolicySettings';
-import CirculationRules from './settings/CirculationRules';
+import CirculationRules from './settings/CirculationRules'; // eslint-disable-line import/no-named-as-default
 import RequestCancellationReasons from './settings/RequestCancellationReasons';
 import CheckoutSettings from './settings/CheckoutSettings/CheckoutSettings';
 import FixedDueDateScheduleManager from './settings/FixedDueDateSchedule/FixedDueDateScheduleManager';


### PR DESCRIPTION
It's complaining about import/no-named-as-default when the import is perfectly cromulent. Community consensus seems to be just to disable it when this happens.

This gives us a clean lint, which is the baseline I want to work from.
