### PR TITLE
[UICIRC-1238] Unconditional hook, fixes slip-editor HTML mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Replace moment with day.js. Refs UICIRC-1194.
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UICIRC-1209.
 * Add "users.collection.get" sub-permission for viewing circulation patron notice template. Refs UICIRC-1232.
+* Invocation of `useFormState` in `StaffSlipTemplateContentSection.js` is no longer conditional, so switching between HTML and WYSIWYG editors for a staff slip works even in minified builds. Fixes UICIRC-1238.
 
 ## [11.0.1](https://github.com/folio-org/ui-circulation/tree/v11.0.1) (2024-04-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v11.0.0...v11.0.1)

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
@@ -15,8 +15,7 @@ import TokensList from '../../../TokensList';
 import getTokens from '../../../tokens';
 
 const StaffSlipTemplateContentSection = ({ intl }) => {
-  // I can't find a way to mock useFormState for Jest, so we allow for it being undefined in testing
-  const formState = useFormState ? useFormState() : {};
+  const formState = useFormState();
   const values = formState.values || {};
 
   const {

--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.test.js
@@ -1,3 +1,8 @@
+jest.mock('react-final-form', () => ({
+  Field: jest.fn(() => (component) => component),
+  useFormState: jest.fn(() => ({})),
+}));
+
 import { Field } from 'react-final-form';
 
 import { render } from '@folio/jest-config-stripes/testing-library/react';


### PR DESCRIPTION
Invocation of `useFormState` in `StaffSlipTemplateContentSection.js`
was conditional on the existence of the `useFormState` function (which
was not present when running tests). Probably as a result of this,
switching between HTML and WYSIWYG editors for a staff slip did not
work in minified builds such as that of snapshot.
    
The invocation is no longer conditional, and I have provided a mock so
that the test works.
