### PR TITLE
UICIRC-1223: Modal with error appears if user has "Settings (Circulation): Can create, edit and remove staff slips" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.0 IN PROGRESS
 
 * Change fee/fine verbiage on Loan Anonymization page. Refs UICIRC-1200.
+* Add "users.collection.get" sub-permission for viewing staff-slips. Refs UICIRC-1223.
 
 ## [11.0.0](https://github.com/folio-org/ui-circulation/tree/v11.0.0) (2024-03-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v10.0.1...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -226,7 +226,8 @@
         "subPermissions": [
           "settings.circulation.enabled",
           "circulation-storage.staff-slips.collection.get",
-          "circulation-storage.staff-slips.item.get"
+          "circulation-storage.staff-slips.item.get",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add "users.collection.get" sub-permission for viewing staff-slips.

## Refs
[UICIRC-1223](https://folio-org.atlassian.net/browse/UICIRC-1223)