### PR TITLE
[UICIRC-1179] Add new token "Series statements" to staff slips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UICIRC-1209.
 * Add "users.collection.get" sub-permission for viewing circulation patron notice template. Refs UICIRC-1232.
 * Invocation of `useFormState` in `StaffSlipTemplateContentSection.js` is no longer conditional, so switching between HTML and WYSIWYG editors for a staff slip works even in minified builds. Fixes UICIRC-1238.
+* Add new token "Series statements" to staff slips. Fixes UICIRC-1179 to 1185.
 
 ## [11.0.1](https://github.com/folio-org/ui-circulation/tree/v11.0.1) (2024-04-14)
 [Full Changelog](https://github.com/folio-org/ui-circulation/compare/v11.0.0...v11.0.1)

--- a/src/settings/StaffSlips/tokens.js
+++ b/src/settings/StaffSlips/tokens.js
@@ -136,6 +136,11 @@ const getTokens = (locale) => ({
       allowedFor: allowedForAllStaffSlips,
     },
     {
+      token: 'item.seriesStatements',
+      previewValue: 'Department of State publication',
+      allowedFor: allowedForAllStaffSlips,
+    },
+    {
       token: 'item.instanceHrid',
       previewValue: 'inst000000000022',
       allowedFor: allowedForAllStaffSlips,


### PR DESCRIPTION
Also fixes UICIRC-1180, UICIRC-1181, UICIRC-1182, UICIRC-1183, UICIRC-1184 and UICIRC-1185, which are more or less duplicates.