### PR TITLE
Revert "Add debugging output for isRawHtml value (#1226)"

### DIFF
--- a/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
+++ b/src/settings/StaffSlips/components/EditSections/StaffSlipTemplateContentSection/StaffSlipTemplateContentSection.js
@@ -17,7 +17,6 @@ import getTokens from '../../../tokens';
 const StaffSlipTemplateContentSection = ({ intl }) => {
   const formState = useFormState();
   const values = formState.values || {};
-  console.log('  *** StaffSlipTemplateContentSection: isRawHtml =', !!values.isRawHtml, '--', values);
 
   const {
     formatMessage,


### PR DESCRIPTION
This reverts commit 9455894c6bea1597ba1fdde616b87ae7d46a11d0.

We no longer need this debugging output due to progress in investigating the problems described in UICIRC-1238.