### PR TITLE
UICIRC-1341: Debounce patron notice template name validation

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useDebounceValidate } from './useDebounceValidate';

--- a/src/hooks/useDebounceValidate/index.js
+++ b/src/hooks/useDebounceValidate/index.js
@@ -1,0 +1,1 @@
+export { default } from './useDebounceValidate';

--- a/src/hooks/useDebounceValidate/useDebounceValidate.js
+++ b/src/hooks/useDebounceValidate/useDebounceValidate.js
@@ -1,0 +1,27 @@
+import {
+  useCallback,
+  useRef,
+} from 'react';
+
+const useDebounceValidate = (validateFn, delay = 300) => {
+  const timerRef = useRef(null);
+  const pendingResolveRef = useRef(null);
+  const validateFnRef = useRef(validateFn);
+  validateFnRef.current = validateFn;
+
+  return useCallback((value) => new Promise((resolve) => {
+    if (pendingResolveRef.current) {
+      pendingResolveRef.current(undefined);
+    }
+    
+    pendingResolveRef.current = resolve;
+    clearTimeout(timerRef.current);
+
+    timerRef.current = setTimeout(() => {
+      pendingResolveRef.current = null;
+      validateFnRef.current(value).then(resolve);
+    }, delay);
+  }), [delay]);
+};
+
+export default useDebounceValidate;

