### PR TITLE
UICIRC-1232: Add missing users view sub-permission to view circulation patron notice template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * When version 1.1 or higher of the `staff-slips-storage` interface is provided, display and maintain the new `isRawHtml` field; when that field is set for a staff slip, request that raw HTML is used by the template editor. Fixes UICIRC-1226.
 * Replace moment with day.js. Refs UICIRC-1194.
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UICIRC-1209.
+* Add "users.collection.get" sub-permission for viewing circulation patron notice template. Refs UICIRC-1232.
 
 ## [11.0.1](https://github.com/folio-org/ui-circulation/tree/v11.0.1) (2024-04-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -321,7 +321,8 @@
           "circulation-storage.patron-notice-policies.collection.get",
           "templates.collection.get",
           "templates.item.get",
-          "settings.circulation.enabled"
+          "settings.circulation.enabled",
+          "users.collection.get"
         ],
         "visible": false
       },
@@ -333,8 +334,7 @@
           "templates.item.post",
           "templates.item.put",
           "templates.item.delete",
-          "template-request.post",
-          "users.collection.get"
+          "template-request.post"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -333,7 +333,8 @@
           "templates.item.post",
           "templates.item.put",
           "templates.item.delete",
-          "template-request.post"
+          "template-request.post",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Requesting `GET /users` fails during viewing circulation patron notice template

## Approach
Add missing `users.collection.get` sub-permission for `ui-circulation.settings.notice-templates`

## Refs
[UICIRC-1232](https://folio-org.atlassian.net/browse/UICIRC-1232)


