### PR TITLE
UICIRC-1225: Modal with error appears if user has "Settings (Circulation): View circulation rules" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.0 IN PROGRESS
 
 * Change fee/fine verbiage on Loan Anonymization page. Refs UICIRC-1200.
+* Add "users.collection.get" sub-permission for viewing circulation rules. Refs UICIRC-1225.
 
 ## [11.0.0](https://github.com/folio-org/ui-circulation/tree/v11.0.0) (2024-03-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v10.0.1...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
           "inventory-storage.location-units.libraries.collection.get",
           "inventory-storage.locations.collection.get",
           "overdue-fines-policies.collection.get",
-          "lost-item-fees-policies.collection.get"
+          "lost-item-fees-policies.collection.get",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add "users.collection.get" sub-permission for viewing circulation rules.

## Refs
[UICIRC-1225](https://folio-org.atlassian.net/browse/UICIRC-1225)