--- a/src/hooks/useDebounceValidate/useDebounceValidate.js
+++ b/src/hooks/useDebounceValidate/useDebounceValidate.js
@@ -13,7 +13,7 @@ const useDebounceValidate = (validateFn, delay = 300) => {
     if (pendingResolveRef.current) {
       pendingResolveRef.current(undefined);
     }
-    
+
     pendingResolveRef.current = resolve;
     clearTimeout(timerRef.current);
 

--- a/src/hooks/useDebounceValidate/useDebounceValidate.test.js
+++ b/src/hooks/useDebounceValidate/useDebounceValidate.test.js
@@ -1,0 +1,135 @@
+import {
+  renderHook,
+  act,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import useDebounceValidate from './useDebounceValidate';
+
+describe('useDebounceValidate', () => {
+  let validateFn;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    validateFn = jest.fn(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return the same function reference across re-renders', () => {
+    const { result, rerender } = renderHook(() => useDebounceValidate(validateFn));
+    const firstRef = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstRef);
+  });
+
+  it('should return a new function reference when delay changes', () => {
+    const { result, rerender } = renderHook(({ delay }) => useDebounceValidate(validateFn, delay), {
+      initialProps: { delay: 300 },
+    });
+    const firstRef = result.current;
+
+    rerender({ delay: 500 });
+
+    expect(result.current).not.toBe(firstRef);
+  });
+
+  it('should return a Promise', () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+
+    expect(result.current('test')).toBeInstanceOf(Promise);
+  });
+
+  it('should not call validateFn before the delay', () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+
+    act(() => { result.current('test'); });
+
+    expect(validateFn).not.toHaveBeenCalled();
+  });
+
+  it('should call validateFn with the value after the delay', () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+
+    act(() => {
+      result.current('test');
+      jest.runAllTimers();
+    });
+
+    expect(validateFn).toHaveBeenCalledWith('test');
+  });
+
+  it('should call validateFn only once with the last value when called rapidly', () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+
+    act(() => {
+      result.current('a');
+      result.current('ab');
+      result.current('abc');
+      jest.runAllTimers();
+    });
+
+    expect(validateFn).toHaveBeenCalledTimes(1);
+    expect(validateFn).toHaveBeenCalledWith('abc');
+  });
+
+  it('should resolve previous pending promises with undefined when a new call arrives', async () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+    let firstPromise;
+
+    act(() => { firstPromise = result.current('a'); });
+    act(() => { result.current('ab'); });
+
+    await expect(firstPromise).resolves.toBeUndefined();
+  });
+
+  it('should resolve with the value returned by validateFn', async () => {
+    const error = 'Name already exists';
+    validateFn.mockResolvedValue(error);
+    const { result } = renderHook(() => useDebounceValidate(validateFn));
+    let promise;
+
+    act(() => {
+      promise = result.current('test');
+      jest.runAllTimers();
+    });
+
+    await expect(promise).resolves.toBe(error);
+  });
+
+  it('should respect a custom delay', () => {
+    const { result } = renderHook(() => useDebounceValidate(validateFn, 500));
+
+    act(() => { result.current('test'); });
+
+    jest.advanceTimersByTime(499);
+    expect(validateFn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(validateFn).toHaveBeenCalledWith('test');
+  });
+
+  it('should always use the latest validateFn without changing the function reference', () => {
+    const firstFn = jest.fn(() => Promise.resolve());
+    const secondFn = jest.fn(() => Promise.resolve());
+
+    const { result, rerender } = renderHook(({ fn }) => useDebounceValidate(fn), {
+      initialProps: { fn: firstFn },
+    });
+    const stableRef = result.current;
+
+    rerender({ fn: secondFn });
+
+    act(() => {
+      result.current('test');
+      jest.runAllTimers();
+    });
+
+    expect(result.current).toBe(stableRef);
+    expect(firstFn).not.toHaveBeenCalled();
+    expect(secondFn).toHaveBeenCalledWith('test');
+  });
+});

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.js
@@ -1,4 +1,3 @@
-import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { Field } from 'react-final-form';
@@ -17,10 +16,10 @@ import {
 
 import { patronNoticeCategories } from '../../../../../constants';
 import { validateUniqueNameById } from '../../../../utils/utils';
+import { useDebounceValidate } from '../../../../../hooks';
 
 const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
   const { formatMessage } = intl;
-  const validateNameTimer = useRef(null);
 
   const categoryOptions = patronNoticeCategories.map(({ label, id }) => ({
     label: formatMessage({ id: label }),
@@ -35,18 +34,15 @@ const PatronNoticeAboutSection = ({ initialValues, okapi, intl }) => {
       });
   };
 
-  const debouncedValidate = (name) => new Promise((resolve) => {
-    clearTimeout(validateNameTimer.current);
-    validateNameTimer.current = setTimeout(() => {
-      validateUniqueNameById({
-        currentName: name,
-        previousId: initialValues.id,
-        getByName: getTemplatesByName,
-        selector: 'templates',
-        errorKey: 'settings.patronNotices.errors.nameExists',
-      }).then(resolve);
-    }, 300);
+  const validateName = (name) => validateUniqueNameById({
+    currentName: name,
+    previousId: initialValues.id,
+    getByName: getTemplatesByName,
+    selector: 'templates',
+    errorKey: 'settings.patronNotices.errors.nameExists',
   });
+
+  const debouncedValidate = useDebounceValidate(validateName);
 
   return (
     <div data-testid="patronNoticeAboutSection">

--- a/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.test.js
+++ b/src/settings/PatronNotices/components/EditSections/PatronNoticeAboutSection/PatronNoticeAboutSection.test.js
@@ -15,6 +15,7 @@ import {
 
 import { componentPropsCheck } from '../../../../../../test/jest/helpers';
 import { validateUniqueNameById } from '../../../../utils/utils';
+import { useDebounceValidate } from '../../../../../hooks';
 import PatronNoticeAboutSection from './PatronNoticeAboutSection';
 
 jest.mock('../../../../../constants', () => ({
@@ -26,6 +27,10 @@ jest.mock('../../../../../constants', () => ({
 
 jest.mock('../../../../utils/utils', () => ({
   validateUniqueNameById: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../../../../hooks', () => ({
+  useDebounceValidate: jest.fn((fn) => fn),
 }));
 
 describe('PatronNoticeAboutSectionEdit', () => {
@@ -60,6 +65,7 @@ describe('PatronNoticeAboutSectionEdit', () => {
   afterEach(() => {
     KeyValue.mockClear();
     Field.mockClear();
+    useDebounceValidate.mockClear();
   });
 
   beforeEach(() => {
@@ -121,43 +127,29 @@ describe('PatronNoticeAboutSectionEdit', () => {
     });
   });
 
-  describe('validateName debounce', () => {
-    let validateFn;
-
-    beforeEach(() => {
-      jest.useFakeTimers();
-      const nameFieldCall = Field.mock.calls
-        .reverse()
-        .find(([props]) => props['data-testid'] === testIds.patronNoticesNoticeName);
-      validateFn = nameFieldCall[0].validate;
+  describe('validateName', () => {
+    it('should pass a validateFn to useDebounceValidate', () => {
+      expect(useDebounceValidate).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    afterEach(() => {
-      validateUniqueNameById.mockClear();
-      jest.useRealTimers();
+    it('should use the result of useDebounceValidate as the validate prop for the name Field', () => {
+      const debouncedValidate = useDebounceValidate.mock.results[0].value;
+
+      componentPropsCheck(Field, testIds.patronNoticesNoticeName, {
+        validate: debouncedValidate,
+      }, true);
     });
 
-    it('should return a Promise', () => {
-      expect(validateFn('test')).toBeInstanceOf(Promise);
-    });
+    it('should call validateUniqueNameById with correct params when validateFn is invoked', () => {
+      const validateFn = useDebounceValidate.mock.calls[0][0];
 
-    it('should not call validateUniqueNameById before the debounce delay', () => {
-      validateFn('test');
-      expect(validateUniqueNameById).not.toHaveBeenCalled();
-    });
+      validateFn('testName');
 
-    it('should call validateUniqueNameById once with the last value after the debounce delay', () => {
-      validateFn('t');
-      validateFn('te');
-      validateFn('tes');
-      validateFn('test');
-
-      jest.runAllTimers();
-
-      expect(validateUniqueNameById).toHaveBeenCalledTimes(1);
       expect(validateUniqueNameById).toHaveBeenCalledWith(expect.objectContaining({
-        currentName: 'test',
+        currentName: 'testName',
         previousId: initialValues.id,
+        selector: 'templates',
+        errorKey: 'settings.patronNotices.errors.nameExists',
       }));
     });
   });


### PR DESCRIPTION
## Purpose

The patron notice template name uniqueness validation was blocking form submission. Each keystroke created a new debounce Promise, but intermediate Promises were never resolved — \`final-form\` awaited them indefinitely, preventing the Save button from working.

## Approach

- Fixed the debounce validator by resolving orphaned Promises (via a \`pendingResolveRef\`) when a new validation call arrives, so \`final-form\` is never left waiting on a stale Promise.
- Extracted the pattern into a reusable \`useDebounceValidate\` hook at \`src/hooks/\` with full unit tests.
- The hook uses \`useCallback\` for a stable \`validate\` reference and a \`validateFnRef\` so the latest validator is always used without breaking memoization.

## Issues

[UICIRC-1341](https://folio-org.atlassian.net/browse/UICIRC-1341)