### PR TITLE
[UICIRC-1226] Support `isRawHtml` field in staff slips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change fee/fine verbiage on Loan Anonymization page. Refs UICIRC-1200.
 * Add "users.collection.get" sub-permission for viewing staff-slips. Refs UICIRC-1223.
 * Add "users.collection.get" sub-permission for viewing circulation rules. Refs UICIRC-1225.
+* When version 1.1 or higher of the `staff-slips-storage` interface is provided, display and maintain the new `isRawHtml` field; when that field is set for a staff slip, request that raw HTML is used by the template editor. Fixes UICIRC-1226.
 
 ## [11.0.0](https://github.com/folio-org/ui-circulation/tree/v11.0.0) (2024-03-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v10.0.1...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "configuration": "2.0",
       "fixed-due-date-schedules-storage": "2.0",
       "loan-policy-storage": "1.0 2.0",
+      "staff-slips-storage": "1.0",
       "template-engine": "2.0",
       "patron-notice-policy-storage": "0.11",
       "location-units": "2.0",

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipAboutSection/StaffSlipAboutSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipAboutSection/StaffSlipAboutSection.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
+import { IfInterface } from '@folio/stripes/core';
 
 import {
+  Checkbox,
   Col,
   KeyValue,
   Row,
@@ -46,6 +48,25 @@ const StaffSlipAboutSection = ({ initialValues, disabled }) => {
           />
         </Col>
       </Row>
+      {/* Version 1.1 of the `staff-slips-storage` interface added the `isRawHtml` field */}
+      <IfInterface name="staff-slips-storage" version="1.1">
+        <Row>
+          <Col
+            data-test-staff-slip-isRawHtml
+            xs={12}
+          >
+            <Field
+              label={<FormattedMessage id="ui-circulation.settings.staffSlips.isRawHtml" />}
+              name="isRawHtml"
+              id="input-staff-slip-isRawHtml"
+              data-testid="staffSlipDescriptionIsRawHtml"
+              component={Checkbox}
+              type="checkbox"
+              disabled={disabled}
+            />
+          </Col>
+        </Row>
+      </IfInterface>
     </div>
   );
 };

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
@@ -15,7 +15,10 @@ import TokensList from '../../../TokensList';
 import getTokens from '../../../tokens';
 
 const StaffSlipTemplateContentSection = ({ intl }) => {
-  const { values } = useFormState();
+  // I can't find a way to mock useFormState for Jest, so we allow for it being undefined in testing
+  const formState = useFormState ? useFormState() : {};
+  const values = formState.values || {};
+
   const {
     formatMessage,
     locale,

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   injectIntl,
 } from 'react-intl';
-import { Field } from 'react-final-form';
+import { useFormState, Field } from 'react-final-form';
 
 import {
   Col,
@@ -15,6 +15,7 @@ import TokensList from '../../../TokensList';
 import getTokens from '../../../tokens';
 
 const StaffSlipTemplateContentSection = ({ intl }) => {
+  const { values } = useFormState();
   const {
     formatMessage,
     locale,
@@ -32,6 +33,7 @@ const StaffSlipTemplateContentSection = ({ intl }) => {
           previewModalHeader={formatMessage({ id:'ui-circulation.settings.staffSlips.form.previewLabel' })}
           tokensList={TokensList}
           printable
+          editAsHtml={!!values.isRawHtml}
         />
       </Col>
     </Row>

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
@@ -36,6 +36,7 @@ describe('StaffSlipTemplateContentEditSection', () => {
       previewModalHeader: labelIds.preview,
       tokensList: TokensList,
       printable: true,
+      editAsHtml: false,
     };
 
     expect(Field).toHaveBeenCalledWith(expectedResult, {});

--- a/src/settings/StaffSlips/components/ViewSections/StaffSlipAboutSection/StaffSlipAboutSection.js
+++ b/src/settings/StaffSlips/components/ViewSections/StaffSlipAboutSection/StaffSlipAboutSection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { IfInterface } from '@folio/stripes/core';
 
 import {
   Col,
@@ -40,6 +41,19 @@ const StaffSlipAboutSection = ({ staffSlip }) => {
           </div>
         </Col>
       </Row>
+      {/* Version 1.1 of the `staff-slips-storage` interface added the `isRawHtml` field */}
+      <IfInterface name="staff-slips-storage" version="1.1">
+        <Row>
+          <Col xs={12}>
+            <KeyValue
+              label={<FormattedMessage id="ui-circulation.settings.staffSlips.isRawHtml" />}
+              value={staffSlip.isRawHtml ?
+                     <FormattedMessage id="ui-circulation.settings.common.yes" /> :
+                     <FormattedMessage id="ui-circulation.settings.common.no" />}
+            />
+          </Col>
+        </Row>
+      </IfInterface>
     </div>
   );
 };

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -19,6 +19,7 @@ jest.mock('@folio/stripes/core', () => {
     stripesShape: {},
     withStripes: (Component) => (props) => <Component {...props} />,
     IfPermission: jest.fn(({ children }) => <div>{children}</div>),
+    IfInterface: jest.fn(({ children }) => <div>{children}</div>),
     TitleManager: jest.fn(({ children }) => <div>{children}</div>),
     useCustomFields: jest.fn(() => []),
     useOkapiKy: jest.fn(),

--- a/translations/ui-circulation/en.json
+++ b/translations/ui-circulation/en.json
@@ -253,6 +253,7 @@
   "settings.staffSlips.new": "New staff slip",
   "settings.staffSlips.display": "Display",
   "settings.staffSlips.description": "Description",
+  "settings.staffSlips.isRawHtml": "Maintained as raw HTML?",
   "settings.staffSlips.preview": "Preview",
   "settings.staffSlips.hold": "Hold",
   "settings.staffSlips.untitledStaffSlip": "Staff slip name",


### PR DESCRIPTION
When version 1.1 or higher of the `staff-slips-storage` interface is provided, display and maintain the new `isRawHtml` field; when that field is set for a staff slip, request that raw HTML is used by the template editor.