### PR TITLE
UICIRC-1191: Patron Notice form Validation fires too often, causing unnecessary requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Refactor RulesEditor away from componentWillReceiveProps. Refs UICIRC-431.
 * Add seven new item-level tokens to patron note editor. Fixes UICIRC-1178.
 * Make `Consortium title level request` settings available only in Central tenant. Refs UICIRC-1192.
+* Get rid of unnecessary validation of "Patron notice template name" field. Refs UICIRC-1191.
 
 ## [10.0.1](https://github.com/folio-org/ui-circulation/tree/v10.0.1) (2024-12-04)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v10.0.0...v10.0.1)

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
@@ -72,6 +72,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
             id="input-patron-notice-active"
             component={Checkbox}
             defaultChecked={isActive}
+            validateFields={[]}
           />
         </Col>
       </Row>
@@ -84,6 +85,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
             name="description"
             id="input-patron-notice-description"
             component={TextArea}
+            validateFields={[]}
           />
         </Col>
       </Row>
@@ -97,6 +99,7 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
               component={Select}
               fullWidth
               dataOptions={categoryOptions}
+              validateFields={[]}
             />
           </div>
         </Col>

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.test.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.test.js
@@ -88,6 +88,7 @@ describe('PatronNoticeAboutSectionEdit', () => {
       id: 'input-patron-notice-active',
       component: Checkbox,
       defaultChecked: true,
+      validateFields: [],
     }, true);
   });
 
@@ -97,6 +98,7 @@ describe('PatronNoticeAboutSectionEdit', () => {
       name: 'description',
       id: 'input-patron-notice-description',
       component: TextArea,
+      validateFields: [],
     }, true);
   });
 
@@ -110,6 +112,7 @@ describe('PatronNoticeAboutSectionEdit', () => {
         value: 'testId',
         label: 'testLabel',
       }],
+      validateFields: [],
     });
   });
 });

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailEditSection.test.js
@@ -67,6 +67,7 @@ describe('PatronNoticeEmailEditSection', () => {
       component: TextField,
       required: true,
       name: 'localizedTemplates.en.header',
+      validateFields: [],
     }, true);
   });
 
@@ -84,6 +85,7 @@ describe('PatronNoticeEmailEditSection', () => {
       tokens: mockGetTokensReturnValue,
       tokensList: TokensList,
       selectedCategory: categoryValue,
+      validateFields: [],
     }, true);
   });
 });

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailSection.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeEmailSection/PatronNoticeEmailSection.js
@@ -28,6 +28,7 @@ const PatronNoticeEmailSection = ({ category, locale, printOnly }) => {
             label={<FormattedMessage id="ui-circulation.settings.patronNotices.printOnly" />}
             name="additionalProperties.printOnly"
             type="checkbox"
+            validateFields={[]}
           />
         </Col>
       </Row>
@@ -43,6 +44,7 @@ const PatronNoticeEmailSection = ({ category, locale, printOnly }) => {
               required
               label={<FormattedMessage id="ui-circulation.settings.patronNotices.subject" />}
               name="localizedTemplates.en.header"
+              validateFields={[]}
             />
           </Col>
         </Row>
@@ -60,6 +62,7 @@ const PatronNoticeEmailSection = ({ category, locale, printOnly }) => {
             tokensList={TokensList}
             previewModalHeader={<FormattedMessage id="ui-circulation.settings.patronNotices.form.previewHeader" />}
             selectedCategory={category}
+            validateFields={[]}
           />
         </Col>
       </Row>


### PR DESCRIPTION
## Purpose
Get rid of unnecessary validation of "Patron notice template name" field after editing each field on the form.

## Refs
[UICIRC-1191](https://folio-org.atlassian.net/browse/UICIRC-1191)